### PR TITLE
Add FSRS and Alea attribution notices

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,34 @@
 # Third-Party Notices
 
-This file lists third-party assets and runtime libraries bundled for the review reaction animations.
+This file lists third-party software, assets, and runtime libraries used by the product.
+
+## FSRS scheduler adaptations
+
+The scheduler adaptations covered by the notices below are carried in these paths:
+
+- Backend: `apps/backend/src/scheduling/index.ts`
+- iOS: `apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift`
+- Android: `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/scheduling/FsrsScheduler.kt`
+
+### `ts-fsrs` 5.2.3
+
+- Component: Open Spaced Repetition `ts-fsrs`
+- Version: 5.2.3
+- Copyright: Copyright (c) 2025 Open Spaced Repetition
+- Source: https://github.com/open-spaced-repetition/ts-fsrs/tree/v5.2.3
+- License: MIT
+- Local license text: [third_party_licenses/ts-fsrs-5.2.3-MIT.txt](third_party_licenses/ts-fsrs-5.2.3-MIT.txt)
+- Changes: The upstream scheduler flow and formulas were adapted into independent backend TypeScript, iOS Swift, and Android Kotlin implementations and integrated with product-specific persisted card state and workspace scheduler settings.
+
+### Alea/Mash
+
+- Component: Alea/Mash seeded pseudorandom number generator
+- Upstream version: `ts-fsrs` 5.2.3, `src/fsrs/alea.ts`
+- Original author and copyright: Copyright (C) 2010 by Johannes Baagøe <baagoe@baagoe.org>
+- Source: https://github.com/open-spaced-repetition/ts-fsrs/blob/v5.2.3/src/fsrs/alea.ts
+- License: MIT
+- Local license text: [third_party_licenses/alea-MIT.txt](third_party_licenses/alea-MIT.txt)
+- Changes: The Alea/Mash implementation used by `ts-fsrs` was adapted into the backend, iOS, and Android schedulers for deterministic interval fuzzing.
 
 ## Review again rain cloud Lottie animation
 

--- a/third_party_licenses/alea-MIT.txt
+++ b/third_party_licenses/alea-MIT.txt
@@ -1,0 +1,25 @@
+https://github.com/davidbau/seedrandom/blob/released/lib/alea.js
+A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
+http://baagoe.com/en/RandomMusings/javascript/
+https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
+Original work is under MIT license -
+
+Copyright (C) 2010 by Johannes Baagøe <baagoe@baagoe.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/third_party_licenses/ts-fsrs-5.2.3-MIT.txt
+++ b/third_party_licenses/ts-fsrs-5.2.3-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Open Spaced Repetition
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add the exact ts-fsrs 5.2.3 MIT notice
- add the upstream-attributed Alea/Mash MIT notice
- document source, version, changes, and all scheduler adaptation paths

## Testing
- Not run locally; cloud CI owns validation.