### PR TITLE
Extract card managed-media owner

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -101,7 +101,7 @@ export const boundaryDefinitions = Object.freeze([
     migrationFileName: "0107_catalog_test_collection.sql",
     expectedMigrationCount: 109,
     testFiles: Object.freeze([
-      "src/cards/generatedImageAppend.postgres.integration.ts",
+      "src/cards/managedMedia/generatedImageAppend.postgres.integration.ts",
       "src/chat/cardImages/operation.postgres.integration.ts",
       "src/chat/cardImages/promotion/jobsLeasing.postgres.integration.ts",
       "src/chat/cardImages/promotion/jobsSettlement.postgres.integration.ts",

--- a/apps/backend/src/cards/index.ts
+++ b/apps/backend/src/cards/index.ts
@@ -60,11 +60,11 @@ export {
   markPendingManagedImageFailedOnCardSideInExecutor,
   markPendingManagedImageReadyOnCardSideInExecutor,
   PendingManagedImageSettlementConflictError,
-} from "./managedImageSettlement";
+} from "./managedMedia";
 
 export type {
   ManagedImageSettlementConflictError,
-} from "./managedImageSettlement";
+} from "./managedMedia";
 
 export {
   createCard,

--- a/apps/backend/src/cards/managedMedia/generatedImageAppend.postgres.integration.ts
+++ b/apps/backend/src/cards/managedMedia/generatedImageAppend.postgres.integration.ts
@@ -2,16 +2,16 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import test from "node:test";
 import pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../database";
-import { HttpError } from "../shared/errors";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { HttpError } from "../../shared/errors";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import {
   appendManagedImageToCardSideInExecutor,
   appendPendingManagedImageToCardSideInExecutor,
   markPendingManagedImageFailedOnCardSideInExecutor,
   markPendingManagedImageReadyOnCardSideInExecutor,
 } from "./managedImageSettlement";
-import type { AppendManagedImageToCardSideInput, AppendManagedImageToCardSideResult } from "./types";
+import type { AppendManagedImageToCardSideInput, AppendManagedImageToCardSideResult } from "../types";
 
 const futureClientUpdatedAt = "2099-01-01T00:00:00.000Z";
 const expectedGeneratedClientUpdatedAt = "2099-01-01T00:00:00.001Z";

--- a/apps/backend/src/cards/managedMedia/generatedImageAppend.test.ts
+++ b/apps/backend/src/cards/managedMedia/generatedImageAppend.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../database";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   appendManagedImageToCardSideInExecutor,
   appendManagedImageToCardText,
   buildManagedImageMarkdownReference,
 } from "./managedImageSettlement";
-import type { AppendManagedImageToCardSideInput, CardMutationMetadata, CardRow, CardTextSide } from "./types";
+import type { AppendManagedImageToCardSideInput, CardMutationMetadata, CardRow, CardTextSide } from "../types";
 
 const testWorkspaceId = "22222222-2222-4222-8222-222222222222";
 const testCardId = "33333333-3333-4333-8333-333333333333";

--- a/apps/backend/src/cards/managedMedia/index.ts
+++ b/apps/backend/src/cards/managedMedia/index.ts
@@ -1,0 +1,17 @@
+export {
+  appendManagedImageToCardSideInExecutor,
+  appendManagedImageToCardText,
+  appendPendingManagedImageToCardSideInExecutor,
+  buildManagedImageMarkdownReference,
+  hasPendingManagedImageOnCardSideInExecutor,
+  isManagedImageSettlementConflictError,
+  managedImageMarkdownComplexitySettlementConflictCode,
+  ManagedImageMarkdownComplexitySettlementConflictError,
+  markPendingManagedImageFailedOnCardSideInExecutor,
+  markPendingManagedImageReadyOnCardSideInExecutor,
+  PendingManagedImageSettlementConflictError,
+} from "./managedImageSettlement";
+
+export type {
+  ManagedImageSettlementConflictError,
+} from "./managedImageSettlement";

--- a/apps/backend/src/cards/managedMedia/managedImageSettlement.ts
+++ b/apps/backend/src/cards/managedMedia/managedImageSettlement.ts
@@ -1,15 +1,15 @@
-import type { DatabaseExecutor } from "../database";
-import { expectUuidString } from "../server/requestParsing";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor } from "../../database";
+import { expectUuidString } from "../../server/requestParsing";
+import { HttpError } from "../../shared/errors";
 import {
   lockWorkspaceSyncMetadataForHotChangesInExecutor,
   type HotChangeWriteLock,
-} from "../sync/replication/changes";
+} from "../../sync/replication/changes";
 import {
   extractMarkdownImageDestinationUrls,
   isMarkdownComplexityLimitError,
   rewriteMarkdownImageDestinationUrl,
-} from "../workspacePackages/markdownMedia";
+} from "../../workspacePackages/markdownMedia";
 import {
   CARD_COLUMNS,
   CARD_SELECT,
@@ -17,7 +17,7 @@ import {
   mapCard,
   normalizeCardMutationMetadata,
   recordCardSyncChange,
-} from "./shared";
+} from "../shared";
 import type {
   AppendManagedImageToCardSideInput,
   AppendManagedImageToCardSideResult,
@@ -25,7 +25,7 @@ import type {
   CardMutationMetadata,
   CardRow,
   CardTextSide,
-} from "./types";
+} from "../types";
 
 type AppendedManagedImageCardText = Readonly<{ text: string; applied: boolean }>;
 


### PR DESCRIPTION
## Summary

- move card managed-image append and settlement into the managedMedia owner
- preserve the root cards facade through the new internal barrel
- relocate existing module-boundary and PostgreSQL integration coverage

## Validation

Cloud CI owns executable validation; no project checks were run locally.