### PR TITLE
Run live web smoke with Bash

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -474,6 +474,7 @@ jobs:
       - name: Run live web smoke test
         id: live_smoke
         working-directory: apps/web
+        shell: bash
         env:
           FLASHCARDS_E2E_APP_BASE_URL: https://app.flashcards-open-source-app.com
           FLASHCARDS_E2E_AUTH_BASE_URL: https://auth.flashcards-open-source-app.com


### PR DESCRIPTION
## Summary

- run the Playwright container live-smoke step with Bash explicitly
- preserve the existing image, timeouts, test command, artifacts, and summaries

## Validation

- local checks intentionally not run; cloud PR CI owns validation
- fresh independent static review found no P0-P4 issues