### PR TITLE
Stack admin community charts by user

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -59,8 +59,8 @@ The dashboard shows six charts:
 - stacked review events by user
 - daily active users by platform
 - daily review events by platform
-- daily friend invite links created
-- existing friend connections at the end of each day, counted per user
+- daily friend invite links created, stacked by user
+- existing friend connections at the end of each day, counted per user and stacked by user
 
 The default chart range starts on the first calendar day with any review event, friend invite link, or friendship row and ends on today, inclusive, in the dashboard timezone. The dashboard includes date range filters that can narrow the chart range and reset back to that default.
 The filter panel keeps date, user, new/returning cohort, and platform filters in one compact row. All four filters apply to every chart, including the friend invite and friend connection charts, which carry per-user community rows. A cohort or platform filter keeps community rows only for users that still have review events in range, and the user filter list also offers users with community activity but no review events in range. User emails and user IDs are shown only inside the user filter popup and chart tooltips, not as a persistent page list.

--- a/apps/admin/src/adminApi.ts
+++ b/apps/admin/src/adminApi.ts
@@ -58,16 +58,6 @@ export type ReviewEventsByDateUniqueUserCohort = Readonly<{
   returningReviewingUsers: number;
 }>;
 
-export type ReviewEventsByDateFriendInvitationTotal = Readonly<{
-  date: string;
-  friendInvitationCount: number;
-}>;
-
-export type ReviewEventsByDateFriendshipTotal = Readonly<{
-  date: string;
-  friendshipCount: number;
-}>;
-
 export type ReviewEventsByDatePlatformActiveUserTotal = Readonly<{
   date: string;
   platform: ReviewEventPlatform;
@@ -108,8 +98,6 @@ export type ReviewEventsByDateReport = Readonly<{
   communityOnlyUsers: ReadonlyArray<ReviewEventsByDateUser>;
   dateTotals: ReadonlyArray<ReviewEventsByDateTotal>;
   dailyUniqueUserCohorts: ReadonlyArray<ReviewEventsByDateUniqueUserCohort>;
-  friendInvitationTotals: ReadonlyArray<ReviewEventsByDateFriendInvitationTotal>;
-  friendshipTotals: ReadonlyArray<ReviewEventsByDateFriendshipTotal>;
   platformActiveUserTotals: ReadonlyArray<ReviewEventsByDatePlatformActiveUserTotal>;
   platformReviewEventTotals: ReadonlyArray<ReviewEventsByDatePlatformReviewEventTotal>;
   rows: ReadonlyArray<ReviewEventsByDateRow>;

--- a/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
@@ -173,16 +173,29 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
       svgElement: friendInvitationsSvgElement,
       dates: props.chartModel.dates,
       tickDates: props.chartModel.tickDates,
-      friendInvitationCounts: props.chartModel.friendInvitationCounts,
+      friendInvitationUserMatrix: props.chartModel.friendInvitationUserMatrix,
+      friendInvitationUserIds: props.chartModel.friendInvitationUserIds,
+      userColorScale: props.chartModel.userColorScale,
+      userById: props.userById,
+      totalFriendInvitationsByDate: props.chartModel.totalFriendInvitationsByDate,
+      friendInvitationTotalsByUserId: props.chartModel.friendInvitationTotalsByUserId,
       peakDailyFriendInvitations: props.chartModel.peakDailyFriendInvitations,
+      isReportLoading: props.isReportLoading,
+      onUserFilterApply: handleUserFilterApply,
       tooltipHandlers,
     });
     renderDailyFriendshipsChart({
       svgElement: friendshipsSvgElement,
       dates: props.chartModel.dates,
       tickDates: props.chartModel.tickDates,
-      friendshipCounts: props.chartModel.friendshipCounts,
+      friendshipUserMatrix: props.chartModel.friendshipUserMatrix,
+      friendshipUserIds: props.chartModel.friendshipUserIds,
+      userColorScale: props.chartModel.userColorScale,
+      userById: props.userById,
+      totalFriendshipsByDate: props.chartModel.totalFriendshipsByDate,
       peakDailyFriendships: props.chartModel.peakDailyFriendships,
+      isReportLoading: props.isReportLoading,
+      onUserFilterApply: handleUserFilterApply,
       tooltipHandlers,
     });
   }, [
@@ -247,7 +260,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
           <div className="chart-meta">
             <span>Friend invite links created</span>
             <div className="chart-meta-right">
-              <span>Follows all active filters</span>
+              <span>Stacked by user &mdash; follows all active filters</span>
             </div>
           </div>
           <div className="chart-scroll">
@@ -259,7 +272,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
           <div className="chart-meta">
             <span>Existing friend connections by day</span>
             <div className="chart-meta-right">
-              <span>Per-user connections - follows all active filters</span>
+              <span>Stacked by user &mdash; follows all active filters</span>
             </div>
           </div>
           <div className="chart-scroll">

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
@@ -4,8 +4,7 @@ import {
   reviewEventPlatforms,
   type ReviewEventCohort,
   type ReviewEventPlatform,
-  type ReviewEventsByDateFriendInvitationTotal,
-  type ReviewEventsByDateFriendshipTotal,
+  type ReviewEventsByDateCommunityRow,
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUniqueUserCohort,
   type ReviewEventsByDateUser,
@@ -18,7 +17,7 @@ export type ChartTooltipState = Readonly<{
   top: number;
 }>;
 
-export type DailyValueEntry = Readonly<{
+type DailyValueEntry = Readonly<{
   date: string;
   value: number;
 }>;
@@ -48,14 +47,19 @@ export type ReviewEventsByDateChartModel = Readonly<{
   userIds: ReadonlyArray<string>;
   userColorScale: d3.ScaleOrdinal<string, string>;
   dailyUniqueUserCohortMatrix: ReadonlyArray<MatrixChartEntry>;
-  friendInvitationCounts: ReadonlyArray<DailyValueEntry>;
-  friendshipCounts: ReadonlyArray<DailyValueEntry>;
+  friendInvitationUserIds: ReadonlyArray<string>;
+  friendshipUserIds: ReadonlyArray<string>;
+  friendInvitationUserMatrix: ReadonlyArray<MatrixChartEntry>;
+  friendshipUserMatrix: ReadonlyArray<MatrixChartEntry>;
+  friendInvitationTotalsByUserId: ReadonlyMap<string, number>;
   userMatrix: ReadonlyArray<MatrixChartEntry>;
   platformActiveUsersMatrix: ReadonlyArray<MatrixChartEntry>;
   platformReviewEventsMatrix: ReadonlyArray<MatrixChartEntry>;
   totalReviewEventsByDate: ReadonlyMap<string, number>;
   dailyUniqueUsersByDate: ReadonlyMap<string, number>;
   totalPlatformReviewEventsByDate: ReadonlyMap<string, number>;
+  totalFriendInvitationsByDate: ReadonlyMap<string, number>;
+  totalFriendshipsByDate: ReadonlyMap<string, number>;
   peakDailyUniqueUsers: number;
   peakDailyFriendInvitations: number;
   peakDailyFriendships: number;
@@ -94,11 +98,6 @@ export const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string
   new: "#2e6f95",
 };
 
-export const communityMetricColors = {
-  friendInvitations: "#76b7b2",
-  friendships: "#edc948",
-} as const;
-
 const userColorPalette: ReadonlyArray<string> = [
   ...d3.schemeTableau10,
   ...d3.schemeSet2,
@@ -123,8 +122,26 @@ export function buildReviewEventsByDateChartModel(
     date: item.date,
     value: item.newReviewingUsers + item.returningReviewingUsers,
   }));
-  const friendInvitationCounts = buildFriendInvitationCounts(report.friendInvitationTotals);
-  const friendshipCounts = buildFriendshipCounts(report.friendshipTotals);
+  const friendInvitationTotalsByUserId = buildCommunityTotalsByUserId(
+    report.communityRows,
+    (row) => row.friendInvitationCount,
+  );
+  const friendshipTotalsByUserId = buildCommunityTotalsByUserId(
+    report.communityRows,
+    (row) => row.friendshipCount,
+  );
+  const friendInvitationUserIds = buildCommunityUserIds(friendInvitationTotalsByUserId);
+  const friendshipUserIds = buildCommunityUserIds(friendshipTotalsByUserId);
+  const friendInvitationUserMatrix = buildCommunityUserMatrix(
+    report.communityRows,
+    (row) => row.friendInvitationCount,
+    dates,
+  );
+  const friendshipUserMatrix = buildCommunityUserMatrix(
+    report.communityRows,
+    (row) => row.friendshipCount,
+    dates,
+  );
   const userMatrix = buildUserMatrix(report);
   const platformActiveUsersMatrix = buildPlatformMatrix(
     report.platformActiveUserTotals,
@@ -139,9 +156,11 @@ export function buildReviewEventsByDateChartModel(
   const totalReviewEventsByDate = new Map(report.dateTotals.map((item) => [item.date, item.totalReviewEvents]));
   const dailyUniqueUsersByDate = new Map(dailyUniqueUserTotals.map((item) => [item.date, item.value]));
   const totalPlatformReviewEventsByDate = buildTotalsByDate(platformReviewEventsMatrix);
+  const totalFriendInvitationsByDate = buildTotalsByDate(friendInvitationUserMatrix);
+  const totalFriendshipsByDate = buildTotalsByDate(friendshipUserMatrix);
   const peakDailyUniqueUsers = getPeakDailyValue(dailyUniqueUserTotals);
-  const peakDailyFriendInvitations = getPeakDailyValue(friendInvitationCounts);
-  const peakDailyFriendships = getPeakDailyValue(friendshipCounts);
+  const peakDailyFriendInvitations = getPeakStackedValue(friendInvitationUserMatrix);
+  const peakDailyFriendships = getPeakStackedValue(friendshipUserMatrix);
   const peakDailyVolume = d3.max(report.dateTotals, (item) => item.totalReviewEvents) ?? 0;
   const peakDailyPlatformUsers = getPeakGroupedValue(platformActiveUsersMatrix);
   const peakDailyPlatformReviewEvents = getPeakStackedValue(platformReviewEventsMatrix);
@@ -152,14 +171,19 @@ export function buildReviewEventsByDateChartModel(
     userIds,
     userColorScale,
     dailyUniqueUserCohortMatrix,
-    friendInvitationCounts,
-    friendshipCounts,
+    friendInvitationUserIds,
+    friendshipUserIds,
+    friendInvitationUserMatrix,
+    friendshipUserMatrix,
+    friendInvitationTotalsByUserId,
     userMatrix,
     platformActiveUsersMatrix,
     platformReviewEventsMatrix,
     totalReviewEventsByDate,
     dailyUniqueUsersByDate,
     totalPlatformReviewEventsByDate,
+    totalFriendInvitationsByDate,
+    totalFriendshipsByDate,
     peakDailyUniqueUsers,
     peakDailyFriendInvitations,
     peakDailyFriendships,
@@ -189,21 +213,49 @@ function buildDailyUniqueUserCohortMatrix(
   }));
 }
 
-function buildFriendInvitationCounts(
-  totals: ReadonlyArray<ReviewEventsByDateFriendInvitationTotal>,
-): ReadonlyArray<DailyValueEntry> {
-  return totals.map((total) => ({
-    date: total.date,
-    value: total.friendInvitationCount,
-  }));
+function buildCommunityTotalsByUserId(
+  communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
+  getValue: (row: ReviewEventsByDateCommunityRow) => number,
+): ReadonlyMap<string, number> {
+  const totalsByUserId = new Map<string, number>();
+
+  for (const row of communityRows) {
+    totalsByUserId.set(row.userId, (totalsByUserId.get(row.userId) ?? 0) + getValue(row));
+  }
+
+  return totalsByUserId;
 }
 
-function buildFriendshipCounts(
-  totals: ReadonlyArray<ReviewEventsByDateFriendshipTotal>,
-): ReadonlyArray<DailyValueEntry> {
-  return totals.map((total) => ({
-    date: total.date,
-    value: total.friendshipCount,
+/** Stack keys for a community chart, ordered by range total so the largest contributors sit at the bottom. */
+function buildCommunityUserIds(totalsByUserId: ReadonlyMap<string, number>): ReadonlyArray<string> {
+  return Array.from(totalsByUserId.entries())
+    .filter(([, total]) => total > 0)
+    .sort(([leftUserId, leftTotal], [rightUserId, rightTotal]) => {
+      if (rightTotal !== leftTotal) {
+        return rightTotal - leftTotal;
+      }
+
+      return leftUserId.localeCompare(rightUserId);
+    })
+    .map(([userId]) => userId);
+}
+
+function buildCommunityUserMatrix(
+  communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
+  getValue: (row: ReviewEventsByDateCommunityRow) => number,
+  dates: ReadonlyArray<string>,
+): ReadonlyArray<MatrixChartEntry> {
+  const valuesByDate = new Map<string, Record<string, number>>();
+
+  for (const row of communityRows) {
+    const currentValues = valuesByDate.get(row.date) ?? {};
+    currentValues[row.userId] = (currentValues[row.userId] ?? 0) + getValue(row);
+    valuesByDate.set(row.date, currentValues);
+  }
+
+  return dates.map((date) => ({
+    date,
+    valuesByKey: valuesByDate.get(date) ?? {},
   }));
 }
 

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
@@ -7,7 +7,6 @@ import {
 import {
   chartMargin,
   chartWidth,
-  communityMetricColors,
   getPlatformColor,
   platformLabels,
   simpleChartHeight,
@@ -15,7 +14,6 @@ import {
   uniqueUserCohortColors,
   uniqueUserCohortKeys,
   uniqueUserCohortLabels,
-  type DailyValueEntry,
   type GroupedChartRectEntry,
   type MatrixChartEntry,
   type StackedChartRectEntry,
@@ -37,16 +35,21 @@ type ChartTooltipHandlers = Readonly<{
   hideTooltip: () => void;
 }>;
 
-type RenderDailyValueBarChartParams = Readonly<{
+type UserStackedBarChartParams = Readonly<{
   svgElement: SVGSVGElement;
   dates: ReadonlyArray<string>;
   tickDates: ReadonlyArray<string>;
-  values: ReadonlyArray<DailyValueEntry>;
-  peakValue: number;
-  color: string;
+  userMatrix: ReadonlyArray<MatrixChartEntry>;
+  userIds: ReadonlyArray<string>;
+  userColorScale: d3.ScaleOrdinal<string, string>;
+  userById: ReadonlyMap<string, ReviewEventsByDateUser>;
+  peakStackedValue: number;
   yAxisLabel: string;
-  tooltipSubtitle: string;
-  tooltipMetricLabel: string;
+  xAxisLabel: string;
+  segmentClass: string;
+  buildTooltipMetricsHtml: (entry: StackedChartRectEntry, user: ReviewEventsByDateUser) => string;
+  isReportLoading: boolean;
+  onUserFilterApply: (userId: string) => void;
   tooltipHandlers: ChartTooltipHandlers;
 }>;
 
@@ -80,8 +83,15 @@ export type RenderDailyFriendInvitationsChartParams = Readonly<{
   svgElement: SVGSVGElement;
   dates: ReadonlyArray<string>;
   tickDates: ReadonlyArray<string>;
-  friendInvitationCounts: ReadonlyArray<DailyValueEntry>;
+  friendInvitationUserMatrix: ReadonlyArray<MatrixChartEntry>;
+  friendInvitationUserIds: ReadonlyArray<string>;
+  userColorScale: d3.ScaleOrdinal<string, string>;
+  userById: ReadonlyMap<string, ReviewEventsByDateUser>;
+  totalFriendInvitationsByDate: ReadonlyMap<string, number>;
+  friendInvitationTotalsByUserId: ReadonlyMap<string, number>;
   peakDailyFriendInvitations: number;
+  isReportLoading: boolean;
+  onUserFilterApply: (userId: string) => void;
   tooltipHandlers: ChartTooltipHandlers;
 }>;
 
@@ -89,8 +99,14 @@ export type RenderDailyFriendshipsChartParams = Readonly<{
   svgElement: SVGSVGElement;
   dates: ReadonlyArray<string>;
   tickDates: ReadonlyArray<string>;
-  friendshipCounts: ReadonlyArray<DailyValueEntry>;
+  friendshipUserMatrix: ReadonlyArray<MatrixChartEntry>;
+  friendshipUserIds: ReadonlyArray<string>;
+  userColorScale: d3.ScaleOrdinal<string, string>;
+  userById: ReadonlyMap<string, ReviewEventsByDateUser>;
+  totalFriendshipsByDate: ReadonlyMap<string, number>;
   peakDailyFriendships: number;
+  isReportLoading: boolean;
+  onUserFilterApply: (userId: string) => void;
   tooltipHandlers: ChartTooltipHandlers;
 }>;
 
@@ -203,47 +219,71 @@ function renderChartFrame(
   return group;
 }
 
-function renderDailyValueBarChart(params: RenderDailyValueBarChartParams): void {
+function renderUserStackedBarChart(params: UserStackedBarChartParams): void {
   const svg = d3.select(params.svgElement);
   const x = createDateScale(params.dates);
-  const innerHeight = getInnerHeight(simpleChartHeight);
+  const innerHeight = getInnerHeight(stackedChartHeight);
   const y = d3.scaleLinear()
-    .domain([0, Math.max(1, params.peakValue)])
+    .domain([0, Math.max(1, params.peakStackedValue)])
     .nice()
     .range([innerHeight, 0]);
   const group = renderChartFrame(svg, {
-    chartHeight: simpleChartHeight,
+    chartHeight: stackedChartHeight,
     x,
     y,
     tickDates: params.tickDates,
     yAxisLabel: params.yAxisLabel,
-    xAxisLabel: "Date",
+    xAxisLabel: params.xAxisLabel,
   });
-
-  group.selectAll<SVGRectElement, DailyValueEntry>(".bar-segment")
-    .data(params.values.filter((entry) => entry.value > 0))
+  const series = d3.stack<MatrixChartEntry>()
+    .keys(params.userIds)
+    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.userMatrix);
+  const bars = group.selectAll(".series")
+    .data(series)
+    .join("g")
+    .attr("class", "series")
+    .attr("fill", (segment) => params.userColorScale(segment.key))
+    .selectAll("rect")
+    .data((segment) => segment.map((entry) => ({
+      key: segment.key,
+      date: entry.data.date,
+      y0: entry[0],
+      y1: entry[1],
+      value: entry.data.valuesByKey[segment.key] ?? 0,
+    })).filter((entry) => entry.value > 0))
     .join("rect")
-    .attr("class", "bar-segment")
-    .attr("fill", params.color)
+    .attr("class", `bar-segment ${params.segmentClass}${params.isReportLoading ? "" : " clickable"}`)
     .attr("x", (entry) => x(entry.date) ?? 0)
-    .attr("y", (entry) => y(entry.value))
+    .attr("y", (entry) => y(entry.y1))
     .attr("width", x.bandwidth())
-    .attr("height", (entry) => Math.max(0, innerHeight - y(entry.value)))
-    .attr("rx", 3)
-    .attr("stroke", "rgba(255, 255, 255, 0.18)")
-    .attr("stroke-width", 1)
-    .on("mousemove", (event, entry: DailyValueEntry) => {
+    .attr("height", (entry) => Math.max(0, y(entry.y0) - y(entry.y1)))
+    .attr("rx", 2)
+    .on("mousemove", (event, entry: StackedChartRectEntry) => {
+      const user = params.userById.get(entry.key);
+      if (user === undefined) {
+        return;
+      }
+
       params.tooltipHandlers.showTooltip(
         [
           `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-          `<p class="tooltip-subtitle">${escapeHtml(params.tooltipSubtitle)}</p>`,
-          `<div class="tooltip-metric"><span>${escapeHtml(params.tooltipMetricLabel)}</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+          `<p class="tooltip-user-primary">${escapeHtml(user.email)}</p>`,
+          `<p class="tooltip-user-secondary">${escapeHtml(user.userId)}</p>`,
+          params.buildTooltipMetricsHtml(entry, user),
         ].join(""),
         event.clientX,
         event.clientY,
       );
     })
     .on("mouseleave", params.tooltipHandlers.hideTooltip);
+
+  if (params.isReportLoading === false) {
+    bars.on("click", (_event: MouseEvent, entry: StackedChartRectEntry) => {
+      params.onUserFilterApply(entry.key);
+    });
+  } else {
+    bars.on("click", null);
+  }
 }
 
 export function renderDailyUniqueUsersChart(params: RenderDailyUniqueUsersChartParams): void {
@@ -307,100 +347,73 @@ export function renderDailyUniqueUsersChart(params: RenderDailyUniqueUsersChartP
 }
 
 export function renderUserReviewEventsChart(params: RenderUserReviewEventsChartParams): void {
-  const svg = d3.select(params.svgElement);
-  const x = createDateScale(params.dates);
-  const innerHeight = getInnerHeight(stackedChartHeight);
-  const y = d3.scaleLinear()
-    .domain([0, Math.max(1, params.peakDailyVolume)])
-    .nice()
-    .range([innerHeight, 0]);
-  const group = renderChartFrame(svg, {
-    chartHeight: stackedChartHeight,
-    x,
-    y,
-    tickDates: params.tickDates,
-    yAxisLabel: "Review events",
-    xAxisLabel: "Review date",
-  });
-  const series = d3.stack<MatrixChartEntry>()
-    .keys(params.userIds)
-    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.userMatrix);
-  const bars = group.selectAll(".series")
-    .data(series)
-    .join("g")
-    .attr("class", "series")
-    .attr("fill", (segment) => params.userColorScale(segment.key))
-    .selectAll("rect")
-    .data((segment) => segment.map((entry) => ({
-      key: segment.key,
-      date: entry.data.date,
-      y0: entry[0],
-      y1: entry[1],
-      value: entry.data.valuesByKey[segment.key] ?? 0,
-    })).filter((entry) => entry.value > 0))
-    .join("rect")
-    .attr("class", `bar-segment user-review-events${params.isReportLoading ? "" : " clickable"}`)
-    .attr("x", (entry) => x(entry.date) ?? 0)
-    .attr("y", (entry) => y(entry.y1))
-    .attr("width", x.bandwidth())
-    .attr("height", (entry) => Math.max(0, y(entry.y0) - y(entry.y1)))
-    .attr("rx", 2)
-    .on("mousemove", (event, entry: StackedChartRectEntry) => {
-      const user = params.userById.get(entry.key);
-      if (user === undefined) {
-        return;
-      }
-
-      params.tooltipHandlers.showTooltip(
-        [
-          `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-          `<p class="tooltip-user-primary">${escapeHtml(user.email)}</p>`,
-          `<p class="tooltip-user-secondary">${escapeHtml(user.userId)}</p>`,
-          `<div class="tooltip-metric"><span>User review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
-          `<div class="tooltip-metric"><span>Total on this date</span><strong>${numberFormatter(params.totalReviewEventsByDate.get(entry.date) ?? entry.value)}</strong></div>`,
-          `<div class="tooltip-metric"><span>User total</span><strong>${numberFormatter(user.totalReviewEvents)}</strong></div>`,
-        ].join(""),
-        event.clientX,
-        event.clientY,
-      );
-    })
-    .on("mouseleave", params.tooltipHandlers.hideTooltip);
-
-  if (params.isReportLoading === false) {
-    bars.on("click", (_event: MouseEvent, entry: StackedChartRectEntry) => {
-      params.onUserFilterApply(entry.key);
-    });
-  } else {
-    bars.on("click", null);
-  }
-}
-
-export function renderDailyFriendInvitationsChart(params: RenderDailyFriendInvitationsChartParams): void {
-  renderDailyValueBarChart({
+  renderUserStackedBarChart({
     svgElement: params.svgElement,
     dates: params.dates,
     tickDates: params.tickDates,
-    values: params.friendInvitationCounts,
-    peakValue: params.peakDailyFriendInvitations,
-    color: communityMetricColors.friendInvitations,
-    yAxisLabel: "Invite links",
-    tooltipSubtitle: "Invite links",
-    tooltipMetricLabel: "Created invite links",
+    userMatrix: params.userMatrix,
+    userIds: params.userIds,
+    userColorScale: params.userColorScale,
+    userById: params.userById,
+    peakStackedValue: params.peakDailyVolume,
+    yAxisLabel: "Review events",
+    xAxisLabel: "Review date",
+    segmentClass: "user-review-events",
+    buildTooltipMetricsHtml: (entry, user) => [
+      `<div class="tooltip-metric"><span>User review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>Total on this date</span><strong>${numberFormatter(params.totalReviewEventsByDate.get(entry.date) ?? entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>User total</span><strong>${numberFormatter(user.totalReviewEvents)}</strong></div>`,
+    ].join(""),
+    isReportLoading: params.isReportLoading,
+    onUserFilterApply: params.onUserFilterApply,
     tooltipHandlers: params.tooltipHandlers,
   });
 }
 
-export function renderDailyFriendshipsChart(params: RenderDailyFriendshipsChartParams): void {
-  renderDailyValueBarChart({
+export function renderDailyFriendInvitationsChart(params: RenderDailyFriendInvitationsChartParams): void {
+  renderUserStackedBarChart({
     svgElement: params.svgElement,
     dates: params.dates,
     tickDates: params.tickDates,
-    values: params.friendshipCounts,
-    peakValue: params.peakDailyFriendships,
-    color: communityMetricColors.friendships,
+    userMatrix: params.friendInvitationUserMatrix,
+    userIds: params.friendInvitationUserIds,
+    userColorScale: params.userColorScale,
+    userById: params.userById,
+    peakStackedValue: params.peakDailyFriendInvitations,
+    yAxisLabel: "Invite links",
+    xAxisLabel: "Date",
+    segmentClass: "friend-invitations",
+    buildTooltipMetricsHtml: (entry, user) => [
+      `<div class="tooltip-metric"><span>User invite links</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>Total on this date</span><strong>${numberFormatter(params.totalFriendInvitationsByDate.get(entry.date) ?? entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>User total</span><strong>${numberFormatter(params.friendInvitationTotalsByUserId.get(user.userId) ?? entry.value)}</strong></div>`,
+    ].join(""),
+    isReportLoading: params.isReportLoading,
+    onUserFilterApply: params.onUserFilterApply,
+    tooltipHandlers: params.tooltipHandlers,
+  });
+}
+
+// Friend connections are an end-of-day snapshot per user, so there is no meaningful range total to show.
+export function renderDailyFriendshipsChart(params: RenderDailyFriendshipsChartParams): void {
+  renderUserStackedBarChart({
+    svgElement: params.svgElement,
+    dates: params.dates,
+    tickDates: params.tickDates,
+    userMatrix: params.friendshipUserMatrix,
+    userIds: params.friendshipUserIds,
+    userColorScale: params.userColorScale,
+    userById: params.userById,
+    peakStackedValue: params.peakDailyFriendships,
     yAxisLabel: "Connections",
-    tooltipSubtitle: "Friend connections",
-    tooltipMetricLabel: "Per-user connections at end of day",
+    xAxisLabel: "Date",
+    segmentClass: "friend-connections",
+    buildTooltipMetricsHtml: (entry) => [
+      `<div class="tooltip-metric"><span>User connections at end of day</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>Total on this date</span><strong>${numberFormatter(params.totalFriendshipsByDate.get(entry.date) ?? entry.value)}</strong></div>`,
+    ].join(""),
+    isReportLoading: params.isReportLoading,
+    onUserFilterApply: params.onUserFilterApply,
     tooltipHandlers: params.tooltipHandlers,
   });
 }

--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -9,8 +9,6 @@ import type {
   ReviewEventCohort,
   ReviewEventPlatform,
   ReviewEventsByDateCommunityRow,
-  ReviewEventsByDateFriendInvitationTotal,
-  ReviewEventsByDateFriendshipTotal,
   ReviewEventsByDatePlatformActiveUserTotal,
   ReviewEventsByDatePlatformReviewEventTotal,
   ReviewEventsByDateReport,
@@ -63,11 +61,6 @@ type ReviewEventsByDateAggregateFields = Readonly<Pick<
   | "dailyUniqueUserCohorts"
   | "platformActiveUserTotals"
   | "platformReviewEventTotals"
->>;
-
-type ReviewEventsByDateCommunityAggregateFields = Readonly<Pick<
-  ReviewEventsByDateReport,
-  "friendInvitationTotals" | "friendshipTotals"
 >>;
 
 function parseCalendarDate(date: string): Date {
@@ -306,38 +299,6 @@ function assertCommunityRowsInRange(
   }
 }
 
-function buildFriendInvitationTotals(
-  rows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
-  dates: ReadonlyArray<string>,
-): ReadonlyArray<ReviewEventsByDateFriendInvitationTotal> {
-  const countsByDate = new Map<string, number>();
-
-  for (const row of rows) {
-    countsByDate.set(row.date, (countsByDate.get(row.date) ?? 0) + row.friendInvitationCount);
-  }
-
-  return dates.map((date) => ({
-    date,
-    friendInvitationCount: countsByDate.get(date) ?? 0,
-  }));
-}
-
-function buildFriendshipTotals(
-  rows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
-  dates: ReadonlyArray<string>,
-): ReadonlyArray<ReviewEventsByDateFriendshipTotal> {
-  const countsByDate = new Map<string, number>();
-
-  for (const row of rows) {
-    countsByDate.set(row.date, (countsByDate.get(row.date) ?? 0) + row.friendshipCount);
-  }
-
-  return dates.map((date) => ({
-    date,
-    friendshipCount: countsByDate.get(date) ?? 0,
-  }));
-}
-
 function buildCommunityOnlyUsers(
   communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
   reviewUsers: ReadonlyArray<ReviewEventsByDateUser>,
@@ -362,16 +323,6 @@ function buildCommunityOnlyUsers(
     const rightLabel = right.email === "(no email)" ? right.userId : right.email;
     return leftLabel.localeCompare(rightLabel);
   });
-}
-
-function buildReviewEventsByDateCommunityAggregateFields(
-  communityRows: ReadonlyArray<ReviewEventsByDateCommunityRow>,
-  dates: ReadonlyArray<string>,
-): ReviewEventsByDateCommunityAggregateFields {
-  return {
-    friendInvitationTotals: buildFriendInvitationTotals(communityRows, dates),
-    friendshipTotals: buildFriendshipTotals(communityRows, dates),
-  };
 }
 
 function buildReviewEventsByDateAggregateFields(
@@ -447,7 +398,6 @@ function buildReviewEventsByDateReport(
     to,
     ...aggregateFields,
     communityOnlyUsers: buildCommunityOnlyUsers(communityRows, aggregateFields.users),
-    ...buildReviewEventsByDateCommunityAggregateFields(communityRows, dates),
     rows,
     communityRows,
   };
@@ -531,7 +481,6 @@ export function filterReviewEventsByDateReport(
     rows,
     communityRows,
     ...aggregateFields,
-    ...buildReviewEventsByDateCommunityAggregateFields(communityRows, dates),
   };
 }
 

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -717,7 +717,7 @@ h2 {
   opacity: 0.82;
 }
 
-.bar-segment.user-review-events.clickable {
+.bar-segment.clickable {
   cursor: pointer;
 }
 

--- a/docs/admin-app.md
+++ b/docs/admin-app.md
@@ -72,8 +72,8 @@ Current v1 attribution contract for `review-events-by-date`:
 - dashboard filters can narrow date range, user, new/returning cohort, and platform; all four filters apply to every chart, including the community charts, where a cohort or platform filter keeps community rows only for users that still have review events in range, and the user filter list also offers users with community activity but no review events in range; Reset all returns date range to the same first-activity-day-through-today default and restores all local filters
 - `users[]` and `rows[].userId` are derived from the current `sync.workspace_replicas.user_id` label for stacked per-user event volume
 - platform charts derive `web` / `android` / `ios` from `content.review_events.replica_id -> sync.workspace_replicas.platform`
-- friend invite charts count `community.friend_invitations` rows created on each UTC date, attributed per user to `community.friend_invitations.inviter_user_id`
-- friend connection charts count directed `community.friendships` rows per `viewer_user_id` that exist at the end of each UTC date, so the all-user sum is intentionally twice the number of friendship pairs
+- friend invite charts count `community.friend_invitations` rows created on each UTC date, attributed per user to `community.friend_invitations.inviter_user_id`, and stack those per-user counts with the same per-user colors as the review-events chart
+- friend connection charts count directed `community.friendships` rows per `viewer_user_id` that exist at the end of each UTC date and stack them per user, so the all-user column is intentionally twice the number of friendship pairs
 - that label is acceptable for today's product shape, but it is not a durable historical review-author field
 - do not interpret this report as collaborative per-user analytics unless review authorship is stored immutably on each review event
 
@@ -150,5 +150,5 @@ The admin frontend fails fast on any other non-local hostname. Do not serve the 
 - the dashboard does not show a persistent email or user list outside the user filter popup
 - unique-users, stacked-by-user, platform-users, platform-events, friend-invite-links, and friend-connections charts all render
 - narrowing the date filter reloads all charts, and Reset all restores the default range and all local filters
-- stacked-by-user hover tooltips may reveal the current email and user ID for the hovered segment
+- hover tooltips on the per-user stacked charts (review events, friend invite links, friend connections) may reveal the current email and user ID for the hovered segment, and clicking a segment applies that user filter
 - backend logs do not show writes through the reporting path


### PR DESCRIPTION
Follow-up to #1528 on the same integration branch. That PR made the two community metrics per-user and filter-aware; this one draws them that way.

## What changes

- "Friend invite links created" and "Existing friend connections by day" render as per-user stacked bars, reusing the same `userColorScale` as "Stacked review events by user", so a user keeps one colour across all three per-user charts.
- Tooltips show the user's email and user id, their value on that date, and the all-user total for that date. The invite chart also shows the user's range total; the connections chart deliberately omits it, because a cumulative end-of-day snapshot has no meaningful total across dates.
- Clicking a segment applies the user filter, gated on report loading exactly like the review-events chart. The pointer-cursor rule in `styles.css` is widened from `.bar-segment.user-review-events.clickable` to `.bar-segment.clickable`; no other chart emits `clickable`.
- Stack keys are derived from the filtered `communityRows` only, never from `communityOnlyUsers`, which is deliberately not narrowed by the active filters.
- The three per-user charts now share one private stacked renderer. The review-events chart's classes, axis labels, tooltip rows and click gating are unchanged.
- The `friendInvitationTotals` / `friendshipTotals` daily aggregations are removed from the report, its types and both builders: nothing consumes them once the charts read `communityRows`.
- `apps/admin/README.md` and the `review-events-by-date` contract in `docs/admin-app.md` describe the stacked-by-user rendering.

## Scope

Base is the integration branch `feature/admin-community-charts-by-user`, not `main`. This is the last item of the queue; the branch is then promoted to `main` as one feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)