### PR TITLE
refactor(web): split media transfer storage ownership

### DIFF
--- a/apps/web/src/localDb/mediaTransfers/blobCache.ts
+++ b/apps/web/src/localDb/mediaTransfers/blobCache.ts
@@ -1,0 +1,32 @@
+import {
+  closeDatabaseAfter,
+  closeDatabaseAfterWrite,
+  getFromStore,
+  runReadwrite,
+} from "../core/database";
+import type { MediaBlobCacheRecord } from "./types";
+
+export async function loadMediaBlobCacheRecord(sha256: string): Promise<MediaBlobCacheRecord | null> {
+  const record = await closeDatabaseAfter((database) => getFromStore<MediaBlobCacheRecord>(
+    database,
+    "mediaBlobCache",
+    sha256,
+  ));
+  return record ?? null;
+}
+
+export async function writeMediaBlobCacheRecord(record: MediaBlobCacheRecord): Promise<void> {
+  await closeDatabaseAfterWrite(async (database) => {
+    await runReadwrite(database, ["mediaBlobCache"], (transaction) => (
+      transaction.objectStore("mediaBlobCache").put(record)
+    ));
+  });
+}
+
+export async function deleteMediaBlobCacheRecord(sha256: string): Promise<void> {
+  await closeDatabaseAfterWrite(async (database) => {
+    await runReadwrite(database, ["mediaBlobCache"], (transaction) => (
+      transaction.objectStore("mediaBlobCache").delete(sha256)
+    ));
+  });
+}

--- a/apps/web/src/localDb/mediaTransfers/index.ts
+++ b/apps/web/src/localDb/mediaTransfers/index.ts
@@ -1,1 +1,40 @@
-export * from "./mediaTransfers";
+export {
+  deleteMediaBlobCacheRecord,
+  loadMediaBlobCacheRecord,
+  writeMediaBlobCacheRecord,
+} from "./blobCache";
+export { persistLocalMediaUpload } from "./localMediaUpload";
+export {
+  claimNextDueMediaTransfer,
+  claimNextDueMediaTransferByKind,
+  clearCompletedMediaTransfersForWorkspace,
+  enqueueMediaTransferDownload,
+  enqueueMediaTransferUpload,
+  loadMediaTransferQueueRecord,
+  loadMediaUploadTransfersForWorkspaceMediaAssets,
+  loadNextPendingMediaTransferAttemptAtByKind,
+  markClaimedMediaTransferFailed,
+  markClaimedMediaTransferSucceeded,
+  markMediaTransferFailed,
+  markMediaTransferSucceeded,
+  markMediaUploadTransferCompletionTerminal,
+  markMediaUploadTransferDueForRetry,
+  recoverStaleInProgressMediaTransfersByKind,
+  renewInProgressMediaTransferClaim,
+} from "./transferQueue";
+export type {
+  EnqueueMediaTransferDownloadInput,
+  EnqueueMediaTransferUploadInput,
+  MarkClaimedMediaTransferFailedInput,
+  MarkClaimedMediaTransferSucceededInput,
+  MarkMediaUploadTransferCompletionTerminalInput,
+  MarkMediaUploadTransferDueForRetryInput,
+  MediaBlobCacheRecord,
+  MediaTransferKind,
+  MediaTransferQueueRecord,
+  MediaTransferStatus,
+  MediaUploadTransferForMediaAsset,
+  PersistLocalMediaUploadInput,
+  RecoverStaleInProgressMediaTransfersByKindInput,
+  RenewInProgressMediaTransferClaimInput,
+} from "./types";

--- a/apps/web/src/localDb/mediaTransfers/localMediaUpload.ts
+++ b/apps/web/src/localDb/mediaTransfers/localMediaUpload.ts
@@ -1,0 +1,24 @@
+import {
+  closeDatabaseAfterWrite,
+  runReadwrite,
+  type StoredMediaAsset,
+} from "../core/database";
+import { createQueuedMediaTransferRecord } from "./transferQueue";
+import type {
+  MediaTransferQueueRecord,
+  PersistLocalMediaUploadInput,
+} from "./types";
+
+export async function persistLocalMediaUpload(
+  input: PersistLocalMediaUploadInput,
+): Promise<MediaTransferQueueRecord> {
+  const transferRecord = createQueuedMediaTransferRecord(input.upload, "upload", input.upload.sourceBlobCacheKey);
+  await closeDatabaseAfterWrite(async (database) => {
+    await runReadwrite(database, ["mediaBlobCache", "mediaAssets", "mediaTransferQueue"], (transaction) => {
+      transaction.objectStore("mediaBlobCache").put(input.cacheRecord);
+      transaction.objectStore("mediaAssets").put(input.mediaAsset satisfies StoredMediaAsset);
+      return transaction.objectStore("mediaTransferQueue").put(transferRecord);
+    });
+  });
+  return transferRecord;
+}

--- a/apps/web/src/localDb/mediaTransfers/mediaTransfers.test.ts
+++ b/apps/web/src/localDb/mediaTransfers/mediaTransfers.test.ts
@@ -24,7 +24,7 @@ import {
   persistLocalMediaUpload,
   recoverStaleInProgressMediaTransfersByKind,
   renewInProgressMediaTransferClaim,
-} from "./mediaTransfers";
+} from ".";
 
 const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
   hasFailed: () => false,

--- a/apps/web/src/localDb/mediaTransfers/transferQueue.ts
+++ b/apps/web/src/localDb/mediaTransfers/transferQueue.ts
@@ -1,4 +1,3 @@
-import type { MediaAsset } from "../../types";
 import type { IndexedDbOpenRecoveryState } from "../../appError/AppErrorContext";
 import {
   closeDatabaseAfter,
@@ -6,126 +5,25 @@ import {
   describeIndexedDbError,
   getFromStore,
   runReadwrite,
-  type StoredMediaAsset,
 } from "../core/database";
-
-export type MediaBlobCacheRecord = Readonly<{
-  sha256: string;
-  mimeType: string;
-  sizeBytes: number;
-  blob: Blob;
-  createdAt: string;
-  lastAccessedAt: string;
-  sourceMediaAssetId?: string;
-}>;
-
-export type MediaTransferKind = "download" | "upload";
-export type MediaTransferStatus = "queued" | "in_progress" | "completed" | "failed";
-
-export type MediaTransferQueueRecord = Readonly<{
-  transferId: string;
-  workspaceId: string;
-  kind: MediaTransferKind;
-  status: MediaTransferStatus;
-  mediaAssetId: string;
-  sha256: string;
-  mimeType: string;
-  sizeBytes: number;
-  sourceBlobCacheKey: string | null;
-  attemptCount: number;
-  nextAttemptAt: string;
-  lastError: string | null;
-  createdAt: string;
-  updatedAt: string;
-  claimedAt: string | null;
-  completedAt: string | null;
-}>;
-
-export type EnqueueMediaTransferDownloadInput = Readonly<{
-  transferId: string;
-  workspaceId: string;
-  mediaAssetId: string;
-  sha256: string;
-  mimeType: string;
-  sizeBytes: number;
-  createdAt: string;
-  nextAttemptAt: string;
-}>;
-
-export type EnqueueMediaTransferUploadInput = Readonly<{
-  transferId: string;
-  workspaceId: string;
-  mediaAssetId: string;
-  sha256: string;
-  mimeType: string;
-  sizeBytes: number;
-  sourceBlobCacheKey: string;
-  createdAt: string;
-  nextAttemptAt: string;
-}>;
-
-export type PersistLocalMediaUploadInput = Readonly<{
-  mediaAsset: MediaAsset;
-  cacheRecord: MediaBlobCacheRecord;
-  upload: EnqueueMediaTransferUploadInput;
-}>;
-
-export type MediaUploadTransferForMediaAsset = Readonly<{
-  mediaAssetId: string;
-  transfer: MediaTransferQueueRecord;
-}>;
+import type {
+  EnqueueMediaTransferDownloadInput,
+  EnqueueMediaTransferUploadInput,
+  MarkClaimedMediaTransferFailedInput,
+  MarkClaimedMediaTransferSucceededInput,
+  MarkMediaUploadTransferCompletionTerminalInput,
+  MarkMediaUploadTransferDueForRetryInput,
+  MediaTransferKind,
+  MediaTransferQueueRecord,
+  MediaTransferStatus,
+  MediaUploadTransferForMediaAsset,
+  RecoverStaleInProgressMediaTransfersByKindInput,
+  RenewInProgressMediaTransferClaimInput,
+} from "./types";
 
 type ClaimableMediaTransferStatus = "queued" | "failed";
 
-export type RecoverStaleInProgressMediaTransfersByKindInput = Readonly<{
-  workspaceId: string;
-  kind: MediaTransferKind;
-  staleClaimedBefore: string;
-  recoveredAt: string;
-  nextAttemptAt: string;
-  lastError: string;
-}>;
-
-export type RenewInProgressMediaTransferClaimInput = Readonly<{
-  transferId: string;
-  kind: MediaTransferKind;
-  expectedClaimedAt: string;
-  renewedAt: string;
-}>;
-
-export type MarkClaimedMediaTransferSucceededInput = Readonly<{
-  transferId: string;
-  kind: MediaTransferKind;
-  expectedClaimedAt: string;
-  completedAt: string;
-}>;
-
-export type MarkClaimedMediaTransferFailedInput = Readonly<{
-  transferId: string;
-  kind: MediaTransferKind;
-  expectedClaimedAt: string;
-  failedAt: string;
-  lastError: string;
-  nextAttemptAt: string;
-}>;
-
-export type MarkMediaUploadTransferDueForRetryInput = Readonly<{
-  transferId: string;
-  workspaceId: string;
-  mediaAssetId: string;
-  retryAt: string;
-}>;
-
-export type MarkMediaUploadTransferCompletionTerminalInput = Readonly<{
-  transferId: string;
-  workspaceId: string;
-  mediaAssetId: string;
-  failedAt: string;
-  lastError: string;
-  nextAttemptAt: string;
-}>;
-
-function createQueuedMediaTransferRecord(
+export function createQueuedMediaTransferRecord(
   input: EnqueueMediaTransferDownloadInput | EnqueueMediaTransferUploadInput,
   kind: MediaTransferKind,
   sourceBlobCacheKey: string | null,
@@ -264,15 +162,6 @@ function rejectIndexedDbTransaction(
   reject(error);
 }
 
-export async function loadMediaBlobCacheRecord(sha256: string): Promise<MediaBlobCacheRecord | null> {
-  const record = await closeDatabaseAfter((database) => getFromStore<MediaBlobCacheRecord>(
-    database,
-    "mediaBlobCache",
-    sha256,
-  ));
-  return record ?? null;
-}
-
 export async function loadMediaTransferQueueRecord(
   transferId: string,
 ): Promise<MediaTransferQueueRecord | null> {
@@ -352,22 +241,6 @@ export async function loadMediaUploadTransfersForWorkspaceMediaAssets(
   }));
 }
 
-export async function writeMediaBlobCacheRecord(record: MediaBlobCacheRecord): Promise<void> {
-  await closeDatabaseAfterWrite(async (database) => {
-    await runReadwrite(database, ["mediaBlobCache"], (transaction) => (
-      transaction.objectStore("mediaBlobCache").put(record)
-    ));
-  });
-}
-
-export async function deleteMediaBlobCacheRecord(sha256: string): Promise<void> {
-  await closeDatabaseAfterWrite(async (database) => {
-    await runReadwrite(database, ["mediaBlobCache"], (transaction) => (
-      transaction.objectStore("mediaBlobCache").delete(sha256)
-    ));
-  });
-}
-
 async function putMediaTransferQueueRecord(record: MediaTransferQueueRecord): Promise<void> {
   await closeDatabaseAfterWrite(async (database) => {
     await runReadwrite(database, ["mediaTransferQueue"], (transaction) => (
@@ -390,20 +263,6 @@ export async function enqueueMediaTransferUpload(
   const record = createQueuedMediaTransferRecord(input, "upload", input.sourceBlobCacheKey);
   await putMediaTransferQueueRecord(record);
   return record;
-}
-
-export async function persistLocalMediaUpload(
-  input: PersistLocalMediaUploadInput,
-): Promise<MediaTransferQueueRecord> {
-  const transferRecord = createQueuedMediaTransferRecord(input.upload, "upload", input.upload.sourceBlobCacheKey);
-  await closeDatabaseAfterWrite(async (database) => {
-    await runReadwrite(database, ["mediaBlobCache", "mediaAssets", "mediaTransferQueue"], (transaction) => {
-      transaction.objectStore("mediaBlobCache").put(input.cacheRecord);
-      transaction.objectStore("mediaAssets").put(input.mediaAsset satisfies StoredMediaAsset);
-      return transaction.objectStore("mediaTransferQueue").put(transferRecord);
-    });
-  });
-  return transferRecord;
 }
 
 async function claimNextDueMediaTransferWithSelector(

--- a/apps/web/src/localDb/mediaTransfers/types.ts
+++ b/apps/web/src/localDb/mediaTransfers/types.ts
@@ -1,0 +1,115 @@
+import type { MediaAsset } from "../../types";
+
+export type MediaBlobCacheRecord = Readonly<{
+  sha256: string;
+  mimeType: string;
+  sizeBytes: number;
+  blob: Blob;
+  createdAt: string;
+  lastAccessedAt: string;
+  sourceMediaAssetId?: string;
+}>;
+
+export type MediaTransferKind = "download" | "upload";
+export type MediaTransferStatus = "queued" | "in_progress" | "completed" | "failed";
+
+export type MediaTransferQueueRecord = Readonly<{
+  transferId: string;
+  workspaceId: string;
+  kind: MediaTransferKind;
+  status: MediaTransferStatus;
+  mediaAssetId: string;
+  sha256: string;
+  mimeType: string;
+  sizeBytes: number;
+  sourceBlobCacheKey: string | null;
+  attemptCount: number;
+  nextAttemptAt: string;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+  claimedAt: string | null;
+  completedAt: string | null;
+}>;
+
+export type EnqueueMediaTransferDownloadInput = Readonly<{
+  transferId: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  sha256: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  nextAttemptAt: string;
+}>;
+
+export type EnqueueMediaTransferUploadInput = Readonly<{
+  transferId: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  sha256: string;
+  mimeType: string;
+  sizeBytes: number;
+  sourceBlobCacheKey: string;
+  createdAt: string;
+  nextAttemptAt: string;
+}>;
+
+export type PersistLocalMediaUploadInput = Readonly<{
+  mediaAsset: MediaAsset;
+  cacheRecord: MediaBlobCacheRecord;
+  upload: EnqueueMediaTransferUploadInput;
+}>;
+
+export type MediaUploadTransferForMediaAsset = Readonly<{
+  mediaAssetId: string;
+  transfer: MediaTransferQueueRecord;
+}>;
+
+export type RecoverStaleInProgressMediaTransfersByKindInput = Readonly<{
+  workspaceId: string;
+  kind: MediaTransferKind;
+  staleClaimedBefore: string;
+  recoveredAt: string;
+  nextAttemptAt: string;
+  lastError: string;
+}>;
+
+export type RenewInProgressMediaTransferClaimInput = Readonly<{
+  transferId: string;
+  kind: MediaTransferKind;
+  expectedClaimedAt: string;
+  renewedAt: string;
+}>;
+
+export type MarkClaimedMediaTransferSucceededInput = Readonly<{
+  transferId: string;
+  kind: MediaTransferKind;
+  expectedClaimedAt: string;
+  completedAt: string;
+}>;
+
+export type MarkClaimedMediaTransferFailedInput = Readonly<{
+  transferId: string;
+  kind: MediaTransferKind;
+  expectedClaimedAt: string;
+  failedAt: string;
+  lastError: string;
+  nextAttemptAt: string;
+}>;
+
+export type MarkMediaUploadTransferDueForRetryInput = Readonly<{
+  transferId: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  retryAt: string;
+}>;
+
+export type MarkMediaUploadTransferCompletionTerminalInput = Readonly<{
+  transferId: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  failedAt: string;
+  lastError: string;
+  nextAttemptAt: string;
+}>;


### PR DESCRIPTION
## Summary
- separate media blob-cache persistence from transfer queue state transitions
- keep local media upload persistence atomic across all three IndexedDB stores
- preserve the media transfer public barrel and exercise it in the existing boundary test

## Validation
- not run locally; repository CI owns executable validation