### PR TITLE
Add admin catalog version audit endpoint

### DIFF
--- a/apps/backend/src/catalog/authoring/versions/audit.ts
+++ b/apps/backend/src/catalog/authoring/versions/audit.ts
@@ -1,0 +1,129 @@
+import type { CardMetadata } from "../../../cards/types";
+import type { DatabaseExecutor } from "../../../database";
+import { unsafeRepeatableReadReadOnlyTransaction } from "../../../database/core";
+import { HttpError } from "../../../shared/errors";
+import { toSafeNumber } from "../../common";
+import type {
+  CatalogPackageStatus,
+  CatalogPackageVersionAudit,
+  CatalogPackageVersionAuditCard,
+} from "../../types";
+
+type CatalogPackageVersionAuditRow = Readonly<{
+  package_version_id: string;
+  version_number: string | number;
+  status: CatalogPackageStatus;
+}>;
+
+type CatalogPackageVersionAuditCardRow = Readonly<{
+  package_version_id: string;
+  package_card_id: string;
+  stable_card_key: string;
+  ordinal: string | number;
+  front_text: string;
+  back_text: string;
+  card_type: string;
+  metadata: CardMetadata;
+  tags: ReadonlyArray<string>;
+  media_asset_keys: ReadonlyArray<string>;
+}>;
+
+async function assertCatalogPackageExistsInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<void> {
+  const result = await executor.query<Readonly<{ package_id: string }>>(
+    "SELECT package_id FROM catalog.packages WHERE package_id = $1",
+    [packageId],
+  );
+  if (result.rows[0] !== undefined) {
+    return;
+  }
+
+  throw new HttpError(
+    404,
+    `Catalog package not found. packageId=${packageId}`,
+    "CATALOG_PACKAGE_NOT_FOUND",
+  );
+}
+
+function mapCatalogPackageVersionAuditCard(
+  row: CatalogPackageVersionAuditCardRow,
+): CatalogPackageVersionAuditCard {
+  return {
+    packageCardId: row.package_card_id,
+    stableCardKey: row.stable_card_key,
+    ordinal: toSafeNumber(row.ordinal, "ordinal"),
+    frontText: row.front_text,
+    backText: row.back_text,
+    cardType: row.card_type,
+    metadata: row.metadata,
+    tags: [...row.tags],
+    mediaAssetKeys: [...row.media_asset_keys],
+  };
+}
+
+function groupCatalogPackageVersionAuditCards(
+  rows: ReadonlyArray<CatalogPackageVersionAuditCardRow>,
+): ReadonlyMap<string, ReadonlyArray<CatalogPackageVersionAuditCard>> {
+  const cardsByVersionId = new Map<string, Array<CatalogPackageVersionAuditCard>>();
+  for (const row of rows) {
+    const card = mapCatalogPackageVersionAuditCard(row);
+    const cards = cardsByVersionId.get(row.package_version_id);
+    if (cards === undefined) {
+      cardsByVersionId.set(row.package_version_id, [card]);
+    } else {
+      cards.push(card);
+    }
+  }
+
+  return cardsByVersionId;
+}
+
+export async function listCatalogPackageVersionsForAuditInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<ReadonlyArray<CatalogPackageVersionAudit>> {
+  await assertCatalogPackageExistsInExecutor(executor, packageId);
+  const versionsResult = await executor.query<CatalogPackageVersionAuditRow>(
+    [
+      "SELECT package_version_id, version_number, status",
+      "FROM catalog.package_versions",
+      "WHERE package_id = $1",
+      "ORDER BY version_number ASC, package_version_id ASC",
+    ].join(" "),
+    [packageId],
+  );
+  if (versionsResult.rows.length === 0) {
+    return [];
+  }
+
+  const cardsResult = await executor.query<CatalogPackageVersionAuditCardRow>(
+    [
+      "SELECT cards.package_version_id, cards.package_card_id, cards.stable_card_key, cards.ordinal,",
+      "cards.front_text, cards.back_text, cards.card_type, cards.metadata, cards.tags, cards.media_asset_keys",
+      "FROM catalog.package_cards AS cards",
+      "INNER JOIN catalog.package_versions AS versions",
+      "ON versions.package_version_id = cards.package_version_id",
+      "WHERE versions.package_id = $1",
+      "ORDER BY versions.version_number ASC, cards.ordinal ASC, cards.package_card_id ASC",
+    ].join(" "),
+    [packageId],
+  );
+  const cardsByVersionId = groupCatalogPackageVersionAuditCards(cardsResult.rows);
+
+  return versionsResult.rows.map((version): CatalogPackageVersionAudit => ({
+    packageVersionId: version.package_version_id,
+    versionNumber: toSafeNumber(version.version_number, "version_number"),
+    status: version.status,
+    cards: cardsByVersionId.get(version.package_version_id) ?? [],
+  }));
+}
+
+export async function listCatalogPackageVersionsForAudit(
+  packageId: string,
+): Promise<ReadonlyArray<CatalogPackageVersionAudit>> {
+  return unsafeRepeatableReadReadOnlyTransaction(async (executor) => (
+    listCatalogPackageVersionsForAuditInExecutor(executor, packageId)
+  ));
+}

--- a/apps/backend/src/catalog/authoring/versions/index.ts
+++ b/apps/backend/src/catalog/authoring/versions/index.ts
@@ -18,6 +18,11 @@ import {
 } from "./publication";
 
 export {
+  listCatalogPackageVersionsForAudit,
+  listCatalogPackageVersionsForAuditInExecutor,
+} from "./audit";
+
+export {
   createCatalogPackageVersionFromCardsInExecutor,
 } from "./creation";
 export {

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -37,6 +37,8 @@ export {
   delistCatalogPackageVersion,
   delistCatalogPackageVersionInExecutor,
   isCatalogPackageVersionStatusTransitionAllowed,
+  listCatalogPackageVersionsForAudit,
+  listCatalogPackageVersionsForAuditInExecutor,
   publishCatalogPackageVersion,
   publishCatalogPackageVersionInExecutor,
   updateCatalogPackageVersionReviewStatus,

--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -411,6 +411,25 @@ export type CatalogPackageCardSnapshotInput = Readonly<{
   mediaAssetKeys: ReadonlyArray<string>;
 }>;
 
+export type CatalogPackageVersionAuditCard = Readonly<{
+  packageCardId: string;
+  stableCardKey: string;
+  ordinal: number;
+  frontText: string;
+  backText: string;
+  cardType: string;
+  metadata: CardMetadata;
+  tags: ReadonlyArray<string>;
+  mediaAssetKeys: ReadonlyArray<string>;
+}>;
+
+export type CatalogPackageVersionAudit = Readonly<{
+  packageVersionId: string;
+  versionNumber: number;
+  status: CatalogPackageStatus;
+  cards: ReadonlyArray<CatalogPackageVersionAuditCard>;
+}>;
+
 export type CreateCatalogPackageVersionInput = Readonly<{
   packageVersionId: string;
   cards: ReadonlyArray<CatalogPackageCardSnapshotInput>;

--- a/apps/backend/src/routes/catalog/admin.ts
+++ b/apps/backend/src/routes/catalog/admin.ts
@@ -11,6 +11,7 @@ import {
   createCatalogPackageVersionFromCards,
   createCatalogPackageVersionFromWorkspaceSelection,
   delistCatalogPackageVersion,
+  listCatalogPackageVersionsForAudit,
   loadCatalogPackageDraft,
   publishCatalogPackageVersion,
   updateCatalogAuthor,
@@ -27,6 +28,7 @@ import {
   type CatalogPackageMediaAsset,
   type CatalogPackageStatus,
   type CatalogPackageVersion,
+  type CatalogPackageVersionAudit,
   type CreateCatalogPackageDraftInput,
   type CreateCatalogPackageVersionFromWorkspaceInput,
   type CreateCatalogPackageVersionInput,
@@ -55,6 +57,9 @@ type CatalogAdminRoutesOptions = Readonly<{
   createCatalogPackageDraftFn?: (input: CreateCatalogPackageDraftInput) => Promise<CatalogPackage>;
   updateCatalogPackageDraftFn?: (input: UpdateCatalogPackageDraftInput) => Promise<CatalogPackage>;
   loadCatalogPackageDraftFn?: (packageId: string) => Promise<CatalogPackageDraft>;
+  listCatalogPackageVersionsForAuditFn?: (
+    packageId: string,
+  ) => Promise<ReadonlyArray<CatalogPackageVersionAudit>>;
   attachCatalogPackageDraftMediaAssetFn?: (
     packageId: string,
     input: AttachCatalogPackageMediaAssetInput,
@@ -311,6 +316,8 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
   const createCatalogPackageDraftFn = options.createCatalogPackageDraftFn ?? createCatalogPackageDraft;
   const updateCatalogPackageDraftFn = options.updateCatalogPackageDraftFn ?? updateCatalogPackageDraft;
   const loadCatalogPackageDraftFn = options.loadCatalogPackageDraftFn ?? loadCatalogPackageDraft;
+  const listCatalogPackageVersionsForAuditFn = options.listCatalogPackageVersionsForAuditFn
+    ?? listCatalogPackageVersionsForAudit;
   const attachCatalogPackageDraftMediaAssetFn = options.attachCatalogPackageDraftMediaAssetFn
     ?? attachCatalogPackageDraftMediaAsset;
   const createCatalogPackageVersionFromCardsFn = options.createCatalogPackageVersionFromCardsFn
@@ -371,6 +378,13 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
       parsePackageMediaAssetInput(await parseCatalogAdminJsonBody(context.req.raw)),
     );
     return context.json({ mediaAsset }, 201);
+  });
+
+  app.get("/admin/catalog/packages/:packageId/versions", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageId = parseUuidParam(context.req.param("packageId"), "packageId");
+    const packageVersions = await listCatalogPackageVersionsForAuditFn(packageId);
+    return context.json({ packageVersions });
   });
 
   app.post("/admin/catalog/packages/:packageId/versions", async (context) => {

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -139,6 +139,10 @@ export function addDirectImageIngestionApiRoutes(
   const catalogPackage = packages.addResource("{packageId}");
   catalogPackage.addMethod("ANY", sharedIntegration);
   catalogPackage.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
+  const catalogPackageVersions = catalogPackage.addResource("versions");
+  catalogPackageVersions.addMethod("ANY", sharedIntegration);
+  catalogPackageVersions.addMethod("GET", sharedIntegration);
+  catalogPackageVersions.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
   const packageMediaAssets = catalogPackage.addResource("media-assets");
   packageMediaAssets.addMethod("ANY", sharedIntegration);
   packageMediaAssets.addResource("{proxy+}").addMethod("ANY", sharedIntegration);


### PR DESCRIPTION
## Summary
- add an admin-authenticated package-scoped catalog version audit endpoint
- return every stored version and authoritative cards in deterministic order
- register the explicit API Gateway route while preserving existing version mutations

## Validation
- independent static review found no P0-P4 issues
- local project checks were not run; required cloud CI owns executable validation

## Dependency
- needs-trunk prerequisite for APP-2 publication correction work