### PR TITLE
Extract card review owner

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/CardSchedulingSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/CardSchedulingSupport.kt
@@ -15,7 +15,7 @@ fun isReviewedCard(card: CardSummary): Boolean {
     return card.reps > 0 || card.lapses > 0
 }
 
-// Keep in sync with apps/backend/src/cards/reviews.ts::toReviewableCardScheduleState and apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::makeReviewableCardScheduleState(card:).
+// Keep in sync with apps/backend/src/cards/review/reviews.ts::toReviewableCardScheduleState and apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::makeReviewableCardScheduleState(card:).
 fun toReviewableCardScheduleState(card: CardSummary): ReviewableCardScheduleState {
     return ReviewableCardScheduleState(
         cardId = card.cardId,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/scheduling/FsrsScheduler.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/scheduling/FsrsScheduler.kt
@@ -888,7 +888,7 @@ fun createEmptyReviewableCardScheduleState(cardId: String): ReviewableCardSchedu
     )
 }
 
-    // Keep in sync with apps/backend/src/cards/reviews.ts::submitReview, apps/backend/src/scheduling/index.ts::computeReviewSchedule, and apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::computeReviewSchedule(card:settings:rating:now:).
+    // Keep in sync with apps/backend/src/cards/review/reviews.ts::submitReview, apps/backend/src/scheduling/index.ts::computeReviewSchedule, and apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::computeReviewSchedule(card:settings:rating:now:).
 fun computeReviewSchedule(
     card: CardSummary,
     settings: WorkspaceSchedulerSettings,

--- a/apps/backend/src/cards/index.ts
+++ b/apps/backend/src/cards/index.ts
@@ -1,6 +1,6 @@
 /**
- * Card domain barrel. Review persistence lives in ./reviews, and persisted
- * FSRS state validation lives in ./fsrs. Those modules enforce the invariants
+ * Card domain barrel. Review persistence and persisted FSRS state validation
+ * live in ./review. Those modules enforce the invariants
  * described in docs/fsrs-scheduling-logic.md.
  */
 export type {
@@ -44,11 +44,6 @@ export {
 } from "./filters";
 
 export {
-  assertConsistentFsrsState,
-  getInvalidFsrsStateReason,
-} from "./fsrs";
-
-export {
   appendManagedImageToCardSideInExecutor,
   appendManagedImageToCardText,
   appendPendingManagedImageToCardSideInExecutor,
@@ -85,16 +80,18 @@ export {
   getCards,
   listCards,
   listCardsInExecutor,
-  listReviewHistoryPage,
-  listReviewQueuePage,
   listWorkspaceTagsSummary,
   queryCardsPage,
-  listReviewQueue,
   searchCards,
   summarizeDeckState,
 } from "./queries";
 
 export {
+  assertConsistentFsrsState,
   appendReviewEventSnapshotInExecutor,
+  getInvalidFsrsStateReason,
+  listReviewHistoryPage,
+  listReviewQueue,
+  listReviewQueuePage,
   submitReview,
-} from "./reviews";
+} from "./review";

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -16,7 +16,7 @@ import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
 } from "../sync/conflicts/fork";
-import { assertConsistentFsrsState } from "./fsrs";
+import { assertConsistentFsrsState } from "./review/fsrs";
 import {
   CARD_COLUMNS,
   createDefaultCardMetadata,

--- a/apps/backend/src/cards/queries.ts
+++ b/apps/backend/src/cards/queries.ts
@@ -6,11 +6,6 @@ import {
 } from "../database";
 import { HttpError } from "../shared/errors";
 import {
-  decodeOpaqueCursor,
-  encodeOpaqueCursor,
-  type CursorPageInput,
-} from "../shared/pagination";
-import {
   buildTokenizedAndLikeClause,
   MAX_SEARCH_TOKEN_COUNT,
   tokenizeSearchText,
@@ -18,19 +13,20 @@ import {
 import type { SearchTokenClauseFactory } from "../search/tokens";
 import { normalizeCardFilter } from "./filters";
 import {
+  createCardQueryError,
+  normalizeCardsQueryLimit,
+} from "./querySupport";
+import {
   CARD_COLUMNS,
   CARD_SELECT,
   mapCard,
   mapDeckSummary,
-  mapReviewHistoryItem,
-  toDate,
   toIsoString,
   toNumber,
 } from "./shared";
 import type {
   Card,
   CardFilter,
-  CardListPage,
   CardQuerySort,
   CardQuerySortDirection,
   CardQuerySortKey,
@@ -39,17 +35,12 @@ import type {
   DeckSummaryRow,
   QueryCardsInput,
   QueryCardsPage,
-  ReviewHistoryItem,
-  ReviewHistoryPage,
-  ReviewHistoryRow,
   WorkspaceTagSummary,
   WorkspaceTagsSummary,
 } from "./types";
 
 const defaultCardsQueryPageSize = 50;
-const maximumCardsQueryPageSize = 100;
 const maximumCardsQuerySortCount = 3;
-const recentDuePriorityWindowMillis = 60 * 60 * 1000;
 const cardSearchExpressionFactories: ReadonlyArray<SearchTokenClauseFactory> = [
   (paramIndex) => `lower(front_text || ' ' || back_text) LIKE $${paramIndex}`,
   (paramIndex) => `EXISTS (SELECT 1 FROM unnest(tags) AS tag WHERE lower(tag) LIKE $${paramIndex})`,
@@ -132,70 +123,6 @@ const sortFieldByKey: Readonly<Record<CardQuerySortKey | "cardId", InternalSortF
   },
 };
 
-function getReviewQueueRank(card: CardRow, nowTimestamp: number): number {
-  if (card.due_at === null) {
-    return 2;
-  }
-
-  const dueAtTimestamp = toDate(card.due_at).getTime();
-  if (dueAtTimestamp > nowTimestamp) {
-    return 3;
-  }
-
-  if (card.fsrs_last_reviewed_at !== null) {
-    const fsrsLastReviewedAtTimestamp = toDate(card.fsrs_last_reviewed_at).getTime();
-    if (
-      fsrsLastReviewedAtTimestamp >= nowTimestamp - recentDuePriorityWindowMillis
-      && fsrsLastReviewedAtTimestamp <= nowTimestamp
-    ) {
-      return 0;
-    }
-  }
-
-  return 1;
-}
-
-function getReviewQueueDueTimestamp(card: CardRow): number {
-  if (card.due_at === null) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  return toDate(card.due_at).getTime();
-}
-
-function compareCardsForReviewQueue(leftCard: CardRow, rightCard: CardRow, nowTimestamp: number): number {
-  const rankDifference = getReviewQueueRank(leftCard, nowTimestamp) - getReviewQueueRank(rightCard, nowTimestamp);
-  if (rankDifference !== 0) {
-    return rankDifference;
-  }
-
-  const leftDueTimestamp = getReviewQueueDueTimestamp(leftCard);
-  const rightDueTimestamp = getReviewQueueDueTimestamp(rightCard);
-  if (leftDueTimestamp !== rightDueTimestamp) {
-    return leftDueTimestamp - rightDueTimestamp;
-  }
-
-  if (leftCard.due_at === null && rightCard.due_at === null) {
-    const createdAtDifference = toDate(rightCard.created_at).getTime() - toDate(leftCard.created_at).getTime();
-    if (createdAtDifference !== 0) {
-      return createdAtDifference;
-    }
-
-    return leftCard.card_id.localeCompare(rightCard.card_id);
-  }
-
-  const createdAtDifference = toDate(rightCard.created_at).getTime() - toDate(leftCard.created_at).getTime();
-  if (createdAtDifference !== 0) {
-    return createdAtDifference;
-  }
-
-  return leftCard.card_id.localeCompare(rightCard.card_id);
-}
-
-function createCardQueryError(message: string): HttpError {
-  return new HttpError(400, message);
-}
-
 function encodeCardsQueryCursor(values: ReadonlyArray<CursorValue>): string {
   return Buffer.from(JSON.stringify({ values }), "utf8").toString("base64url");
 }
@@ -225,69 +152,6 @@ function decodeCardsQueryCursor(cursor: string): DecodedCursor {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw createCardQueryError(`cursor is invalid: ${errorMessage}`);
   }
-}
-
-type DueCardsPageCursor = Readonly<{
-  dueAt: string | null;
-  createdAt: string;
-  cardId: string;
-}>;
-
-type ReviewHistoryPageCursor = Readonly<{
-  reviewedAtServer: string;
-  reviewEventId: string;
-}>;
-
-type ReviewHistoryPageRow = ReviewHistoryRow & Readonly<{
-  reviewed_at_server: Date | string;
-}>;
-
-function decodeDueCardsPageCursor(cursor: string): DueCardsPageCursor {
-  const decodedCursor = decodeOpaqueCursor(cursor, "cursor");
-  if (decodedCursor.values.length !== 3) {
-    throw createCardQueryError("cursor does not match the requested due-cards order");
-  }
-
-  const dueAt = decodedCursor.values[0];
-  const createdAt = decodedCursor.values[1];
-  const cardId = decodedCursor.values[2];
-  if ((typeof dueAt !== "string" && dueAt !== null) || typeof createdAt !== "string" || typeof cardId !== "string") {
-    throw createCardQueryError("cursor does not match the requested due-cards order");
-  }
-
-  return {
-    dueAt,
-    createdAt,
-    cardId,
-  };
-}
-
-function decodeReviewHistoryPageCursor(cursor: string): ReviewHistoryPageCursor {
-  const decodedCursor = decodeOpaqueCursor(cursor, "cursor");
-  if (decodedCursor.values.length !== 2) {
-    throw createCardQueryError("cursor does not match the requested review-history order");
-  }
-
-  const reviewedAtServer = decodedCursor.values[0];
-  const reviewEventId = decodedCursor.values[1];
-  if (typeof reviewedAtServer !== "string" || typeof reviewEventId !== "string") {
-    throw createCardQueryError("cursor does not match the requested review-history order");
-  }
-
-  return {
-    reviewedAtServer,
-    reviewEventId,
-  };
-}
-
-function normalizeCardsQueryLimit(limit: number): number {
-  if (!Number.isInteger(limit) || limit < 1 || limit > maximumCardsQueryPageSize) {
-    throw createCardQueryError(
-      `limit must be an integer between 1 and ${maximumCardsQueryPageSize}`,
-    );
-  }
-
-  return limit;
 }
 
 function normalizeCardsQuerySearchTokens(searchText: string | null): ReadonlyArray<string> | null {
@@ -665,77 +529,6 @@ export async function getCards(
   });
 }
 
-/**
- * Materializes the full due-card order for internal callers that must reason
- * about the exact queue as one collection.
- *
- * Keep this helper because `listReviewQueuePage()` currently derives stable
- * cursor pagination from the in-memory due order, which depends on null due
- * dates and `compareCardsForReviewQueue`. API-facing reads should call
- * `listReviewQueuePage()` instead.
- */
-export async function listReviewQueue(
-  userId: string,
-  workspaceId: string,
-  limit: number,
-): Promise<ReadonlyArray<Card>> {
-  return transactionWithWorkspaceScopeReadOnly({ userId, workspaceId }, async (executor) => {
-    const now = new Date();
-    const nowTimestamp = now.getTime();
-    const result = await executor.query<CardRow>(
-      [
-        CARD_SELECT,
-        "WHERE workspace_id = $1",
-        "AND deleted_at IS NULL",
-        "AND (due_at IS NULL OR due_at <= $2 OR fsrs_card_state = 'new')",
-        "ORDER BY created_at DESC, card_id ASC",
-      ].join(" "),
-      [workspaceId, now],
-    );
-
-    return result.rows
-      .filter((row) => row.due_at === null || toDate(row.due_at).getTime() <= nowTimestamp)
-      .sort((leftRow, rightRow) => compareCardsForReviewQueue(leftRow, rightRow, nowTimestamp))
-      .slice(0, limit)
-      .map(mapCard);
-  });
-}
-
-export async function listReviewQueuePage(
-  userId: string,
-  workspaceId: string,
-  input: CursorPageInput,
-): Promise<CardListPage> {
-  const normalizedLimit = normalizeCardsQueryLimit(input.limit);
-  const decodedCursor = input.cursor === null ? null : decodeDueCardsPageCursor(input.cursor);
-  const dueCards = await listReviewQueue(userId, workspaceId, Number.MAX_SAFE_INTEGER);
-  const startIndex = decodedCursor === null
-    ? 0
-    : dueCards.findIndex((card) => (
-      card.dueAt === decodedCursor.dueAt
-      && card.createdAt === decodedCursor.createdAt
-      && card.cardId === decodedCursor.cardId
-    )) + 1;
-  if (decodedCursor !== null && startIndex === 0) {
-    throw createCardQueryError("cursor does not match the requested due-cards order");
-  }
-
-  const visibleCards = dueCards.slice(startIndex, startIndex + normalizedLimit);
-  const nextCard = dueCards[startIndex + normalizedLimit];
-  const nextCursor = nextCard === undefined
-    ? null
-    : encodeOpaqueCursor([
-      visibleCards[visibleCards.length - 1]?.dueAt ?? null,
-      visibleCards[visibleCards.length - 1]?.createdAt ?? "",
-      visibleCards[visibleCards.length - 1]?.cardId ?? "",
-    ]);
-
-  return {
-    cards: visibleCards,
-    nextCursor,
-  };
-}
-
 export async function searchCards(
   userId: string,
   workspaceId: string,
@@ -765,55 +558,6 @@ export async function searchCards(
 
     return result.rows.map(mapCard);
   });
-}
-
-export async function listReviewHistoryPage(
-  userId: string,
-  workspaceId: string,
-  input: CursorPageInput & Readonly<{ cardId: string | null }>,
-): Promise<ReviewHistoryPage> {
-  const normalizedLimit = normalizeCardsQueryLimit(input.limit);
-  const decodedCursor = input.cursor === null ? null : decodeReviewHistoryPageCursor(input.cursor);
-  const cursorClause = decodedCursor === null
-    ? ""
-    : "AND (reviewed_at_server < $2 OR (reviewed_at_server = $2 AND review_event_id < $3))";
-  const cardIdClause = input.cardId === null ? "" : decodedCursor === null ? "AND card_id = $2" : "AND card_id = $4";
-  const params = input.cardId === null
-    ? decodedCursor === null
-      ? [workspaceId, normalizedLimit + 1]
-      : [workspaceId, new Date(decodedCursor.reviewedAtServer), decodedCursor.reviewEventId, normalizedLimit + 1]
-    : decodedCursor === null
-      ? [workspaceId, input.cardId, normalizedLimit + 1]
-      : [workspaceId, new Date(decodedCursor.reviewedAtServer), decodedCursor.reviewEventId, input.cardId, normalizedLimit + 1];
-  const limitParamIndex = input.cardId === null
-    ? decodedCursor === null ? 2 : 4
-    : decodedCursor === null ? 3 : 5;
-
-  const result = await queryWithWorkspaceScopeReadOnly<ReviewHistoryPageRow>(
-    { userId, workspaceId },
-    [
-      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone",
-      "FROM content.review_events",
-      "WHERE workspace_id = $1",
-      cursorClause,
-      cardIdClause,
-      "ORDER BY reviewed_at_server DESC, review_event_id DESC",
-      `LIMIT $${limitParamIndex}`,
-    ].join(" "),
-    params,
-  );
-
-  const hasNextPage = result.rows.length > normalizedLimit;
-  const visibleRows = hasNextPage ? result.rows.slice(0, normalizedLimit) : result.rows;
-  const nextRow = hasNextPage ? visibleRows[visibleRows.length - 1] : undefined;
-
-  return {
-    history: visibleRows.map(mapReviewHistoryItem),
-    nextCursor: nextRow === undefined ? null : encodeOpaqueCursor([
-      toIsoString(nextRow.reviewed_at_server),
-      nextRow.review_event_id,
-    ]),
-  };
 }
 
 export async function summarizeDeckState(userId: string, workspaceId: string): Promise<DeckSummary> {

--- a/apps/backend/src/cards/querySupport.ts
+++ b/apps/backend/src/cards/querySupport.ts
@@ -1,0 +1,17 @@
+import { HttpError } from "../shared/errors";
+
+const maximumCardsQueryPageSize = 100;
+
+export function createCardQueryError(message: string): HttpError {
+  return new HttpError(400, message);
+}
+
+export function normalizeCardsQueryLimit(limit: number): number {
+  if (!Number.isInteger(limit) || limit < 1 || limit > maximumCardsQueryPageSize) {
+    throw createCardQueryError(
+      `limit must be an integer between 1 and ${maximumCardsQueryPageSize}`,
+    );
+  }
+
+  return limit;
+}

--- a/apps/backend/src/cards/review/fsrs.ts
+++ b/apps/backend/src/cards/review/fsrs.ts
@@ -1,4 +1,4 @@
-import type { FsrsStateSnapshot } from "./types";
+import type { FsrsStateSnapshot } from "../types";
 
 function hasNewCardFsrsValues(card: FsrsStateSnapshot): boolean {
   return (

--- a/apps/backend/src/cards/review/index.ts
+++ b/apps/backend/src/cards/review/index.ts
@@ -1,0 +1,15 @@
+export {
+  assertConsistentFsrsState,
+  getInvalidFsrsStateReason,
+} from "./fsrs";
+
+export {
+  listReviewHistoryPage,
+  listReviewQueue,
+  listReviewQueuePage,
+} from "./queries";
+
+export {
+  appendReviewEventSnapshotInExecutor,
+  submitReview,
+} from "./reviews";

--- a/apps/backend/src/cards/review/persistedFsrs.test.ts
+++ b/apps/backend/src/cards/review/persistedFsrs.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
-import type { DatabaseExecutor } from "../database";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor } from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   getInvalidFsrsStateReason,
   listCardsInExecutor,
   submitReview,
-} from "./index";
-import type { CardMetadata, CardRow, ReviewableCardRow } from "./types";
+} from "../index";
+import type { CardMetadata, CardRow, ReviewableCardRow } from "../types";
 
 type QueryRecord = Readonly<{
   text: string;

--- a/apps/backend/src/cards/review/queries.ts
+++ b/apps/backend/src/cards/review/queries.ts
@@ -1,0 +1,262 @@
+import {
+  queryWithWorkspaceScopeReadOnly,
+  transactionWithWorkspaceScopeReadOnly,
+} from "../../database";
+import {
+  decodeOpaqueCursor,
+  encodeOpaqueCursor,
+  type CursorPageInput,
+} from "../../shared/pagination";
+import {
+  createCardQueryError,
+  normalizeCardsQueryLimit,
+} from "../querySupport";
+import {
+  CARD_SELECT,
+  mapCard,
+  mapReviewHistoryItem,
+  toDate,
+  toIsoString,
+} from "../shared";
+import type {
+  Card,
+  CardListPage,
+  CardRow,
+  ReviewHistoryPage,
+  ReviewHistoryRow,
+} from "../types";
+
+const recentDuePriorityWindowMillis = 60 * 60 * 1000;
+
+type DueCardsPageCursor = Readonly<{
+  dueAt: string | null;
+  createdAt: string;
+  cardId: string;
+}>;
+
+type ReviewHistoryPageCursor = Readonly<{
+  reviewedAtServer: string;
+  reviewEventId: string;
+}>;
+
+type ReviewHistoryPageRow = ReviewHistoryRow & Readonly<{
+  reviewed_at_server: Date | string;
+}>;
+
+function getReviewQueueRank(card: CardRow, nowTimestamp: number): number {
+  if (card.due_at === null) {
+    return 2;
+  }
+
+  const dueAtTimestamp = toDate(card.due_at).getTime();
+  if (dueAtTimestamp > nowTimestamp) {
+    return 3;
+  }
+
+  if (card.fsrs_last_reviewed_at !== null) {
+    const fsrsLastReviewedAtTimestamp = toDate(card.fsrs_last_reviewed_at).getTime();
+    if (
+      fsrsLastReviewedAtTimestamp >= nowTimestamp - recentDuePriorityWindowMillis
+      && fsrsLastReviewedAtTimestamp <= nowTimestamp
+    ) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+function getReviewQueueDueTimestamp(card: CardRow): number {
+  if (card.due_at === null) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return toDate(card.due_at).getTime();
+}
+
+function compareCardsForReviewQueue(leftCard: CardRow, rightCard: CardRow, nowTimestamp: number): number {
+  const rankDifference = getReviewQueueRank(leftCard, nowTimestamp) - getReviewQueueRank(rightCard, nowTimestamp);
+  if (rankDifference !== 0) {
+    return rankDifference;
+  }
+
+  const leftDueTimestamp = getReviewQueueDueTimestamp(leftCard);
+  const rightDueTimestamp = getReviewQueueDueTimestamp(rightCard);
+  if (leftDueTimestamp !== rightDueTimestamp) {
+    return leftDueTimestamp - rightDueTimestamp;
+  }
+
+  if (leftCard.due_at === null && rightCard.due_at === null) {
+    const createdAtDifference = toDate(rightCard.created_at).getTime() - toDate(leftCard.created_at).getTime();
+    if (createdAtDifference !== 0) {
+      return createdAtDifference;
+    }
+
+    return leftCard.card_id.localeCompare(rightCard.card_id);
+  }
+
+  const createdAtDifference = toDate(rightCard.created_at).getTime() - toDate(leftCard.created_at).getTime();
+  if (createdAtDifference !== 0) {
+    return createdAtDifference;
+  }
+
+  return leftCard.card_id.localeCompare(rightCard.card_id);
+}
+
+function decodeDueCardsPageCursor(cursor: string): DueCardsPageCursor {
+  const decodedCursor = decodeOpaqueCursor(cursor, "cursor");
+  if (decodedCursor.values.length !== 3) {
+    throw createCardQueryError("cursor does not match the requested due-cards order");
+  }
+
+  const dueAt = decodedCursor.values[0];
+  const createdAt = decodedCursor.values[1];
+  const cardId = decodedCursor.values[2];
+  if ((typeof dueAt !== "string" && dueAt !== null) || typeof createdAt !== "string" || typeof cardId !== "string") {
+    throw createCardQueryError("cursor does not match the requested due-cards order");
+  }
+
+  return {
+    dueAt,
+    createdAt,
+    cardId,
+  };
+}
+
+function decodeReviewHistoryPageCursor(cursor: string): ReviewHistoryPageCursor {
+  const decodedCursor = decodeOpaqueCursor(cursor, "cursor");
+  if (decodedCursor.values.length !== 2) {
+    throw createCardQueryError("cursor does not match the requested review-history order");
+  }
+
+  const reviewedAtServer = decodedCursor.values[0];
+  const reviewEventId = decodedCursor.values[1];
+  if (typeof reviewedAtServer !== "string" || typeof reviewEventId !== "string") {
+    throw createCardQueryError("cursor does not match the requested review-history order");
+  }
+
+  return {
+    reviewedAtServer,
+    reviewEventId,
+  };
+}
+
+/**
+ * Materializes the full due-card order for internal callers that must reason
+ * about the exact queue as one collection.
+ *
+ * Keep this helper because `listReviewQueuePage()` currently derives stable
+ * cursor pagination from the in-memory due order, which depends on null due
+ * dates and `compareCardsForReviewQueue`. API-facing reads should call
+ * `listReviewQueuePage()` instead.
+ */
+export async function listReviewQueue(
+  userId: string,
+  workspaceId: string,
+  limit: number,
+): Promise<ReadonlyArray<Card>> {
+  return transactionWithWorkspaceScopeReadOnly({ userId, workspaceId }, async (executor) => {
+    const now = new Date();
+    const nowTimestamp = now.getTime();
+    const result = await executor.query<CardRow>(
+      [
+        CARD_SELECT,
+        "WHERE workspace_id = $1",
+        "AND deleted_at IS NULL",
+        "AND (due_at IS NULL OR due_at <= $2 OR fsrs_card_state = 'new')",
+        "ORDER BY created_at DESC, card_id ASC",
+      ].join(" "),
+      [workspaceId, now],
+    );
+
+    return result.rows
+      .filter((row) => row.due_at === null || toDate(row.due_at).getTime() <= nowTimestamp)
+      .sort((leftRow, rightRow) => compareCardsForReviewQueue(leftRow, rightRow, nowTimestamp))
+      .slice(0, limit)
+      .map(mapCard);
+  });
+}
+
+export async function listReviewQueuePage(
+  userId: string,
+  workspaceId: string,
+  input: CursorPageInput,
+): Promise<CardListPage> {
+  const normalizedLimit = normalizeCardsQueryLimit(input.limit);
+  const decodedCursor = input.cursor === null ? null : decodeDueCardsPageCursor(input.cursor);
+  const dueCards = await listReviewQueue(userId, workspaceId, Number.MAX_SAFE_INTEGER);
+  const startIndex = decodedCursor === null
+    ? 0
+    : dueCards.findIndex((card) => (
+      card.dueAt === decodedCursor.dueAt
+      && card.createdAt === decodedCursor.createdAt
+      && card.cardId === decodedCursor.cardId
+    )) + 1;
+  if (decodedCursor !== null && startIndex === 0) {
+    throw createCardQueryError("cursor does not match the requested due-cards order");
+  }
+
+  const visibleCards = dueCards.slice(startIndex, startIndex + normalizedLimit);
+  const nextCard = dueCards[startIndex + normalizedLimit];
+  const nextCursor = nextCard === undefined
+    ? null
+    : encodeOpaqueCursor([
+      visibleCards[visibleCards.length - 1]?.dueAt ?? null,
+      visibleCards[visibleCards.length - 1]?.createdAt ?? "",
+      visibleCards[visibleCards.length - 1]?.cardId ?? "",
+    ]);
+
+  return {
+    cards: visibleCards,
+    nextCursor,
+  };
+}
+
+export async function listReviewHistoryPage(
+  userId: string,
+  workspaceId: string,
+  input: CursorPageInput & Readonly<{ cardId: string | null }>,
+): Promise<ReviewHistoryPage> {
+  const normalizedLimit = normalizeCardsQueryLimit(input.limit);
+  const decodedCursor = input.cursor === null ? null : decodeReviewHistoryPageCursor(input.cursor);
+  const cursorClause = decodedCursor === null
+    ? ""
+    : "AND (reviewed_at_server < $2 OR (reviewed_at_server = $2 AND review_event_id < $3))";
+  const cardIdClause = input.cardId === null ? "" : decodedCursor === null ? "AND card_id = $2" : "AND card_id = $4";
+  const params = input.cardId === null
+    ? decodedCursor === null
+      ? [workspaceId, normalizedLimit + 1]
+      : [workspaceId, new Date(decodedCursor.reviewedAtServer), decodedCursor.reviewEventId, normalizedLimit + 1]
+    : decodedCursor === null
+      ? [workspaceId, input.cardId, normalizedLimit + 1]
+      : [workspaceId, new Date(decodedCursor.reviewedAtServer), decodedCursor.reviewEventId, input.cardId, normalizedLimit + 1];
+  const limitParamIndex = input.cardId === null
+    ? decodedCursor === null ? 2 : 4
+    : decodedCursor === null ? 3 : 5;
+
+  const result = await queryWithWorkspaceScopeReadOnly<ReviewHistoryPageRow>(
+    { userId, workspaceId },
+    [
+      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone",
+      "FROM content.review_events",
+      "WHERE workspace_id = $1",
+      cursorClause,
+      cardIdClause,
+      "ORDER BY reviewed_at_server DESC, review_event_id DESC",
+      `LIMIT $${limitParamIndex}`,
+    ].join(" "),
+    params,
+  );
+
+  const hasNextPage = result.rows.length > normalizedLimit;
+  const visibleRows = hasNextPage ? result.rows.slice(0, normalizedLimit) : result.rows;
+  const nextRow = hasNextPage ? visibleRows[visibleRows.length - 1] : undefined;
+
+  return {
+    history: visibleRows.map(mapReviewHistoryItem),
+    nextCursor: nextRow === undefined ? null : encodeOpaqueCursor([
+      toIsoString(nextRow.reviewed_at_server),
+      nextRow.review_event_id,
+    ]),
+  };
+}

--- a/apps/backend/src/cards/review/reviews.ts
+++ b/apps/backend/src/cards/review/reviews.ts
@@ -1,22 +1,22 @@
 import { randomUUID } from "node:crypto";
-import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
+import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
 import {
   createCurrentUserPublicProfileResolver,
   recordQualifiedReviewActivityFactInExecutor,
   type CurrentUserPublicProfileResolver,
-} from "../community/reviewActivityFacts";
-import { HttpError } from "../shared/errors";
-import { storeActiveReviewDayForReviewEventInExecutor } from "../progress/activeReviewDays/activeReviewDays";
+} from "../../community/reviewActivityFacts";
+import { HttpError } from "../../shared/errors";
+import { storeActiveReviewDayForReviewEventInExecutor } from "../../progress/activeReviewDays/activeReviewDays";
 import {
   computeReviewSchedule,
   type ReviewableCardScheduleState,
-} from "../scheduling";
+} from "../../scheduling";
 import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
-} from "../sync/conflicts/fork";
-import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
-import { getWorkspaceSchedulerConfig } from "../scheduling/workspaceSettings";
+} from "../../sync/conflicts/fork";
+import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
+import { getWorkspaceSchedulerConfig } from "../../scheduling/workspaceSettings";
 import { assertConsistentFsrsState } from "./fsrs";
 import {
   CARD_COLUMNS,
@@ -26,7 +26,7 @@ import {
   normalizeCardMutationMetadata,
   recordCardSyncChange,
   toDate,
-} from "./shared";
+} from "../shared";
 import type {
   CardMutationMetadata,
   CardRow,
@@ -36,7 +36,7 @@ import type {
   ReviewResult,
   ReviewableCardRow,
   SubmitReviewInput,
-} from "./types";
+} from "../types";
 
 type ProgressTimeZoneRow = Readonly<{
   progress_time_zone: string | null;

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+FSRSRepair.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+FSRSRepair.swift
@@ -68,7 +68,7 @@ extension CardStore {
     }
 }
 
-// Keep in sync with apps/backend/src/cards/fsrs.ts::getInvalidFsrsStateReason.
+// Keep in sync with apps/backend/src/cards/review/fsrs.ts::getInvalidFsrsStateReason.
 func invalidFsrsStateReason(card: Card) -> String? {
     if card.fsrsCardState == .new {
         if card.dueAt != nil {
@@ -104,7 +104,7 @@ func invalidFsrsStateReason(card: Card) -> String? {
     return nil
 }
 
-// Keep in sync with apps/backend/src/cards/fsrs.ts repair semantics.
+// Keep in sync with apps/backend/src/cards/review/fsrs.ts repair semantics.
 func resetFsrsState(card: Card, updatedAt: String) -> Card {
     Card(
         cardId: card.cardId,

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Review.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension LocalDatabase {
-    // Keep in sync with apps/backend/src/cards/reviews.ts::submitReview.
+    // Keep in sync with apps/backend/src/cards/review/reviews.ts::submitReview.
     func submitReview(workspaceId: String, reviewSubmission: ReviewSubmission) throws -> Card {
         return try self.core.inTransaction {
             let card = try self.cardStore.loadCard(workspaceId: workspaceId, cardId: reviewSubmission.cardId)

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase.swift
@@ -7,7 +7,7 @@ import Foundation
 
  This file mirrors the backend scheduler-settings and review-persistence logic
  in `apps/backend/src/scheduling/workspaceSettings.ts` and
- `apps/backend/src/cards/reviews.ts`.
+ `apps/backend/src/cards/review/reviews.ts`.
  If you change scheduler-state validation or review persistence here, make the
  same change in the backend mirror and update docs/fsrs-scheduling-logic.md.
 

--- a/apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift
@@ -796,7 +796,7 @@ func createEmptyReviewableCardScheduleState(cardId: String) -> ReviewableCardSch
     )
 }
 
-// Keep in sync with apps/backend/src/cards/reviews.ts::toReviewableCardScheduleState and apps/backend/src/scheduling/index.ts::ReviewableCardScheduleState.
+// Keep in sync with apps/backend/src/cards/review/reviews.ts::toReviewableCardScheduleState and apps/backend/src/scheduling/index.ts::ReviewableCardScheduleState.
 private func makeReviewableCardScheduleState(card: Card) -> ReviewableCardScheduleState {
     ReviewableCardScheduleState(
         cardId: card.cardId,
@@ -811,7 +811,7 @@ private func makeReviewableCardScheduleState(card: Card) -> ReviewableCardSchedu
     )
 }
 
-// Keep in sync with apps/backend/src/cards/reviews.ts::submitReview and apps/backend/src/scheduling/index.ts::computeReviewSchedule.
+// Keep in sync with apps/backend/src/cards/review/reviews.ts::submitReview and apps/backend/src/scheduling/index.ts::computeReviewSchedule.
 func computeReviewSchedule(
     card: Card,
     settings: WorkspaceSchedulerSettings,

--- a/docs/fsrs-scheduling-logic.md
+++ b/docs/fsrs-scheduling-logic.md
@@ -14,7 +14,7 @@ Reference implementation:
 Repository implementations:
 
 - backend scheduler: `apps/backend/src/scheduling/index.ts`
-- backend card persistence: `apps/backend/src/cards/reviews.ts` and `apps/backend/src/cards/fsrs.ts`
+- backend card persistence: `apps/backend/src/cards/review/reviews.ts` and `apps/backend/src/cards/review/fsrs.ts`
 - backend workspace scheduler settings: `apps/backend/src/scheduling/workspaceSettings.ts`
 - iOS scheduler: `apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift`
 - iOS local persistence: `apps/ios/Flashcards/Flashcards/LocalDatabase.swift`
@@ -39,7 +39,7 @@ Instead, the web review flow reuses the backend scheduler module from `apps/back
 
 Supporting mirrors around the scheduler contract:
 
-- backend review persistence: `apps/backend/src/cards/reviews.ts`
+- backend review persistence: `apps/backend/src/cards/review/reviews.ts`
 - iOS review persistence: `apps/ios/Flashcards/Flashcards/LocalDatabase.swift`
 - Android review persistence: `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt`
 - web local review submit flow reusing backend scheduler: `apps/web/src/appData/sync/local/syncLocalMutations.ts`
@@ -76,8 +76,8 @@ Scheduler-entrypoint parity:
 
 | Backend | iOS |
 | --- | --- |
-| `apps/backend/src/cards/reviews.ts::toReviewableCardScheduleState` | `apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::makeReviewableCardScheduleState(card:)` |
-| `apps/backend/src/cards/reviews.ts::submitReview` | `apps/ios/Flashcards/Flashcards/LocalDatabase.swift::submitReview(workspaceId:reviewSubmission:)` |
+| `apps/backend/src/cards/review/reviews.ts::toReviewableCardScheduleState` | `apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::makeReviewableCardScheduleState(card:)` |
+| `apps/backend/src/cards/review/reviews.ts::submitReview` | `apps/ios/Flashcards/Flashcards/LocalDatabase.swift::submitReview(workspaceId:reviewSubmission:)` |
 | `apps/backend/src/scheduling/workspaceSettings.ts::parseSteps` | `apps/ios/Flashcards/Flashcards/LocalDatabase.swift::validateSchedulerStepList(values:fieldName:)` |
 | `apps/backend/src/scheduling/workspaceSettings.ts::validateWorkspaceSchedulerSettingsInput` | `apps/ios/Flashcards/Flashcards/LocalDatabase.swift::validateWorkspaceSchedulerSettingsInput(desiredRetention:learningStepsMinutes:relearningStepsMinutes:maximumIntervalDays:enableFuzz:)` |
 | `apps/backend/src/scheduling/workspaceSettings.ts::getWorkspaceSchedulerSettings` / `getWorkspaceSchedulerConfig` | `apps/ios/Flashcards/Flashcards/LocalDatabase.swift::loadWorkspaceSchedulerSettings(workspaceId:)` |


### PR DESCRIPTION
## Summary
- move FSRS validation and review persistence under `cards/review`
- extract review queue and history queries while sharing card query validation
- preserve the root cards facade and update parity path references

## Validation
- Not run locally; cloud CI owns executable validation.