### PR TITLE
Refactor Web lifecycle ownership

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,32 +1,10 @@
 import { Suspense, lazy, useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { BrowserRouter, NavLink, Navigate, Route, Routes as RouterRoutes, useLocation, useParams } from "react-router";
 import { AccountMenu } from "./AccountMenu";
-import {
-  beginAccountDeletionRetryAttempt,
-  clearAllLocalBrowserData,
-  deleteAccountConfirmationText,
-  hasAccountDeletionAttemptDispatched,
-  isAccountDeletionPending,
-  isAccountDeletionServerConfirmed,
-  loadAccountDeletionAttemptId,
-  loadAccountDeletionCsrfToken,
-  markAccountDeletionAttemptDispatched,
-  markAccountDeletionServerConfirmed,
-  runWithAccountDeletionLock,
-  setAccountDeletionPending,
-  subscribeToAccountDeletionPending,
-} from "./accountDeletion";
+import { AccountDeletionRecoveryGate } from "./accountDeletionRecovery";
 import { AppDataProvider, useAppData } from "./appData";
 import { AppErrorDialogProvider } from "./appError/AppErrorContext";
-import {
-  ApiError,
-  ApiContractError,
-  buildLoginUrl,
-  buildLogoutLocalUrl,
-  buildLogoutUrl,
-  deleteMyAccount,
-  primeSessionCsrfToken,
-} from "./api";
+import { buildLoginUrl, buildLogoutUrl } from "./api";
 import { ChatDraftProvider } from "./chat/composer/drafts/ChatDraftContext";
 import { ChatLayoutProvider, useChatLayout } from "./chat/layout/ChatLayoutContext";
 import { ChatSessionControllerProvider } from "./chat/sessionController";
@@ -34,8 +12,6 @@ import { ChatToggle } from "./chat/layout/ChatToggle";
 import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss, type AnchoredFloatingOverlayMinimumWidth } from "./floating";
 import { useAppErrorDialog } from "./appError/AppErrorContext";
 import { type TranslationKey, useI18n } from "./i18n";
-import { captureApiContractError } from "./observability/apiContractObservation";
-import { captureAppOperationError } from "./observability/appOperationObservation";
 import { AppErrorBoundary, wrapRoutesComponent } from "./observability/instrument";
 import {
   accountAgentConnectionsRoute,
@@ -369,7 +345,6 @@ export function AppShell(): ReactElement {
     isSessionVerified,
     sessionErrorMessage,
     sessionTechnicalError,
-    session,
     activeWorkspace,
     availableWorkspaces,
     isChoosingWorkspace,
@@ -381,11 +356,7 @@ export function AppShell(): ReactElement {
     createWorkspace,
     cloudSettings,
   } = useAppData();
-  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
-  const [isAccountDeletionPendingState, setIsAccountDeletionPendingState] = useState<boolean>(isAccountDeletionPending);
-  const [accountDeletionErrorMessage, setAccountDeletionErrorMessage] = useState<string>("");
-  const [accountDeletionTechnicalError, setAccountDeletionTechnicalError] = useState<Error | null>(null);
-  const [isAccountDeletionSubmitting, setIsAccountDeletionSubmitting] = useState<boolean>(false);
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const [isMobileNavigationOpen, setIsMobileNavigationOpen] = useState<boolean>(false);
   const topbarShellRef = useRef<HTMLElement | null>(null);
   const mobileNavigationToggleRef = useRef<HTMLButtonElement | null>(null);
@@ -406,14 +377,6 @@ export function AppShell(): ReactElement {
     : technicalError === null
       ? errorMessage
       : visibleTechnicalErrorMessage;
-  const visibleAccountDeletionErrorMessage = accountDeletionErrorMessage === ""
-    ? ""
-    : accountDeletionTechnicalError === null
-      ? accountDeletionErrorMessage
-      : visibleTechnicalErrorMessage;
-  const visiblePendingAccountDeletionErrorMessage = visibleAccountDeletionErrorMessage === ""
-    ? visibleSessionErrorMessage
-    : visibleAccountDeletionErrorMessage;
 
   const selectInitialWorkspace = useCallback(async function selectInitialWorkspace(workspaceId: string): Promise<void> {
     if (indexedDbOpenRecoveryState.hasFailed()) {
@@ -431,158 +394,6 @@ export function AppShell(): ReactElement {
       throw error;
     }
   }, [chooseWorkspace, indexedDbOpenRecoveryState]);
-
-  const reportAccountDeletionError = useCallback(function reportAccountDeletionError(error: unknown): void {
-    const normalizedError = error instanceof Error ? error : new Error(String(error));
-    let wasCaptured = false;
-    if (normalizedError instanceof ApiContractError) {
-      captureApiContractError(normalizedError, {
-        feature: "auth",
-        sourceAction: "account_deletion_submit",
-        userId: session?.userId ?? null,
-        workspaceId: activeWorkspace?.workspaceId ?? null,
-        installationId: cloudSettings?.installationId ?? null,
-      });
-      wasCaptured = true;
-    } else {
-      wasCaptured = captureAppOperationError(normalizedError, {
-        feature: "auth",
-        operation: "account_deletion_submit",
-        userId: session?.userId ?? null,
-        workspaceId: activeWorkspace?.workspaceId ?? null,
-        installationId: cloudSettings?.installationId ?? null,
-        entityId: null,
-      });
-    }
-
-    setAccountDeletionErrorMessage(normalizedError.message);
-    setAccountDeletionTechnicalError(wasCaptured ? normalizedError : null);
-    if (wasCaptured) {
-      showCapturedTechnicalError(normalizedError);
-    }
-  }, [activeWorkspace?.workspaceId, cloudSettings?.installationId, session?.userId, showCapturedTechnicalError]);
-
-  const completeAccountDeletion = useCallback(async function completeAccountDeletion(): Promise<void> {
-    let didStartSubmission = false;
-    try {
-      indexedDbOpenRecoveryState.throwIfFailed();
-      if (isSessionVerified === false) {
-        if (sessionLoadState !== "error") {
-          return;
-        }
-
-        didStartSubmission = true;
-        setIsAccountDeletionSubmitting(true);
-        setAccountDeletionErrorMessage("");
-        setAccountDeletionTechnicalError(null);
-        await initialize();
-        indexedDbOpenRecoveryState.throwIfFailed();
-        return;
-      }
-
-      await runWithAccountDeletionLock(
-        indexedDbOpenRecoveryState.signal,
-        async (): Promise<void> => {
-          indexedDbOpenRecoveryState.throwIfFailed();
-          if (isAccountDeletionPending() === false) {
-            return;
-          }
-
-          const isServerConfirmed = isAccountDeletionServerConfirmed();
-          if (isServerConfirmed === false && hasAccountDeletionAttemptDispatched()) {
-            return;
-          }
-
-          didStartSubmission = true;
-          setIsAccountDeletionSubmitting(true);
-          setAccountDeletionErrorMessage("");
-          setAccountDeletionTechnicalError(null);
-
-          if (isServerConfirmed === false) {
-            const persistedCsrfToken = loadAccountDeletionCsrfToken();
-            if (persistedCsrfToken !== null) {
-              primeSessionCsrfToken(persistedCsrfToken);
-            }
-
-            markAccountDeletionAttemptDispatched();
-            try {
-              await deleteMyAccount(deleteAccountConfirmationText);
-              markAccountDeletionServerConfirmed();
-            } catch (error) {
-              if ((error instanceof ApiError) === false || error.code !== "ACCOUNT_DELETED") {
-                indexedDbOpenRecoveryState.throwIfFailed();
-                throw error;
-              }
-
-              markAccountDeletionServerConfirmed();
-            }
-          }
-
-          indexedDbOpenRecoveryState.throwIfFailed();
-          await clearAllLocalBrowserData(
-            "account_deletion_submit",
-            indexedDbOpenRecoveryState.throwIfFailed,
-          );
-          indexedDbOpenRecoveryState.throwIfFailed();
-          window.location.href = buildLogoutLocalUrl();
-          setAccountDeletionPending(false);
-        },
-      );
-      indexedDbOpenRecoveryState.throwIfFailed();
-    } catch (error) {
-      indexedDbOpenRecoveryState.markFailed(error);
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
-      reportAccountDeletionError(error);
-    } finally {
-      if (didStartSubmission && indexedDbOpenRecoveryState.hasFailed() === false) {
-        setIsAccountDeletionSubmitting(false);
-      }
-    }
-  }, [indexedDbOpenRecoveryState, initialize, isSessionVerified, reportAccountDeletionError, sessionLoadState]);
-
-  const retryAccountDeletion = useCallback(async function retryAccountDeletion(): Promise<void> {
-    if (
-      isAccountDeletionServerConfirmed()
-      || (isSessionVerified === false && hasAccountDeletionAttemptDispatched() === false)
-    ) {
-      await completeAccountDeletion();
-      return;
-    }
-
-    const expectedAttemptId = loadAccountDeletionAttemptId();
-    if (expectedAttemptId === null) {
-      return;
-    }
-
-    try {
-      indexedDbOpenRecoveryState.throwIfFailed();
-      const didBeginRetryAttempt = await runWithAccountDeletionLock(
-        indexedDbOpenRecoveryState.signal,
-        async (): Promise<boolean> => {
-          indexedDbOpenRecoveryState.throwIfFailed();
-          return beginAccountDeletionRetryAttempt(expectedAttemptId);
-        },
-      );
-      indexedDbOpenRecoveryState.throwIfFailed();
-      if (didBeginRetryAttempt === false) {
-        return;
-      }
-
-      await completeAccountDeletion();
-    } catch (error) {
-      indexedDbOpenRecoveryState.markFailed(error);
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
-      reportAccountDeletionError(error);
-    }
-  }, [completeAccountDeletion, indexedDbOpenRecoveryState, isSessionVerified, reportAccountDeletionError]);
-
-  useEffect(() => subscribeToAccountDeletionPending(() => {
-    setIsAccountDeletionPendingState(isAccountDeletionPending());
-  }), []);
 
   const closeMobileNavigation = useCallback(function closeMobileNavigation(): void {
     setIsMobileNavigationOpen(false);
@@ -641,43 +452,8 @@ export function AppShell(): ReactElement {
     };
   }, [closeMobileNavigationAndFocusToggle, isMobileNavigationOpen]);
 
-  useEffect(() => {
-    if (
-      isSessionVerified
-      && isAccountDeletionPendingState
-      && !isAccountDeletionSubmitting
-      && accountDeletionErrorMessage === ""
-    ) {
-      void completeAccountDeletion();
-    }
-  }, [accountDeletionErrorMessage, completeAccountDeletion, isAccountDeletionPendingState, isAccountDeletionSubmitting, isSessionVerified]);
-
   function toggleMobileNavigation(): void {
     setIsMobileNavigationOpen((currentValue: boolean): boolean => !currentValue);
-  }
-
-  if (isAccountDeletionPendingState) {
-    return (
-      <main className="page-state">
-        <section className="panel panel-center state-panel">
-          <h1 className="title">{t("app.deleteAccountTitle")}</h1>
-          <p className="subtitle">
-            {isSessionVerified
-              ? t("app.deleteAccountInProgress")
-              : t("app.deleteAccountRestoring")}
-          </p>
-          {visiblePendingAccountDeletionErrorMessage !== "" ? <p className="error-banner">{visiblePendingAccountDeletionErrorMessage}</p> : null}
-          <button
-            className="primary-btn"
-            type="button"
-            disabled={isAccountDeletionSubmitting || (isSessionVerified === false && sessionLoadState !== "error")}
-            onClick={() => void retryAccountDeletion()}
-          >
-            {isAccountDeletionSubmitting ? t("app.deleting") : t("app.deleteAccountRetry")}
-          </button>
-        </section>
-      </main>
-    );
   }
 
   if (sessionLoadState === "loading" || sessionLoadState === "redirecting") {
@@ -998,7 +774,9 @@ function AuthenticatedApp(): ReactElement {
         <ChatLayoutProvider>
           <ChatSessionControllerProvider>
             <ChatDraftProvider>
-              <AppShell />
+              <AccountDeletionRecoveryGate>
+                <AppShell />
+              </AccountDeletionRecoveryGate>
             </ChatDraftProvider>
           </ChatSessionControllerProvider>
         </ChatLayoutProvider>

--- a/apps/web/src/accountDeletionRecovery.tsx
+++ b/apps/web/src/accountDeletionRecovery.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useEffect, useState, type ReactElement } from "react";
+import {
+  beginAccountDeletionRetryAttempt,
+  clearAllLocalBrowserData,
+  deleteAccountConfirmationText,
+  hasAccountDeletionAttemptDispatched,
+  isAccountDeletionPending,
+  isAccountDeletionServerConfirmed,
+  loadAccountDeletionAttemptId,
+  loadAccountDeletionCsrfToken,
+  markAccountDeletionAttemptDispatched,
+  markAccountDeletionServerConfirmed,
+  runWithAccountDeletionLock,
+  setAccountDeletionPending,
+  subscribeToAccountDeletionPending,
+} from "./accountDeletion";
+import { useAppData } from "./appData";
+import { useAppErrorDialog } from "./appError/AppErrorContext";
+import {
+  ApiError,
+  ApiContractError,
+  buildLogoutLocalUrl,
+  deleteMyAccount,
+  primeSessionCsrfToken,
+} from "./api";
+import { useI18n } from "./i18n";
+import { captureApiContractError } from "./observability/apiContractObservation";
+import { captureAppOperationError } from "./observability/appOperationObservation";
+
+type AccountDeletionRecoveryGateProps = Readonly<{
+  children: ReactElement;
+}>;
+
+export function AccountDeletionRecoveryGate(props: AccountDeletionRecoveryGateProps): ReactElement {
+  const { children } = props;
+  const { t } = useI18n();
+  const {
+    sessionLoadState,
+    isSessionVerified,
+    sessionErrorMessage,
+    sessionTechnicalError,
+    session,
+    activeWorkspace,
+    initialize,
+    cloudSettings,
+  } = useAppData();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
+  const [isAccountDeletionPendingState, setIsAccountDeletionPendingState] = useState<boolean>(isAccountDeletionPending);
+  const [accountDeletionErrorMessage, setAccountDeletionErrorMessage] = useState<string>("");
+  const [accountDeletionTechnicalError, setAccountDeletionTechnicalError] = useState<Error | null>(null);
+  const [isAccountDeletionSubmitting, setIsAccountDeletionSubmitting] = useState<boolean>(false);
+  const visibleTechnicalErrorMessage = t("appError.technicalError.message");
+  const visibleSessionErrorMessage = sessionErrorMessage === ""
+    ? ""
+    : sessionTechnicalError === null
+      ? sessionErrorMessage
+      : visibleTechnicalErrorMessage;
+  const visibleAccountDeletionErrorMessage = accountDeletionErrorMessage === ""
+    ? ""
+    : accountDeletionTechnicalError === null
+      ? accountDeletionErrorMessage
+      : visibleTechnicalErrorMessage;
+  const visiblePendingAccountDeletionErrorMessage = visibleAccountDeletionErrorMessage === ""
+    ? visibleSessionErrorMessage
+    : visibleAccountDeletionErrorMessage;
+
+  const reportAccountDeletionError = useCallback(function reportAccountDeletionError(error: unknown): void {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    let wasCaptured = false;
+    if (normalizedError instanceof ApiContractError) {
+      captureApiContractError(normalizedError, {
+        feature: "auth",
+        sourceAction: "account_deletion_submit",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+      });
+      wasCaptured = true;
+    } else {
+      wasCaptured = captureAppOperationError(normalizedError, {
+        feature: "auth",
+        operation: "account_deletion_submit",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: null,
+      });
+    }
+
+    setAccountDeletionErrorMessage(normalizedError.message);
+    setAccountDeletionTechnicalError(wasCaptured ? normalizedError : null);
+    if (wasCaptured) {
+      showCapturedTechnicalError(normalizedError);
+    }
+  }, [activeWorkspace?.workspaceId, cloudSettings?.installationId, session?.userId, showCapturedTechnicalError]);
+
+  const completeAccountDeletion = useCallback(async function completeAccountDeletion(): Promise<void> {
+    let didStartSubmission = false;
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      if (isSessionVerified === false) {
+        if (sessionLoadState !== "error") {
+          return;
+        }
+
+        didStartSubmission = true;
+        setIsAccountDeletionSubmitting(true);
+        setAccountDeletionErrorMessage("");
+        setAccountDeletionTechnicalError(null);
+        await initialize();
+        indexedDbOpenRecoveryState.throwIfFailed();
+        return;
+      }
+
+      await runWithAccountDeletionLock(
+        indexedDbOpenRecoveryState.signal,
+        async (): Promise<void> => {
+          indexedDbOpenRecoveryState.throwIfFailed();
+          if (isAccountDeletionPending() === false) {
+            return;
+          }
+
+          const isServerConfirmed = isAccountDeletionServerConfirmed();
+          if (isServerConfirmed === false && hasAccountDeletionAttemptDispatched()) {
+            return;
+          }
+
+          didStartSubmission = true;
+          setIsAccountDeletionSubmitting(true);
+          setAccountDeletionErrorMessage("");
+          setAccountDeletionTechnicalError(null);
+
+          if (isServerConfirmed === false) {
+            const persistedCsrfToken = loadAccountDeletionCsrfToken();
+            if (persistedCsrfToken !== null) {
+              primeSessionCsrfToken(persistedCsrfToken);
+            }
+
+            markAccountDeletionAttemptDispatched();
+            try {
+              await deleteMyAccount(deleteAccountConfirmationText);
+              markAccountDeletionServerConfirmed();
+            } catch (error) {
+              if ((error instanceof ApiError) === false || error.code !== "ACCOUNT_DELETED") {
+                indexedDbOpenRecoveryState.throwIfFailed();
+                throw error;
+              }
+
+              markAccountDeletionServerConfirmed();
+            }
+          }
+
+          indexedDbOpenRecoveryState.throwIfFailed();
+          await clearAllLocalBrowserData(
+            "account_deletion_submit",
+            indexedDbOpenRecoveryState.throwIfFailed,
+          );
+          indexedDbOpenRecoveryState.throwIfFailed();
+          window.location.href = buildLogoutLocalUrl();
+          setAccountDeletionPending(false);
+        },
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
+    } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+      reportAccountDeletionError(error);
+    } finally {
+      if (didStartSubmission && indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsAccountDeletionSubmitting(false);
+      }
+    }
+  }, [indexedDbOpenRecoveryState, initialize, isSessionVerified, reportAccountDeletionError, sessionLoadState]);
+
+  const retryAccountDeletion = useCallback(async function retryAccountDeletion(): Promise<void> {
+    if (
+      isAccountDeletionServerConfirmed()
+      || (isSessionVerified === false && hasAccountDeletionAttemptDispatched() === false)
+    ) {
+      await completeAccountDeletion();
+      return;
+    }
+
+    const expectedAttemptId = loadAccountDeletionAttemptId();
+    if (expectedAttemptId === null) {
+      return;
+    }
+
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      const didBeginRetryAttempt = await runWithAccountDeletionLock(
+        indexedDbOpenRecoveryState.signal,
+        async (): Promise<boolean> => {
+          indexedDbOpenRecoveryState.throwIfFailed();
+          return beginAccountDeletionRetryAttempt(expectedAttemptId);
+        },
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
+      if (didBeginRetryAttempt === false) {
+        return;
+      }
+
+      await completeAccountDeletion();
+    } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+      reportAccountDeletionError(error);
+    }
+  }, [completeAccountDeletion, indexedDbOpenRecoveryState, isSessionVerified, reportAccountDeletionError]);
+
+  useEffect(() => subscribeToAccountDeletionPending(() => {
+    setIsAccountDeletionPendingState(isAccountDeletionPending());
+  }), []);
+
+  useEffect(() => {
+    if (
+      isSessionVerified
+      && isAccountDeletionPendingState
+      && !isAccountDeletionSubmitting
+      && accountDeletionErrorMessage === ""
+    ) {
+      void completeAccountDeletion();
+    }
+  }, [accountDeletionErrorMessage, completeAccountDeletion, isAccountDeletionPendingState, isAccountDeletionSubmitting, isSessionVerified]);
+
+  if (isAccountDeletionPendingState) {
+    return (
+      <main className="page-state">
+        <section className="panel panel-center state-panel">
+          <h1 className="title">{t("app.deleteAccountTitle")}</h1>
+          <p className="subtitle">
+            {isSessionVerified
+              ? t("app.deleteAccountInProgress")
+              : t("app.deleteAccountRestoring")}
+          </p>
+          {visiblePendingAccountDeletionErrorMessage !== "" ? <p className="error-banner">{visiblePendingAccountDeletionErrorMessage}</p> : null}
+          <button
+            className="primary-btn"
+            type="button"
+            disabled={isAccountDeletionSubmitting || (isSessionVerified === false && sessionLoadState !== "error")}
+            onClick={() => void retryAccountDeletion()}
+          >
+            {isAccountDeletionSubmitting ? t("app.deleting") : t("app.deleteAccountRetry")}
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return children;
+}

--- a/apps/web/src/chat/sessionController/actions/useActions.ts
+++ b/apps/web/src/chat/sessionController/actions/useActions.ts
@@ -7,7 +7,6 @@ import {
   ApiContractError,
   ApiError,
   AuthRedirectError,
-  createNewChatSession,
   startChatRun,
   stopChatRun,
 } from "../../../api";
@@ -56,6 +55,7 @@ import {
   isAiChatRequestTooLargeError,
 } from "../../shared/chatSizePolicy";
 import type { ChatHistoryState } from "../../history/useChatHistory";
+import { useRemoteSessionProvisioning } from "./useRemoteSessionProvisioning";
 
 type FreshSessionErrorPresentation = "new_chat" | "refresh" | "silent";
 
@@ -240,106 +240,25 @@ export function useChatSessionActions(
   const clearConversationRequestSequenceRef = useRef<number>(0);
   const currentUiLocaleRef = useRef<Locale>(uiLocale);
   currentUiLocaleRef.current = uiLocale;
-  const remoteSessionProvisioningRef = useRef<Readonly<{
-    workspaceId: string | null;
-    sessionId: string;
-    uiLocale: Locale;
-    promise: Promise<NewChatSessionResponse>;
-  }> | null>(null);
-
-  type RemoteSessionResolution = Readonly<{
-    sessionId: string;
-    provisionedResponse: NewChatSessionResponse | null;
-  }>;
-
   type SessionConflictRecovery =
     | Readonly<{ status: "not_recoverable" }>
     | Readonly<{ status: "recovered"; session: NewChatSessionResponse }>
     | Readonly<{ status: "stale" }>;
 
-  function createRemoteSessionProvisioningError(message: string): Error {
+  function createChatSessionActionError(message: string): Error {
     return new Error(message);
   }
 
-  function normalizeExistingSessionId(sessionId: string | null): string | null {
-    if (sessionId === null) {
-      return null;
-    }
-
-    const trimmedSessionId = sessionId.trim();
-    return trimmedSessionId === "" ? null : trimmedSessionId;
-  }
-
-  function getActiveProvisioningState(): Readonly<{
-    sessionId: string;
-    promise: Promise<NewChatSessionResponse>;
-  }> | null {
-    const provisioningState = remoteSessionProvisioningRef.current;
-    if (
-      provisioningState === null
-      || provisioningState.workspaceId !== workspaceId
-      || provisioningState.uiLocale !== uiLocale
-    ) {
-      return null;
-    }
-
-    return {
-      sessionId: provisioningState.sessionId,
-      promise: provisioningState.promise,
-    };
-  }
-
-  const provisionRemoteSession = useCallback(async (
-    sessionId: string,
-  ): Promise<NewChatSessionResponse> => {
-    indexedDbOpenRecoveryState.throwIfFailed();
-    if (workspaceId === null) {
-      throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
-    }
-
-    const activeProvisioning = getActiveProvisioningState();
-    if (activeProvisioning !== null && activeProvisioning.sessionId === sessionId) {
-      try {
-        const response = await activeProvisioning.promise;
-        indexedDbOpenRecoveryState.throwIfFailed();
-        return response;
-      } catch (error) {
-        indexedDbOpenRecoveryState.throwIfFailed();
-        indexedDbOpenRecoveryState.markFailed(error);
-        indexedDbOpenRecoveryState.throwIfFailed();
-        throw error;
-      }
-    }
-
-    const nextPromise = createNewChatSession(sessionId, workspaceId, uiLocale);
-    remoteSessionProvisioningRef.current = {
-      workspaceId,
-      sessionId,
-      uiLocale,
-      promise: nextPromise,
-    };
-
-    try {
-      const response = await nextPromise;
-      indexedDbOpenRecoveryState.throwIfFailed();
-      return response;
-    } catch (error) {
-      indexedDbOpenRecoveryState.throwIfFailed();
-      indexedDbOpenRecoveryState.markFailed(error);
-      indexedDbOpenRecoveryState.throwIfFailed();
-      throw error;
-    } finally {
-      const currentProvisioning = remoteSessionProvisioningRef.current;
-      if (
-        currentProvisioning !== null
-        && currentProvisioning.workspaceId === workspaceId
-        && currentProvisioning.sessionId === sessionId
-        && currentProvisioning.uiLocale === uiLocale
-      ) {
-        remoteSessionProvisioningRef.current = null;
-      }
-    }
-  }, [indexedDbOpenRecoveryState, uiLocale, uiMessages, workspaceId]);
+  const {
+    provisionRequestedSession,
+    resolveCurrentOrNewSession,
+  } = useRemoteSessionProvisioning({
+    indexedDbOpenRecoveryState,
+    workspaceId,
+    isRemoteReady,
+    uiLocale,
+    uiMessages,
+  });
 
   const beginFreshSessionRequestSequence = useCallback((): number => {
     const nextSequence = clearConversationRequestSequenceRef.current + 1;
@@ -387,10 +306,9 @@ export function useChatSessionActions(
     invalidatePendingSnapshotRequests();
     resetSnapshotTracking(null);
     const nextSessionId = createClientChatSessionId();
-    remoteSessionProvisioningRef.current = null;
-    const response = await provisionRemoteSession(nextSessionId);
+    const response = await provisionRequestedSession(nextSessionId);
     if (response.sessionId !== nextSessionId) {
-      throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
+      throw createChatSessionActionError(uiMessages.unexpectedSessionId);
     }
 
     if (
@@ -408,7 +326,7 @@ export function useChatSessionActions(
     canRecoverFromSessionIdConflict,
     invalidatePendingSnapshotRequests,
     isRequestSequenceCurrent,
-    provisionRemoteSession,
+    provisionRequestedSession,
     resetSnapshotTracking,
     uiMessages,
   ]);
@@ -438,7 +356,7 @@ export function useChatSessionActions(
     const requestLocale = uiLocale;
     void (async (): Promise<void> => {
       try {
-        const response = await provisionRemoteSession(sessionId);
+        const response = await provisionRequestedSession(sessionId);
         indexedDbOpenRecoveryState.throwIfFailed();
         if (response.sessionId !== sessionId) {
           return;
@@ -485,7 +403,7 @@ export function useChatSessionActions(
         });
       }
     })();
-  }, [dispatch, indexedDbOpenRecoveryState, isFreshSessionEnsureCurrent, provisionRemoteSession, uiMessages, workspaceId]);
+  }, [dispatch, indexedDbOpenRecoveryState, isFreshSessionEnsureCurrent, provisionRequestedSession, uiMessages, workspaceId]);
 
   const ensureFreshSessionInBackground = useCallback((sessionId: string, requestSequence: number): void => {
     ensureFreshSession(sessionId, requestSequence, "silent");
@@ -496,58 +414,7 @@ export function useChatSessionActions(
   }, [ensureFreshSession]);
 
   const ensureRemoteSession = useCallback(async (): Promise<string> => {
-    indexedDbOpenRecoveryState.throwIfFailed();
-    if (workspaceId === null) {
-      throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
-    }
-
-    if (isRemoteReady === false) {
-      throw createRemoteSessionProvisioningError(uiMessages.remoteNotReady);
-    }
-
-    const resolveRemoteSession = async (): Promise<RemoteSessionResolution> => {
-      const currentSessionId = normalizeExistingSessionId(runtimeRefs.currentSessionIdRef.current);
-      const activeProvisioning = getActiveProvisioningState();
-
-      if (currentSessionId !== null) {
-        if (activeProvisioning !== null && activeProvisioning.sessionId === currentSessionId) {
-          const response = await activeProvisioning.promise;
-          if (response.sessionId !== currentSessionId) {
-            throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
-          }
-        }
-
-        return {
-          sessionId: currentSessionId,
-          provisionedResponse: null,
-        };
-      }
-
-      if (activeProvisioning !== null) {
-        const response = await activeProvisioning.promise;
-        if (response.sessionId !== activeProvisioning.sessionId) {
-          throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
-        }
-
-        return {
-          sessionId: response.sessionId,
-          provisionedResponse: response,
-        };
-      }
-
-      const nextSessionId = createClientChatSessionId();
-      const response = await provisionRemoteSession(nextSessionId);
-      if (response.sessionId !== nextSessionId) {
-        throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
-      }
-
-      return {
-        sessionId: response.sessionId,
-        provisionedResponse: response,
-      };
-    };
-
-    const resolution = await resolveRemoteSession();
+    const resolution = await resolveCurrentOrNewSession(runtimeRefs.currentSessionIdRef.current);
     indexedDbOpenRecoveryState.throwIfFailed();
     if (
       resolution.provisionedResponse !== null
@@ -564,52 +431,13 @@ export function useChatSessionActions(
     }
 
     return resolution.sessionId;
-  }, [dispatch, indexedDbOpenRecoveryState, isRemoteReady, provisionRemoteSession, runtimeRefs, uiMessages, workspaceId]);
+  }, [dispatch, indexedDbOpenRecoveryState, resolveCurrentOrNewSession, runtimeRefs, workspaceId]);
 
   const ensureRemoteSessionForHydration = useCallback(async (): Promise<string> => {
+    const resolution = await resolveCurrentOrNewSession(runtimeRefs.currentSessionIdRef.current);
     indexedDbOpenRecoveryState.throwIfFailed();
-    if (workspaceId === null) {
-      throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
-    }
-
-    if (isRemoteReady === false) {
-      throw createRemoteSessionProvisioningError(uiMessages.remoteNotReady);
-    }
-
-    const currentSessionId = normalizeExistingSessionId(runtimeRefs.currentSessionIdRef.current);
-    const activeProvisioning = getActiveProvisioningState();
-
-    if (currentSessionId !== null) {
-      if (activeProvisioning !== null && activeProvisioning.sessionId === currentSessionId) {
-        const response = await activeProvisioning.promise;
-        indexedDbOpenRecoveryState.throwIfFailed();
-        if (response.sessionId !== currentSessionId) {
-          throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
-        }
-      }
-
-      return currentSessionId;
-    }
-
-    if (activeProvisioning !== null) {
-      const response = await activeProvisioning.promise;
-      indexedDbOpenRecoveryState.throwIfFailed();
-      if (response.sessionId !== activeProvisioning.sessionId) {
-        throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
-      }
-
-      return response.sessionId;
-    }
-
-    const nextSessionId = createClientChatSessionId();
-    const response = await provisionRemoteSession(nextSessionId);
-    indexedDbOpenRecoveryState.throwIfFailed();
-    if (response.sessionId !== nextSessionId) {
-      throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
-    }
-
-    return response.sessionId;
-  }, [indexedDbOpenRecoveryState, isRemoteReady, provisionRemoteSession, runtimeRefs, uiMessages, workspaceId]);
+    return resolution.sessionId;
+  }, [indexedDbOpenRecoveryState, resolveCurrentOrNewSession, runtimeRefs]);
 
   const sendMessage = useCallback(async (
     sendParams: SendChatMessageParams,
@@ -765,7 +593,7 @@ export function useChatSessionActions(
     }
 
     if (sessionId === null) {
-      return failRemoteSessionRequest(createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId));
+      return failRemoteSessionRequest(createChatSessionActionError(uiMessages.unexpectedSessionId));
     }
 
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -1015,7 +843,7 @@ export function useChatSessionActions(
     dispatch({ type: "stop_requested", runId: requestActiveRunId });
     try {
       if (requestWorkspaceId === null) {
-        throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
+        throw createChatSessionActionError(uiMessages.workspaceRequired);
       }
 
       const response = await stopChatRun(requestSessionId, requestWorkspaceId, requestActiveRunId);

--- a/apps/web/src/chat/sessionController/actions/useRemoteSessionProvisioning.ts
+++ b/apps/web/src/chat/sessionController/actions/useRemoteSessionProvisioning.ts
@@ -1,0 +1,204 @@
+import { useCallback, useRef } from "react";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
+import { createNewChatSession } from "../../../api";
+import type { Locale } from "../../../i18n/types";
+import type { NewChatSessionResponse } from "../../../types";
+import { createClientChatSessionId } from "../support/helpers";
+import type { ChatSessionControllerUiMessages } from "../support/types";
+
+type RemoteSessionProvisioningMessages = Readonly<Pick<
+  ChatSessionControllerUiMessages,
+  "remoteNotReady" | "unexpectedSessionId" | "workspaceRequired"
+>>;
+
+type UseRemoteSessionProvisioningParams = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
+  workspaceId: string | null;
+  isRemoteReady: boolean;
+  uiLocale: Locale;
+  uiMessages: RemoteSessionProvisioningMessages;
+}>;
+
+type RemoteSessionProvisioningState = Readonly<{
+  workspaceId: string;
+  sessionId: string;
+  uiLocale: Locale;
+  promise: Promise<NewChatSessionResponse>;
+}>;
+
+type ActiveRemoteSessionProvisioning = Readonly<{
+  sessionId: string;
+  promise: Promise<NewChatSessionResponse>;
+}>;
+
+type RemoteSessionResolution = Readonly<{
+  sessionId: string;
+  provisionedResponse: NewChatSessionResponse | null;
+}>;
+
+type RemoteSessionProvisioning = Readonly<{
+  provisionRequestedSession: (sessionId: string) => Promise<NewChatSessionResponse>;
+  resolveCurrentOrNewSession: (currentSessionId: string | null) => Promise<RemoteSessionResolution>;
+}>;
+
+function createRemoteSessionProvisioningError(message: string): Error {
+  return new Error(message);
+}
+
+function normalizeExistingSessionId(sessionId: string | null): string | null {
+  if (sessionId === null) {
+    return null;
+  }
+
+  const trimmedSessionId = sessionId.trim();
+  return trimmedSessionId === "" ? null : trimmedSessionId;
+}
+
+export function useRemoteSessionProvisioning(
+  params: UseRemoteSessionProvisioningParams,
+): RemoteSessionProvisioning {
+  const {
+    indexedDbOpenRecoveryState,
+    workspaceId,
+    isRemoteReady,
+    uiLocale,
+    uiMessages,
+  } = params;
+  const provisioningRef = useRef<RemoteSessionProvisioningState | null>(null);
+
+  const getActiveProvisioning = useCallback((): ActiveRemoteSessionProvisioning | null => {
+    const provisioningState = provisioningRef.current;
+    if (
+      provisioningState === null
+      || provisioningState.workspaceId !== workspaceId
+      || provisioningState.uiLocale !== uiLocale
+    ) {
+      return null;
+    }
+
+    return {
+      sessionId: provisioningState.sessionId,
+      promise: provisioningState.promise,
+    };
+  }, [uiLocale, workspaceId]);
+
+  const provisionRequestedSession = useCallback(async (
+    sessionId: string,
+  ): Promise<NewChatSessionResponse> => {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    if (workspaceId === null) {
+      throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
+    }
+
+    const activeProvisioning = getActiveProvisioning();
+    if (activeProvisioning !== null && activeProvisioning.sessionId === sessionId) {
+      try {
+        const response = await activeProvisioning.promise;
+        indexedDbOpenRecoveryState.throwIfFailed();
+        return response;
+      } catch (error) {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        indexedDbOpenRecoveryState.markFailed(error);
+        indexedDbOpenRecoveryState.throwIfFailed();
+        throw error;
+      }
+    }
+
+    const nextPromise = createNewChatSession(sessionId, workspaceId, uiLocale);
+    provisioningRef.current = {
+      workspaceId,
+      sessionId,
+      uiLocale,
+      promise: nextPromise,
+    };
+
+    try {
+      const response = await nextPromise;
+      indexedDbOpenRecoveryState.throwIfFailed();
+      return response;
+    } catch (error) {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throw error;
+    } finally {
+      const currentProvisioning = provisioningRef.current;
+      if (
+        currentProvisioning !== null
+        && currentProvisioning.workspaceId === workspaceId
+        && currentProvisioning.sessionId === sessionId
+        && currentProvisioning.uiLocale === uiLocale
+      ) {
+        provisioningRef.current = null;
+      }
+    }
+  }, [getActiveProvisioning, indexedDbOpenRecoveryState, uiLocale, uiMessages, workspaceId]);
+
+  const resolveCurrentOrNewSession = useCallback(async (
+    currentSessionId: string | null,
+  ): Promise<RemoteSessionResolution> => {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    if (workspaceId === null) {
+      throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
+    }
+
+    if (isRemoteReady === false) {
+      throw createRemoteSessionProvisioningError(uiMessages.remoteNotReady);
+    }
+
+    const normalizedSessionId = normalizeExistingSessionId(currentSessionId);
+    const activeProvisioning = getActiveProvisioning();
+
+    if (normalizedSessionId !== null) {
+      if (activeProvisioning !== null && activeProvisioning.sessionId === normalizedSessionId) {
+        const response = await activeProvisioning.promise;
+        indexedDbOpenRecoveryState.throwIfFailed();
+        if (response.sessionId !== normalizedSessionId) {
+          throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
+        }
+      }
+
+      return {
+        sessionId: normalizedSessionId,
+        provisionedResponse: null,
+      };
+    }
+
+    if (activeProvisioning !== null) {
+      const response = await activeProvisioning.promise;
+      indexedDbOpenRecoveryState.throwIfFailed();
+      if (response.sessionId !== activeProvisioning.sessionId) {
+        throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
+      }
+
+      return {
+        sessionId: response.sessionId,
+        provisionedResponse: response,
+      };
+    }
+
+    const nextSessionId = createClientChatSessionId();
+    const response = await provisionRequestedSession(nextSessionId);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    if (response.sessionId !== nextSessionId) {
+      throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
+    }
+
+    return {
+      sessionId: response.sessionId,
+      provisionedResponse: response,
+    };
+  }, [
+    getActiveProvisioning,
+    indexedDbOpenRecoveryState,
+    isRemoteReady,
+    provisionRequestedSession,
+    uiMessages,
+    workspaceId,
+  ]);
+
+  return {
+    provisionRequestedSession,
+    resolveCurrentOrNewSession,
+  };
+}

--- a/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
@@ -23,7 +23,6 @@ import {
 import { storeChatConfig } from "../support/config";
 import {
   areChatConfigsEqual,
-  areContentPartsEqual,
   areMessagesEqual,
   extractAssistantErrorMessage,
   extractLatestAssistantMessageText,
@@ -40,6 +39,7 @@ import type {
 import type { ChatSessionSnapshot } from "../state/snapshot";
 import type { ChatSessionControllerUiMessages } from "../support/types";
 import { useChatLiveSession } from "./useLiveSession";
+import { useToolRunPostSync } from "./useToolRunPostSync";
 import type { ChatHistoryState } from "../../history/useChatHistory";
 import type { ChatLiveEvent } from "../../streaming/liveStream";
 
@@ -227,182 +227,6 @@ function captureChatSnapshotError(
   });
 }
 
-/**
- * Tool-call detection is only safe when it is scoped to the latest run.
- * Inspect assistant messages after the latest user turn so older historical
- * assistant tool calls do not leak into a newer run.
- */
-function messageHasToolCalls(message: ChatSessionHistoryMessage): boolean {
-  return message.content.some((part) => part.type === "tool_call");
-}
-
-function latestRunHasToolCalls(messages: ReadonlyArray<ChatSessionHistoryMessage>): boolean {
-  let latestUserIndex = -1;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index]?.role === "user") {
-      latestUserIndex = index;
-      break;
-    }
-  }
-
-  for (let index = latestUserIndex + 1; index < messages.length; index += 1) {
-    const message = messages[index];
-    if (message?.role === "assistant" && messageHasToolCalls(message)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function trailingAssistantItemHasToolCalls(
-  messages: ReadonlyArray<ChatSessionHistoryMessage>,
-): boolean {
-  const latestMessage = messages[messages.length - 1];
-  if (latestMessage?.role !== "assistant") {
-    return false;
-  }
-
-  const trailingItemId = latestMessage.itemId;
-  if (trailingItemId === null) {
-    return false;
-  }
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (message === undefined) {
-      continue;
-    }
-
-    if (message.role === "user" || message.itemId !== trailingItemId) {
-      return false;
-    }
-
-    if (messageHasToolCalls(message)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function terminalRunHasToolCalls(messages: ReadonlyArray<ChatSessionHistoryMessage>): boolean {
-  const latestMessage = messages[messages.length - 1];
-
-  if (latestRunHasToolCalls(messages)) {
-    if (latestMessage?.role === "assistant" && messageHasToolCalls(latestMessage)) {
-      return true;
-    }
-  }
-
-  if (latestMessage?.role === "assistant" && latestMessage.itemId !== null) {
-    return trailingAssistantItemHasToolCalls(messages);
-  }
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (message === undefined) {
-      continue;
-    }
-
-    if (message.role === "user") {
-      return false;
-    }
-
-    if (messageHasToolCalls(message)) {
-      return true;
-    }
-
-    if (message.isStopped) {
-      return false;
-    }
-  }
-
-  return false;
-}
-
-function resolveAcceptedResponseMessageDelta(
-  messages: ReadonlyArray<ChatSessionHistoryMessage>,
-  previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
-): ReadonlyArray<ChatSessionHistoryMessage> | null {
-  if (previousMessages === null) {
-    return null;
-  }
-
-  if (messages.length <= previousMessages.length) {
-    return null;
-  }
-
-  const sharedHistory = messages.slice(0, previousMessages.length);
-  if (areMessagesEqual(sharedHistory, previousMessages) === false) {
-    return null;
-  }
-
-  return messages.slice(previousMessages.length);
-}
-
-function resolveMessagesAfterCurrentUser(
-  messages: ReadonlyArray<ChatSessionHistoryMessage>,
-  currentTurnContent: ReadonlyArray<ContentPart>,
-): ReadonlyArray<ChatSessionHistoryMessage> | null {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (message?.role !== "user") {
-      continue;
-    }
-
-    if (areContentPartsEqual(message.content, currentTurnContent)) {
-      return messages.slice(index + 1);
-    }
-
-    return null;
-  }
-
-  return null;
-}
-
-function activeRunHasObservedToolCalls(
-  messages: ReadonlyArray<ChatSessionHistoryMessage>,
-  previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
-  currentTurnContent: ReadonlyArray<ContentPart> | null,
-): boolean {
-  const acceptedResponseDelta = resolveAcceptedResponseMessageDelta(messages, previousMessages);
-
-  if (currentTurnContent !== null) {
-    if (acceptedResponseDelta === null) {
-      return false;
-    }
-
-    const currentRunMessages = resolveMessagesAfterCurrentUser(
-      acceptedResponseDelta,
-      currentTurnContent,
-    );
-    if (currentRunMessages !== null) {
-      return latestRunHasToolCalls(currentRunMessages);
-    }
-
-    const acceptedResponseIncludesUserMessage = acceptedResponseDelta.some((message) => message.role === "user");
-    if (acceptedResponseIncludesUserMessage) {
-      return false;
-    }
-
-    return latestRunHasToolCalls(acceptedResponseDelta);
-  }
-
-  return latestRunHasToolCalls(messages);
-}
-
-function snapshotRunHasToolCalls(
-  activeRun: ChatActiveRun | null,
-  messages: ReadonlyArray<ChatSessionHistoryMessage>,
-  previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
-  currentTurnContent: ReadonlyArray<ContentPart> | null,
-): boolean {
-  return activeRun === null
-    ? terminalRunHasToolCalls(messages)
-    : activeRunHasObservedToolCalls(messages, previousMessages, currentTurnContent);
-}
-
 export function useChatSessionSnapshotSync(
   params: UseChatSessionSnapshotSyncParams,
 ): ChatSessionSnapshotSync {
@@ -438,12 +262,21 @@ export function useChatSessionSnapshotSync(
   const activeSnapshotAbortControllersRef = useRef<Set<AbortController>>(new Set<AbortController>());
   const visibilityResumePromiseRef = useRef<Promise<void> | null>(null);
   const streamTransportRecoveryPromiseRef = useRef<Promise<void> | null>(null);
-  const activeToolRunPostSyncPromiseRef = useRef<Promise<void> | null>(null);
   const liveCursorRef = useRef<string | null>(null);
   const resumeAttemptCounterRef = useRef<number>(0);
   const assistantMessageDoneTerminalReconcileTimerRef = useRef<number | null>(null);
   const reconcileTerminalSnapshotRef = useRef<(sessionId: string | null) => void>(() => {});
-  const pendingToolRunPostSyncRef = useRef<boolean>(state.pendingToolRunPostSync);
+  const {
+    markPendingToolRunPostSync,
+    markRunHadToolCallsFromSnapshot,
+    resetToolRunPostSync,
+    triggerToolRunPostSyncIfNeeded,
+  } = useToolRunPostSync({
+    indexedDbOpenRecoveryState,
+    pendingToolRunPostSync: state.pendingToolRunPostSync,
+    dispatch,
+    onToolRunPostSyncRequested,
+  });
 
   const runtimeRefs: ChatSessionSnapshotRuntimeRefs = {
     currentWorkspaceIdRef,
@@ -462,7 +295,6 @@ export function useChatSessionSnapshotSync(
   runStateRef.current = state.runState;
   messagesRef.current = messages;
   chatConfigRef.current = state.chatConfig;
-  pendingToolRunPostSyncRef.current = state.pendingToolRunPostSync;
 
   const debugLog = useCallback((event: string, details: ChatDebugDetails): void => {
     logChatControllerDebug(controllerId, event, details);
@@ -529,72 +361,6 @@ export function useChatSessionSnapshotSync(
     resumeAttemptCounterRef.current = nextAttemptId;
     return nextAttemptId;
   }, []);
-
-  const requestToolRunPostSyncIfNeeded = useCallback((): Promise<void> => {
-    if (indexedDbOpenRecoveryState.hasFailed() || pendingToolRunPostSyncRef.current === false) {
-      return Promise.resolve();
-    }
-
-    const activePostSyncRequest = activeToolRunPostSyncPromiseRef.current;
-    if (activePostSyncRequest !== null) {
-      return activePostSyncRequest;
-    }
-
-    // Web intentionally follows the same AI sync contract as iOS and Android:
-    // one explicit sync after a terminal tool-backed run, with no extra
-    // invalidation-driven chat refresh on top of it.
-    let postSyncRequestPromise: Promise<void> | null = null;
-    postSyncRequestPromise = (async (): Promise<void> => {
-      try {
-        indexedDbOpenRecoveryState.throwIfFailed();
-        await onToolRunPostSyncRequested();
-        indexedDbOpenRecoveryState.throwIfFailed();
-        pendingToolRunPostSyncRef.current = false;
-        dispatch({ type: "tool_run_post_sync_consumed" });
-      } finally {
-        if (activeToolRunPostSyncPromiseRef.current === postSyncRequestPromise) {
-          activeToolRunPostSyncPromiseRef.current = null;
-        }
-      }
-    })();
-
-    activeToolRunPostSyncPromiseRef.current = postSyncRequestPromise;
-    return postSyncRequestPromise;
-  }, [dispatch, indexedDbOpenRecoveryState, onToolRunPostSyncRequested]);
-
-  const triggerToolRunPostSyncIfNeeded = useCallback((): void => {
-    if (indexedDbOpenRecoveryState.hasFailed()) {
-      return;
-    }
-    void requestToolRunPostSyncIfNeeded().catch(() => undefined);
-  }, [indexedDbOpenRecoveryState, requestToolRunPostSyncIfNeeded]);
-
-  const markPendingToolRunPostSync = useCallback((): void => {
-    if (indexedDbOpenRecoveryState.hasFailed() || pendingToolRunPostSyncRef.current) {
-      return;
-    }
-
-    pendingToolRunPostSyncRef.current = true;
-    dispatch({ type: "tool_run_post_sync_marked" });
-  }, [dispatch, indexedDbOpenRecoveryState]);
-
-  const markRunHadToolCallsFromSnapshot = useCallback((
-    activeRun: ChatActiveRun | null,
-    nextMessages: ReadonlyArray<ChatSessionHistoryMessage>,
-    previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
-    currentTurnContent: ReadonlyArray<ContentPart> | null,
-  ): void => {
-    if (snapshotRunHasToolCalls(
-      activeRun,
-      nextMessages,
-      previousMessages,
-      currentTurnContent,
-    ) === false) {
-      return;
-    }
-
-    markPendingToolRunPostSync();
-  }, [markPendingToolRunPostSync]);
 
   const applyLiveEvent = useCallback((event: ChatLiveEvent): void => {
     if (indexedDbOpenRecoveryState.hasFailed()) {
@@ -917,15 +683,15 @@ export function useChatSessionSnapshotSync(
     invalidatePendingSnapshotRequests();
     abortPendingSnapshotRequests();
     clearAssistantMessageDoneTerminalReconcileTimer();
-    pendingToolRunPostSyncRef.current = false;
     visibilityResumePromiseRef.current = null;
     streamTransportRecoveryPromiseRef.current = null;
-    activeToolRunPostSyncPromiseRef.current = null;
+    resetToolRunPostSync();
   }, [
     abortPendingSnapshotRequests,
     clearAssistantMessageDoneTerminalReconcileTimer,
     indexedDbOpenRecoveryState.isFailed,
     invalidatePendingSnapshotRequests,
+    resetToolRunPostSync,
   ]);
 
   const loadAndApplySnapshot = useCallback(async (

--- a/apps/web/src/chat/sessionController/snapshotSync/useToolRunPostSync.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useToolRunPostSync.ts
@@ -1,0 +1,294 @@
+import { useCallback, useRef, type Dispatch } from "react";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
+import type { ChatActiveRun, ChatSessionHistoryMessage, ContentPart } from "../../../types";
+import { areContentPartsEqual, areMessagesEqual } from "../support/helpers";
+import type { ChatSessionControllerAction } from "../state/state";
+
+type UseToolRunPostSyncParams = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
+  pendingToolRunPostSync: boolean;
+  dispatch: Dispatch<ChatSessionControllerAction>;
+  onToolRunPostSyncRequested: () => Promise<void>;
+}>;
+
+export type ToolRunPostSync = Readonly<{
+  markPendingToolRunPostSync: () => void;
+  markRunHadToolCallsFromSnapshot: (
+    activeRun: ChatActiveRun | null,
+    messages: ReadonlyArray<ChatSessionHistoryMessage>,
+    previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
+    currentTurnContent: ReadonlyArray<ContentPart> | null,
+  ) => void;
+  resetToolRunPostSync: () => void;
+  triggerToolRunPostSyncIfNeeded: () => void;
+}>;
+
+/**
+ * Tool-call detection is only safe when it is scoped to the latest run.
+ * Inspect assistant messages after the latest user turn so older historical
+ * assistant tool calls do not leak into a newer run.
+ */
+function messageHasToolCalls(message: ChatSessionHistoryMessage): boolean {
+  return message.content.some((part) => part.type === "tool_call");
+}
+
+function latestRunHasToolCalls(messages: ReadonlyArray<ChatSessionHistoryMessage>): boolean {
+  let latestUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") {
+      latestUserIndex = index;
+      break;
+    }
+  }
+
+  for (let index = latestUserIndex + 1; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message?.role === "assistant" && messageHasToolCalls(message)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function trailingAssistantItemHasToolCalls(
+  messages: ReadonlyArray<ChatSessionHistoryMessage>,
+): boolean {
+  const latestMessage = messages[messages.length - 1];
+  if (latestMessage?.role !== "assistant") {
+    return false;
+  }
+
+  const trailingItemId = latestMessage.itemId;
+  if (trailingItemId === null) {
+    return false;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message === undefined) {
+      continue;
+    }
+
+    if (message.role === "user" || message.itemId !== trailingItemId) {
+      return false;
+    }
+
+    if (messageHasToolCalls(message)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function terminalRunHasToolCalls(messages: ReadonlyArray<ChatSessionHistoryMessage>): boolean {
+  const latestMessage = messages[messages.length - 1];
+
+  if (latestRunHasToolCalls(messages)) {
+    if (latestMessage?.role === "assistant" && messageHasToolCalls(latestMessage)) {
+      return true;
+    }
+  }
+
+  if (latestMessage?.role === "assistant" && latestMessage.itemId !== null) {
+    return trailingAssistantItemHasToolCalls(messages);
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message === undefined) {
+      continue;
+    }
+
+    if (message.role === "user") {
+      return false;
+    }
+
+    if (messageHasToolCalls(message)) {
+      return true;
+    }
+
+    if (message.isStopped) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function resolveAcceptedResponseMessageDelta(
+  messages: ReadonlyArray<ChatSessionHistoryMessage>,
+  previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
+): ReadonlyArray<ChatSessionHistoryMessage> | null {
+  if (previousMessages === null) {
+    return null;
+  }
+
+  if (messages.length <= previousMessages.length) {
+    return null;
+  }
+
+  const sharedHistory = messages.slice(0, previousMessages.length);
+  if (areMessagesEqual(sharedHistory, previousMessages) === false) {
+    return null;
+  }
+
+  return messages.slice(previousMessages.length);
+}
+
+function resolveMessagesAfterCurrentUser(
+  messages: ReadonlyArray<ChatSessionHistoryMessage>,
+  currentTurnContent: ReadonlyArray<ContentPart>,
+): ReadonlyArray<ChatSessionHistoryMessage> | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") {
+      continue;
+    }
+
+    if (areContentPartsEqual(message.content, currentTurnContent)) {
+      return messages.slice(index + 1);
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+function activeRunHasObservedToolCalls(
+  messages: ReadonlyArray<ChatSessionHistoryMessage>,
+  previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
+  currentTurnContent: ReadonlyArray<ContentPart> | null,
+): boolean {
+  const acceptedResponseDelta = resolveAcceptedResponseMessageDelta(messages, previousMessages);
+
+  if (currentTurnContent !== null) {
+    if (acceptedResponseDelta === null) {
+      return false;
+    }
+
+    const currentRunMessages = resolveMessagesAfterCurrentUser(
+      acceptedResponseDelta,
+      currentTurnContent,
+    );
+    if (currentRunMessages !== null) {
+      return latestRunHasToolCalls(currentRunMessages);
+    }
+
+    const acceptedResponseIncludesUserMessage = acceptedResponseDelta.some((message) => message.role === "user");
+    if (acceptedResponseIncludesUserMessage) {
+      return false;
+    }
+
+    return latestRunHasToolCalls(acceptedResponseDelta);
+  }
+
+  return latestRunHasToolCalls(messages);
+}
+
+function snapshotRunHasToolCalls(
+  activeRun: ChatActiveRun | null,
+  messages: ReadonlyArray<ChatSessionHistoryMessage>,
+  previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
+  currentTurnContent: ReadonlyArray<ContentPart> | null,
+): boolean {
+  return activeRun === null
+    ? terminalRunHasToolCalls(messages)
+    : activeRunHasObservedToolCalls(messages, previousMessages, currentTurnContent);
+}
+
+/** Owns the one-shot sync lifecycle for tool-backed chat runs. */
+export function useToolRunPostSync(
+  params: UseToolRunPostSyncParams,
+): ToolRunPostSync {
+  const {
+    indexedDbOpenRecoveryState,
+    pendingToolRunPostSync,
+    dispatch,
+    onToolRunPostSyncRequested,
+  } = params;
+  const pendingToolRunPostSyncRef = useRef<boolean>(pendingToolRunPostSync);
+  const activeToolRunPostSyncPromiseRef = useRef<Promise<void> | null>(null);
+
+  pendingToolRunPostSyncRef.current = pendingToolRunPostSync;
+
+  const requestToolRunPostSyncIfNeeded = useCallback((): Promise<void> => {
+    if (indexedDbOpenRecoveryState.hasFailed() || pendingToolRunPostSyncRef.current === false) {
+      return Promise.resolve();
+    }
+
+    const activePostSyncRequest = activeToolRunPostSyncPromiseRef.current;
+    if (activePostSyncRequest !== null) {
+      return activePostSyncRequest;
+    }
+
+    // Web intentionally follows the same AI sync contract as iOS and Android:
+    // one explicit sync after a terminal tool-backed run, with no extra
+    // invalidation-driven chat refresh on top of it.
+    let postSyncRequestPromise: Promise<void> | null = null;
+    postSyncRequestPromise = (async (): Promise<void> => {
+      try {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        await onToolRunPostSyncRequested();
+        indexedDbOpenRecoveryState.throwIfFailed();
+        pendingToolRunPostSyncRef.current = false;
+        dispatch({ type: "tool_run_post_sync_consumed" });
+      } finally {
+        if (activeToolRunPostSyncPromiseRef.current === postSyncRequestPromise) {
+          activeToolRunPostSyncPromiseRef.current = null;
+        }
+      }
+    })();
+
+    activeToolRunPostSyncPromiseRef.current = postSyncRequestPromise;
+    return postSyncRequestPromise;
+  }, [dispatch, indexedDbOpenRecoveryState, onToolRunPostSyncRequested]);
+
+  const triggerToolRunPostSyncIfNeeded = useCallback((): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+    void requestToolRunPostSyncIfNeeded().catch(() => undefined);
+  }, [indexedDbOpenRecoveryState, requestToolRunPostSyncIfNeeded]);
+
+  const markPendingToolRunPostSync = useCallback((): void => {
+    if (indexedDbOpenRecoveryState.hasFailed() || pendingToolRunPostSyncRef.current) {
+      return;
+    }
+
+    pendingToolRunPostSyncRef.current = true;
+    dispatch({ type: "tool_run_post_sync_marked" });
+  }, [dispatch, indexedDbOpenRecoveryState]);
+
+  const markRunHadToolCallsFromSnapshot = useCallback((
+    activeRun: ChatActiveRun | null,
+    messages: ReadonlyArray<ChatSessionHistoryMessage>,
+    previousMessages: ReadonlyArray<ChatSessionHistoryMessage> | null,
+    currentTurnContent: ReadonlyArray<ContentPart> | null,
+  ): void => {
+    if (snapshotRunHasToolCalls(
+      activeRun,
+      messages,
+      previousMessages,
+      currentTurnContent,
+    ) === false) {
+      return;
+    }
+
+    markPendingToolRunPostSync();
+  }, [markPendingToolRunPostSync]);
+
+  const resetToolRunPostSync = useCallback((): void => {
+    pendingToolRunPostSyncRef.current = false;
+    activeToolRunPostSyncPromiseRef.current = null;
+  }, []);
+
+  return {
+    markPendingToolRunPostSync,
+    markRunHadToolCallsFromSnapshot,
+    resetToolRunPostSync,
+    triggerToolRunPostSyncIfNeeded,
+  };
+}


### PR DESCRIPTION
## Summary

- move account-deletion lifecycle ownership outside AppShell
- centralize remote chat-session provisioning and current-or-new resolution outside useActions
- centralize one-shot tool-backed post-run synchronization outside useSnapshotSync
- preserve behavior and existing persisted-state, reducer, API, protocol, localization, ordering, and public-facade contracts

## Review

- all three item patches passed independent review and applicable cloud CI
- cumulative promotion review found no P0-P4 issues and no additional reviewer notes

## Validation

- no project checks run locally; cloud PR checks own executable validation