### PR TITLE
Make admin community charts per-user and filter-aware

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -60,9 +60,9 @@ The dashboard shows six charts:
 - daily active users by platform
 - daily review events by platform
 - daily friend invite links created
-- existing friend connections at the end of each day
+- existing friend connections at the end of each day, counted per user
 
 The default chart range starts on the first calendar day with any review event, friend invite link, or friendship row and ends on today, inclusive, in the dashboard timezone. The dashboard includes date range filters that can narrow the chart range and reset back to that default.
-The filter panel keeps date, user, new/returning cohort, and platform filters in one compact row. Date filters apply to all charts. User, cohort, and platform filters apply to review-event charts only; friend invite and friend connection charts stay all-user date-range metrics. User emails and user IDs are shown only inside the user filter popup and chart tooltips, not as a persistent page list.
+The filter panel keeps date, user, new/returning cohort, and platform filters in one compact row. All four filters apply to every chart, including the friend invite and friend connection charts, which carry per-user community rows. A cohort or platform filter keeps community rows only for users that still have review events in range, and the user filter list also offers users with community activity but no review events in range. User emails and user IDs are shown only inside the user filter popup and chart tooltips, not as a persistent page list.
 
 Its SQL lives in the admin frontend as a chart-owned query and runs through the generic admin reporting endpoint.

--- a/apps/admin/src/adminApi.ts
+++ b/apps/admin/src/adminApi.ts
@@ -89,12 +89,23 @@ export type ReviewEventsByDateRow = Readonly<{
   firstReviewDate: string;
 }>;
 
+/** One community activity row per report date and user. */
+export type ReviewEventsByDateCommunityRow = Readonly<{
+  date: string;
+  userId: string;
+  email: string;
+  friendInvitationCount: number;
+  friendshipCount: number;
+}>;
+
 export type ReviewEventsByDateReport = Readonly<{
   generatedAtUtc: string;
   from: string;
   to: string;
   totalReviewEvents: number;
   users: ReadonlyArray<ReviewEventsByDateUser>;
+  /** Users with community activity in range but no review events in range. */
+  communityOnlyUsers: ReadonlyArray<ReviewEventsByDateUser>;
   dateTotals: ReadonlyArray<ReviewEventsByDateTotal>;
   dailyUniqueUserCohorts: ReadonlyArray<ReviewEventsByDateUniqueUserCohort>;
   friendInvitationTotals: ReadonlyArray<ReviewEventsByDateFriendInvitationTotal>;
@@ -102,6 +113,7 @@ export type ReviewEventsByDateReport = Readonly<{
   platformActiveUserTotals: ReadonlyArray<ReviewEventsByDatePlatformActiveUserTotal>;
   platformReviewEventTotals: ReadonlyArray<ReviewEventsByDatePlatformReviewEventTotal>;
   rows: ReadonlyArray<ReviewEventsByDateRow>;
+  communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>;
 }>;
 
 export class AdminApiError extends Error {

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -5,6 +5,7 @@ import {
   type ReviewEventCohort,
   type ReviewEventPlatform,
   type ReviewEventsByDateReport,
+  type ReviewEventsByDateUser,
 } from "../../adminApi";
 import { ReviewEventsByDateCharts } from "./charts/ReviewEventsByDateCharts";
 import { buildReviewEventsByDateChartModel } from "./charts/chartModel";
@@ -25,6 +26,15 @@ import {
   filterReviewEventsByDateReport,
   type ReviewEventsByDateRange,
 } from "./query";
+
+function buildUserById(
+  reviewUsers: ReadonlyArray<ReviewEventsByDateUser>,
+  communityOnlyUsers: ReadonlyArray<ReviewEventsByDateUser>,
+): ReadonlyMap<string, ReviewEventsByDateUser> {
+  return new Map<string, ReviewEventsByDateUser>(
+    [...reviewUsers, ...communityOnlyUsers].map((user) => [user.userId, user]),
+  );
+}
 
 function getUpdatedUserFilterSelection(
   currentUserIds: ReadonlyArray<string>,
@@ -177,13 +187,17 @@ export function ReviewEventsByDateDashboard(
     () => new Set(selectedPlatforms),
     [selectedPlatforms],
   );
+  const userFilterOptionUsers = useMemo(
+    () => [...props.report.users, ...props.report.communityOnlyUsers],
+    [props.report.communityOnlyUsers, props.report.users],
+  );
   const reportUserById = useMemo(
-    () => new Map(props.report.users.map((user) => [user.userId, user])),
-    [props.report.users],
+    () => buildUserById(props.report.users, props.report.communityOnlyUsers),
+    [props.report.communityOnlyUsers, props.report.users],
   );
   const filteredUserById = useMemo(
-    () => new Map(filteredReport.users.map((user) => [user.userId, user])),
-    [filteredReport.users],
+    () => buildUserById(filteredReport.users, filteredReport.communityOnlyUsers),
+    [filteredReport.communityOnlyUsers, filteredReport.users],
   );
   const activeUserFilters = useMemo(
     () => buildActiveUserFilters(selectedUserIds, reportUserById),
@@ -194,8 +208,8 @@ export function ReviewEventsByDateDashboard(
     [userFilterSearchValue],
   );
   const searchableUserFilterOptions = useMemo(
-    () => buildSearchableUserFilterOptions(props.report.users),
-    [props.report.users],
+    () => buildSearchableUserFilterOptions(userFilterOptionUsers),
+    [userFilterOptionUsers],
   );
   const matchingUserFilterOptions = useMemo(
     () => searchableUserFilterOptions
@@ -208,21 +222,17 @@ export function ReviewEventsByDateDashboard(
     [matchingUserFilterOptions],
   );
   const hiddenUserFilterOptionCount = matchingUserFilterOptions.length - visibleUserFilterOptions.length;
-  const reviewChartModel = useMemo(
-    () => buildReviewEventsByDateChartModel(filteredReport, props.report.users),
-    [filteredReport, props.report.users],
-  );
-  const communityChartModel = useMemo(
-    () => buildReviewEventsByDateChartModel(props.report, props.report.users),
-    [props.report],
+  const chartModel = useMemo(
+    () => buildReviewEventsByDateChartModel(filteredReport, userFilterOptionUsers),
+    [filteredReport, userFilterOptionUsers],
   );
   const summaryCards = useMemo(
     () => buildReviewEventsByDateSummaryCards(
       filteredReport,
-      reviewChartModel.peakDailyVolume,
-      reviewChartModel.peakDailyUniqueUsers,
+      chartModel.peakDailyVolume,
+      chartModel.peakDailyUniqueUsers,
     ),
-    [reviewChartModel.peakDailyUniqueUsers, reviewChartModel.peakDailyVolume, filteredReport],
+    [chartModel.peakDailyUniqueUsers, chartModel.peakDailyVolume, filteredReport],
   );
 
   return (
@@ -251,7 +261,7 @@ export function ReviewEventsByDateDashboard(
         draftRange={draftRange}
         isReportLoading={props.isReportLoading}
         dateRangeError={props.dateRangeError}
-        reportUsers={props.report.users}
+        reportUsers={userFilterOptionUsers}
         selectedUserIds={selectedUserIds}
         selectedUserIdSet={selectedUserIdSet}
         selectedCohorts={selectedCohorts}
@@ -263,7 +273,7 @@ export function ReviewEventsByDateDashboard(
         matchingUserFilterOptionCount={matchingUserFilterOptions.length}
         hiddenUserFilterOptionCount={hiddenUserFilterOptionCount}
         activeUserFilters={activeUserFilters}
-        userColorScale={reviewChartModel.userColorScale}
+        userColorScale={chartModel.userColorScale}
         onFromDateChange={handleFromDateChange}
         onToDateChange={handleToDateChange}
         onDateRangeSubmit={handleDateRangeSubmit}
@@ -280,8 +290,7 @@ export function ReviewEventsByDateDashboard(
       <ReviewEventsByDateSummary cards={summaryCards} />
 
       <ReviewEventsByDateCharts
-        reviewChartModel={reviewChartModel}
-        communityChartModel={communityChartModel}
+        chartModel={chartModel}
         generatedAtUtc={props.report.generatedAtUtc}
         isReportLoading={props.isReportLoading}
         userById={filteredUserById}

--- a/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
@@ -20,8 +20,7 @@ import {
 import { formatGeneratedAt } from "../formatting";
 
 type ReviewEventsByDateChartsProps = Readonly<{
-  reviewChartModel: ReviewEventsByDateChartModel;
-  communityChartModel: ReviewEventsByDateChartModel;
+  chartModel: ReviewEventsByDateChartModel;
   generatedAtUtc: string;
   isReportLoading: boolean;
   userById: ReadonlyMap<string, ReviewEventsByDateUser>;
@@ -130,65 +129,64 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
 
     renderDailyUniqueUsersChart({
       svgElement: uniqueUsersSvgElement,
-      dates: props.reviewChartModel.dates,
-      tickDates: props.reviewChartModel.tickDates,
-      dailyUniqueUserCohortMatrix: props.reviewChartModel.dailyUniqueUserCohortMatrix,
-      dailyUniqueUsersByDate: props.reviewChartModel.dailyUniqueUsersByDate,
-      totalReviewEventsByDate: props.reviewChartModel.totalReviewEventsByDate,
-      peakDailyUniqueUsers: props.reviewChartModel.peakDailyUniqueUsers,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      dailyUniqueUserCohortMatrix: props.chartModel.dailyUniqueUserCohortMatrix,
+      dailyUniqueUsersByDate: props.chartModel.dailyUniqueUsersByDate,
+      totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
+      peakDailyUniqueUsers: props.chartModel.peakDailyUniqueUsers,
       tooltipHandlers,
     });
     renderUserReviewEventsChart({
       svgElement: userReviewEventsSvgElement,
-      dates: props.reviewChartModel.dates,
-      tickDates: props.reviewChartModel.tickDates,
-      userMatrix: props.reviewChartModel.userMatrix,
-      userIds: props.reviewChartModel.userIds,
-      userColorScale: props.reviewChartModel.userColorScale,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      userMatrix: props.chartModel.userMatrix,
+      userIds: props.chartModel.userIds,
+      userColorScale: props.chartModel.userColorScale,
       userById: props.userById,
-      totalReviewEventsByDate: props.reviewChartModel.totalReviewEventsByDate,
-      peakDailyVolume: props.reviewChartModel.peakDailyVolume,
+      totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
+      peakDailyVolume: props.chartModel.peakDailyVolume,
       isReportLoading: props.isReportLoading,
       onUserFilterApply: handleUserFilterApply,
       tooltipHandlers,
     });
     renderPlatformActiveUsersChart({
       svgElement: platformUsersSvgElement,
-      dates: props.reviewChartModel.dates,
-      tickDates: props.reviewChartModel.tickDates,
-      platformActiveUsersMatrix: props.reviewChartModel.platformActiveUsersMatrix,
-      dailyUniqueUsersByDate: props.reviewChartModel.dailyUniqueUsersByDate,
-      peakDailyPlatformUsers: props.reviewChartModel.peakDailyPlatformUsers,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      platformActiveUsersMatrix: props.chartModel.platformActiveUsersMatrix,
+      dailyUniqueUsersByDate: props.chartModel.dailyUniqueUsersByDate,
+      peakDailyPlatformUsers: props.chartModel.peakDailyPlatformUsers,
       tooltipHandlers,
     });
     renderPlatformReviewEventsChart({
       svgElement: platformReviewEventsSvgElement,
-      dates: props.reviewChartModel.dates,
-      tickDates: props.reviewChartModel.tickDates,
-      platformReviewEventsMatrix: props.reviewChartModel.platformReviewEventsMatrix,
-      totalPlatformReviewEventsByDate: props.reviewChartModel.totalPlatformReviewEventsByDate,
-      peakDailyPlatformReviewEvents: props.reviewChartModel.peakDailyPlatformReviewEvents,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      platformReviewEventsMatrix: props.chartModel.platformReviewEventsMatrix,
+      totalPlatformReviewEventsByDate: props.chartModel.totalPlatformReviewEventsByDate,
+      peakDailyPlatformReviewEvents: props.chartModel.peakDailyPlatformReviewEvents,
       tooltipHandlers,
     });
     renderDailyFriendInvitationsChart({
       svgElement: friendInvitationsSvgElement,
-      dates: props.communityChartModel.dates,
-      tickDates: props.communityChartModel.tickDates,
-      friendInvitationCounts: props.communityChartModel.friendInvitationCounts,
-      peakDailyFriendInvitations: props.communityChartModel.peakDailyFriendInvitations,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      friendInvitationCounts: props.chartModel.friendInvitationCounts,
+      peakDailyFriendInvitations: props.chartModel.peakDailyFriendInvitations,
       tooltipHandlers,
     });
     renderDailyFriendshipsChart({
       svgElement: friendshipsSvgElement,
-      dates: props.communityChartModel.dates,
-      tickDates: props.communityChartModel.tickDates,
-      friendshipCounts: props.communityChartModel.friendshipCounts,
-      peakDailyFriendships: props.communityChartModel.peakDailyFriendships,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      friendshipCounts: props.chartModel.friendshipCounts,
+      peakDailyFriendships: props.chartModel.peakDailyFriendships,
       tooltipHandlers,
     });
   }, [
-    props.reviewChartModel,
-    props.communityChartModel,
+    props.chartModel,
     props.isReportLoading,
     props.userById,
     handleUserFilterApply,
@@ -249,7 +247,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
           <div className="chart-meta">
             <span>Friend invite links created</span>
             <div className="chart-meta-right">
-              <span>All users - date filter only</span>
+              <span>Follows all active filters</span>
             </div>
           </div>
           <div className="chart-scroll">
@@ -261,7 +259,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
           <div className="chart-meta">
             <span>Existing friend connections by day</span>
             <div className="chart-meta-right">
-              <span>All users - date filter only</span>
+              <span>Per-user connections - follows all active filters</span>
             </div>
           </div>
           <div className="chart-scroll">

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
@@ -398,9 +398,9 @@ export function renderDailyFriendshipsChart(params: RenderDailyFriendshipsChartP
     values: params.friendshipCounts,
     peakValue: params.peakDailyFriendships,
     color: communityMetricColors.friendships,
-    yAxisLabel: "Friendships",
-    tooltipSubtitle: "Friendships",
-    tooltipMetricLabel: "Existing friendships at end of day",
+    yAxisLabel: "Connections",
+    tooltipSubtitle: "Friend connections",
+    tooltipMetricLabel: "Per-user connections at end of day",
     tooltipHandlers: params.tooltipHandlers,
   });
 }

--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -8,6 +8,7 @@ import type {
   AdminQueryValue,
   ReviewEventCohort,
   ReviewEventPlatform,
+  ReviewEventsByDateCommunityRow,
   ReviewEventsByDateFriendInvitationTotal,
   ReviewEventsByDateFriendshipTotal,
   ReviewEventsByDatePlatformActiveUserTotal,
@@ -32,6 +33,8 @@ type ReviewEventsByDateQueryRow = Readonly<{
 
 type ReviewEventsByDateCommunityQueryRow = Readonly<{
   report_date: string;
+  user_id: string;
+  email: string;
   friend_invitation_count: string | number;
   friendship_count: string | number;
 }>;
@@ -60,6 +63,11 @@ type ReviewEventsByDateAggregateFields = Readonly<Pick<
   | "dailyUniqueUserCohorts"
   | "platformActiveUserTotals"
   | "platformReviewEventTotals"
+>>;
+
+type ReviewEventsByDateCommunityAggregateFields = Readonly<Pick<
+  ReviewEventsByDateReport,
+  "friendInvitationTotals" | "friendshipTotals"
 >>;
 
 function parseCalendarDate(date: string): Date {
@@ -154,6 +162,8 @@ function toReviewEventsByDateCommunityQueryRow(
 ): ReviewEventsByDateCommunityQueryRow {
   return {
     report_date: assertIsString(resultSetRow.report_date ?? null, "report_date"),
+    user_id: assertIsString(resultSetRow.user_id ?? null, "user_id"),
+    email: assertIsString(resultSetRow.email ?? null, "email"),
     friend_invitation_count: toInteger(resultSetRow.friend_invitation_count ?? null, "friend_invitation_count"),
     friendship_count: toInteger(resultSetRow.friendship_count ?? null, "friendship_count"),
   };
@@ -275,50 +285,93 @@ function buildDailyUniqueUserCohorts(
   }));
 }
 
-function buildCommunityRowsByDate(
-  rows: ReadonlyArray<ReviewEventsByDateCommunityQueryRow>,
+function assertCommunityRowsInRange(
+  rows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
   dates: ReadonlyArray<string>,
-): ReadonlyMap<string, ReviewEventsByDateCommunityQueryRow> {
+): void {
   const dateSet = new Set(dates);
-  const rowsByDate = new Map<string, ReviewEventsByDateCommunityQueryRow>();
+  const seenDateUserKeys = new Set<string>();
 
   for (const row of rows) {
-    if (dateSet.has(row.report_date) === false) {
-      throw new Error(`Community report returned a date outside the requested range: ${row.report_date}`);
+    if (dateSet.has(row.date) === false) {
+      throw new Error(`Community report returned a date outside the requested range: ${row.date}`);
     }
 
-    if (rowsByDate.has(row.report_date)) {
-      throw new Error(`Community report returned duplicate rows for date: ${row.report_date}`);
+    const dateUserKey = `${row.date}:${row.userId}`;
+    if (seenDateUserKeys.has(dateUserKey)) {
+      throw new Error(`Community report returned duplicate rows for date and user: ${dateUserKey}`);
     }
 
-    rowsByDate.set(row.report_date, row);
+    seenDateUserKeys.add(dateUserKey);
   }
-
-  return rowsByDate;
 }
 
 function buildFriendInvitationTotals(
-  rows: ReadonlyArray<ReviewEventsByDateCommunityQueryRow>,
+  rows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
   dates: ReadonlyArray<string>,
 ): ReadonlyArray<ReviewEventsByDateFriendInvitationTotal> {
-  const rowsByDate = buildCommunityRowsByDate(rows, dates);
+  const countsByDate = new Map<string, number>();
+
+  for (const row of rows) {
+    countsByDate.set(row.date, (countsByDate.get(row.date) ?? 0) + row.friendInvitationCount);
+  }
 
   return dates.map((date) => ({
     date,
-    friendInvitationCount: toInteger(rowsByDate.get(date)?.friend_invitation_count ?? 0, "friend_invitation_count"),
+    friendInvitationCount: countsByDate.get(date) ?? 0,
   }));
 }
 
 function buildFriendshipTotals(
-  rows: ReadonlyArray<ReviewEventsByDateCommunityQueryRow>,
+  rows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
   dates: ReadonlyArray<string>,
 ): ReadonlyArray<ReviewEventsByDateFriendshipTotal> {
-  const rowsByDate = buildCommunityRowsByDate(rows, dates);
+  const countsByDate = new Map<string, number>();
+
+  for (const row of rows) {
+    countsByDate.set(row.date, (countsByDate.get(row.date) ?? 0) + row.friendshipCount);
+  }
 
   return dates.map((date) => ({
     date,
-    friendshipCount: toInteger(rowsByDate.get(date)?.friendship_count ?? 0, "friendship_count"),
+    friendshipCount: countsByDate.get(date) ?? 0,
   }));
+}
+
+function buildCommunityOnlyUsers(
+  communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
+  reviewUsers: ReadonlyArray<ReviewEventsByDateUser>,
+): ReadonlyArray<ReviewEventsByDateUser> {
+  const reviewUserIds = new Set(reviewUsers.map((user) => user.userId));
+  const usersByUserId = new Map<string, ReviewEventsByDateUser>();
+
+  for (const row of communityRows) {
+    if (reviewUserIds.has(row.userId) || usersByUserId.has(row.userId)) {
+      continue;
+    }
+
+    usersByUserId.set(row.userId, {
+      userId: row.userId,
+      email: row.email,
+      totalReviewEvents: 0,
+    });
+  }
+
+  return Array.from(usersByUserId.values()).sort((left, right) => {
+    const leftLabel = left.email === "(no email)" ? left.userId : left.email;
+    const rightLabel = right.email === "(no email)" ? right.userId : right.email;
+    return leftLabel.localeCompare(rightLabel);
+  });
+}
+
+function buildReviewEventsByDateCommunityAggregateFields(
+  communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
+  dates: ReadonlyArray<string>,
+): ReviewEventsByDateCommunityAggregateFields {
+  return {
+    friendInvitationTotals: buildFriendInvitationTotals(communityRows, dates),
+    friendshipTotals: buildFriendshipTotals(communityRows, dates),
+  };
 }
 
 function buildReviewEventsByDateAggregateFields(
@@ -372,16 +425,31 @@ function buildReviewEventsByDateReport(
   const aggregateFields = buildReviewEventsByDateAggregateFields(rows, dates);
   const communityRows = communityResultSet.rows
     .map(toReviewEventsByDateCommunityQueryRow)
-    .sort((left, right) => left.report_date.localeCompare(right.report_date));
+    .map((row) => ({
+      date: row.report_date,
+      userId: row.user_id,
+      email: row.email,
+      friendInvitationCount: toInteger(row.friend_invitation_count, "friend_invitation_count"),
+      friendshipCount: toInteger(row.friendship_count, "friendship_count"),
+    }))
+    .sort((left, right) => {
+      if (left.date !== right.date) {
+        return left.date.localeCompare(right.date);
+      }
+
+      return left.userId.localeCompare(right.userId);
+    });
+  assertCommunityRowsInRange(communityRows, dates);
 
   return {
     generatedAtUtc: executedAtUtc,
     from,
     to,
     ...aggregateFields,
-    friendInvitationTotals: buildFriendInvitationTotals(communityRows, dates),
-    friendshipTotals: buildFriendshipTotals(communityRows, dates),
+    communityOnlyUsers: buildCommunityOnlyUsers(communityRows, aggregateFields.users),
+    ...buildReviewEventsByDateCommunityAggregateFields(communityRows, dates),
     rows,
+    communityRows,
   };
 }
 
@@ -393,6 +461,24 @@ function isUnfilteredReviewEventsByDateReport(filters: ReviewEventsByDateFilterS
   return filters.selectedUserIds.length === 0
     && filters.selectedCohorts.length === reviewEventCohorts.length
     && filters.selectedPlatforms.length === reviewEventPlatforms.length;
+}
+
+function hasRestrictedReviewEventFilters(filters: ReviewEventsByDateFilterState): boolean {
+  return filters.selectedCohorts.length !== reviewEventCohorts.length
+    || filters.selectedPlatforms.length !== reviewEventPlatforms.length;
+}
+
+function shouldIncludeCommunityRow(
+  row: ReviewEventsByDateCommunityRow,
+  selectedUserIdSet: ReadonlySet<string>,
+  filteredReviewUserIdSet: ReadonlySet<string>,
+  isRestrictedToFilteredReviewUsers: boolean,
+): boolean {
+  if (selectedUserIdSet.size > 0 && selectedUserIdSet.has(row.userId) === false) {
+    return false;
+  }
+
+  return isRestrictedToFilteredReviewUsers === false || filteredReviewUserIdSet.has(row.userId);
 }
 
 function shouldIncludeReviewEventsByDateRow(
@@ -429,13 +515,23 @@ export function filterReviewEventsByDateReport(
     selectedCohortSet,
     selectedPlatformSet,
   ));
+  const filteredReviewUserIdSet = new Set(rows.map((row) => row.userId));
+  const isRestrictedToFilteredReviewUsers = hasRestrictedReviewEventFilters(filters);
+  const communityRows = report.communityRows.filter((row) => shouldIncludeCommunityRow(
+    row,
+    selectedUserIdSet,
+    filteredReviewUserIdSet,
+    isRestrictedToFilteredReviewUsers,
+  ));
   const dates = buildRequestedDateRange(report.from, report.to);
   const aggregateFields = buildReviewEventsByDateAggregateFields(rows, dates);
 
   return {
     ...report,
     rows,
+    communityRows,
     ...aggregateFields,
+    ...buildReviewEventsByDateCommunityAggregateFields(communityRows, dates),
   };
 }
 
@@ -536,6 +632,10 @@ export function buildReviewEventsByDateSql(from: string, to: string): string {
   ].join("\n");
 }
 
+// Per-user community activity for the admin "Review events by date" report.
+// One row per (report date, user) with at least one non-zero count; the client fills
+// the remaining dates. `friendship_count` counts the directed `community.friendships`
+// rows owned by that viewer, so the sum across users is twice the number of pairs.
 export function buildReviewEventsByDateCommunitySql(from: string, to: string): string {
   assertValidDateRange({ from, to }, "community report");
 
@@ -549,6 +649,7 @@ export function buildReviewEventsByDateCommunitySql(from: string, to: string): s
     "),",
     "real_friend_invitations AS (",
     "  SELECT",
+    "    friend_invitations.inviter_user_id AS user_id,",
     "    (friend_invitations.created_at AT TIME ZONE 'UTC')::date AS created_date",
     "  FROM community.friend_invitations AS friend_invitations",
     "  LEFT JOIN org.user_settings AS inviter_user_settings",
@@ -560,18 +661,18 @@ export function buildReviewEventsByDateCommunitySql(from: string, to: string): s
     "),",
     "daily_friend_invitations AS (",
     "  SELECT",
+    "    real_friend_invitations.user_id,",
     "    real_friend_invitations.created_date,",
     "    COUNT(*)::int AS friend_invitation_count",
     "  FROM real_friend_invitations",
     "  WHERE real_friend_invitations.created_date >= " + escapeSqlStringLiteral(from) + "::date",
     "    AND real_friend_invitations.created_date <= " + escapeSqlStringLiteral(to) + "::date",
-    "  GROUP BY real_friend_invitations.created_date",
+    "  GROUP BY real_friend_invitations.user_id, real_friend_invitations.created_date",
     "),",
-    "real_friendship_pairs AS (",
+    "real_friendships AS (",
     "  SELECT",
-    "    LEAST(friendships.viewer_user_id, friendships.friend_user_id) AS first_user_id,",
-    "    GREATEST(friendships.viewer_user_id, friendships.friend_user_id) AS second_user_id,",
-    "    MIN(friendships.created_at) AS created_at",
+    "    friendships.viewer_user_id AS user_id,",
+    "    friendships.created_at",
     "  FROM community.friendships AS friendships",
     "  LEFT JOIN org.user_settings AS viewer_user_settings",
     "    ON viewer_user_settings.user_id = friendships.viewer_user_id",
@@ -585,24 +686,48 @@ export function buildReviewEventsByDateCommunitySql(from: string, to: string): s
     "      friend_user_settings.email IS NULL",
     "      OR LOWER(btrim(friend_user_settings.email)) NOT LIKE '%@example.com'",
     "    )",
-    "  GROUP BY",
-    "    LEAST(friendships.viewer_user_id, friendships.friend_user_id),",
-    "    GREATEST(friendships.viewer_user_id, friendships.friend_user_id)",
-    ")",
-    "SELECT",
-    "  to_char(requested_dates.report_date, 'YYYY-MM-DD') AS report_date,",
-    "  COALESCE(daily_friend_invitations.friend_invitation_count, 0)::int AS friend_invitation_count,",
-    "  COALESCE((",
-    "    SELECT COUNT(*)",
-    "    FROM real_friendship_pairs",
-    "    WHERE real_friendship_pairs.created_at < (",
+    "),",
+    "daily_friendships AS (",
+    "  SELECT",
+    "    requested_dates.report_date,",
+    "    real_friendships.user_id,",
+    "    COUNT(*)::int AS friendship_count",
+    "  FROM requested_dates",
+    "  INNER JOIN real_friendships",
+    "    ON real_friendships.created_at < (",
     "      (requested_dates.report_date + INTERVAL '1 day')::timestamp AT TIME ZONE 'UTC'",
     "    )",
-    "  ), 0)::int AS friendship_count",
-    "FROM requested_dates",
+    "  GROUP BY requested_dates.report_date, real_friendships.user_id",
+    "),",
+    "community_user_dates AS (",
+    "  SELECT",
+    "    daily_friend_invitations.created_date AS report_date,",
+    "    daily_friend_invitations.user_id",
+    "  FROM daily_friend_invitations",
+    "  UNION",
+    "  SELECT",
+    "    daily_friendships.report_date,",
+    "    daily_friendships.user_id",
+    "  FROM daily_friendships",
+    ")",
+    "SELECT",
+    "  to_char(community_user_dates.report_date, 'YYYY-MM-DD') AS report_date,",
+    "  community_user_dates.user_id,",
+    "  COALESCE(NULLIF(btrim(user_settings.email), ''), '(no email)') AS email,",
+    "  COALESCE(daily_friend_invitations.friend_invitation_count, 0)::int AS friend_invitation_count,",
+    "  COALESCE(daily_friendships.friendship_count, 0)::int AS friendship_count",
+    "FROM community_user_dates",
+    "LEFT JOIN org.user_settings AS user_settings",
+    "  ON user_settings.user_id = community_user_dates.user_id",
     "LEFT JOIN daily_friend_invitations",
-    "  ON daily_friend_invitations.created_date = requested_dates.report_date",
-    "ORDER BY requested_dates.report_date ASC",
+    "  ON daily_friend_invitations.user_id = community_user_dates.user_id",
+    "  AND daily_friend_invitations.created_date = community_user_dates.report_date",
+    "LEFT JOIN daily_friendships",
+    "  ON daily_friendships.user_id = community_user_dates.user_id",
+    "  AND daily_friendships.report_date = community_user_dates.report_date",
+    "ORDER BY",
+    "  report_date ASC,",
+    "  community_user_dates.user_id ASC",
   ].join("\n");
 }
 

--- a/docs/admin-app.md
+++ b/docs/admin-app.md
@@ -69,11 +69,11 @@ Current v1 attribution contract for `review-events-by-date`:
 
 - the report is intended for the current single-effective-learner workspace model
 - the default chart range starts on the first calendar day with any `content.review_events.reviewed_at_server`, `community.friend_invitations.created_at`, or `community.friendships.created_at` row and ends on today, inclusive, in the report timezone
-- dashboard filters can narrow date range, user, new/returning cohort, and platform; date filters apply to every chart, while user, cohort, and platform filters apply only to review-event charts; Reset all returns date range to the same first-activity-day-through-today default and restores all local filters
+- dashboard filters can narrow date range, user, new/returning cohort, and platform; all four filters apply to every chart, including the community charts, where a cohort or platform filter keeps community rows only for users that still have review events in range, and the user filter list also offers users with community activity but no review events in range; Reset all returns date range to the same first-activity-day-through-today default and restores all local filters
 - `users[]` and `rows[].userId` are derived from the current `sync.workspace_replicas.user_id` label for stacked per-user event volume
 - platform charts derive `web` / `android` / `ios` from `content.review_events.replica_id -> sync.workspace_replicas.platform`
-- friend invite charts count `community.friend_invitations` rows created on each UTC date
-- friend connection charts count friendship pairs that exist at the end of each UTC date; directed `community.friendships` rows are not double-counted
+- friend invite charts count `community.friend_invitations` rows created on each UTC date, attributed per user to `community.friend_invitations.inviter_user_id`
+- friend connection charts count directed `community.friendships` rows per `viewer_user_id` that exist at the end of each UTC date, so the all-user sum is intentionally twice the number of friendship pairs
 - that label is acceptable for today's product shape, but it is not a durable historical review-author field
 - do not interpret this report as collaborative per-user analytics unless review authorship is stored immutably on each review event
 


### PR DESCRIPTION
The two community charts on the admin `review-events-by-date` dashboard ("Friend invite links created" and "Existing friend connections by day") were all-user, date-range-only metrics. This makes them per-user data that obeys every active dashboard filter.

## What changes

- The community SQL returns one row per (date, user) with `user_id`, `email`, `friend_invitation_count` and `friendship_count` instead of one aggregate row per date. Invite links are attributed to `community.friend_invitations.inviter_user_id`; friend connections are counted per user from the directed `community.friendships` rows.
- `filterReviewEventsByDateReport` now filters the community rows too: a user selection restricts them directly, and a narrowed cohort/platform filter keeps only users that still have review events in range.
- The separate review and community chart models collapse into one model built from the filtered report.
- Users with community activity but no review events in range become selectable in the user filter and resolvable in tooltips. The "Users With Review Events" summary card still counts review users only.
- Chart axis/tooltip text, `apps/admin/README.md`, and the `review-events-by-date` attribution contract in `docs/admin-app.md` are updated to match.

Counting friend connections per user means the all-user sum is intentionally twice the number of friendship pairs. This was explicitly chosen so that filtering to one user shows that user's own connections.

## Scope

Base is the integration branch `feature/admin-community-charts-by-user`, not `main`. A follow-up item on the same branch converts both community charts to per-user stacked bars with per-user colours, email tooltips, and click-to-filter; this PR keeps them rendering as single-colour daily bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)