### PR TITLE
Fix iOS test target reference to removed strings table constant

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/Progress/SnapshotFactory/ProgressSnapshotFactoryTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/SnapshotFactory/ProgressSnapshotFactoryTestSupport.swift
@@ -179,7 +179,7 @@ func expectedProgressSnapshotFactoryLeaderboardUpdatedText(elapsedText: String) 
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at",
         defaultValue: "Updated %@ ago",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness text with localized elapsed time"
     )
     return String(format: localizedFormat, locale: Locale.current, elapsedText)
@@ -190,7 +190,7 @@ func expectedProgressSnapshotFactoryLeaderboardElapsedHourText(hours: Int64) -> 
         return String(
             localized: "progress.screen.leaderboard.updated_at.hour.one",
             defaultValue: "1 hour",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard freshness singular elapsed hour"
         )
     }
@@ -198,7 +198,7 @@ func expectedProgressSnapshotFactoryLeaderboardElapsedHourText(hours: Int64) -> 
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at.hour.other",
         defaultValue: "%lld hours",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness plural elapsed hours"
     )
     return String(format: localizedFormat, locale: Locale.current, hours)
@@ -209,7 +209,7 @@ func expectedProgressSnapshotFactoryLeaderboardElapsedMinuteText(minutes: Int64)
         return String(
             localized: "progress.screen.leaderboard.updated_at.minute.one",
             defaultValue: "1 minute",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard freshness singular elapsed minute"
         )
     }
@@ -217,7 +217,7 @@ func expectedProgressSnapshotFactoryLeaderboardElapsedMinuteText(minutes: Int64)
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at.minute.other",
         defaultValue: "%lld minutes",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness plural elapsed minutes"
     )
     return String(format: localizedFormat, locale: Locale.current, minutes)
@@ -230,7 +230,7 @@ func expectedProgressSnapshotFactoryLeaderboardElapsedHoursMinutesText(
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at.elapsed.hours_minutes",
         defaultValue: "%1$@ %2$@",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness elapsed time with hours and remaining minutes"
     )
     return String(


### PR DESCRIPTION
## Problem

Xcode Cloud `Test - iOS` build 567 failed to compile the `Flashcards Open Source App Tests` target with six errors:

```
Cannot find 'progressStringsTableName' in scope
ProgressSnapshotFactoryTestSupport.swift:182, 193, 201, 212, 220, 233
```

Commit `ad05b4c31` ("Make Foundation table extraction static") deleted `let progressStringsTableName: String = "Foundation"` from `ProgressFormatting.swift` and inlined `table: "Foundation"` across every app-code call site, but did not update the test target. Nothing compiles iOS before merge by design, so the break only appeared in Xcode Cloud after merge.

## Change

Inline the same `"Foundation"` literal at the six test call sites, matching the convention the app code and `docs/ios-localization.md` already use.

## Risk

None to runtime behavior. `"Foundation"` is the exact value the deleted constant held, and each edited call site's key, `defaultValue`, and `comment` match its app-side counterpart in `ProgressFormatting.swift` verbatim, so localized output is unchanged. `progressStringsTableName` no longer appears anywhere in the repository.

## Testing

Static review only. Per repository rules no `xcodebuild`, simulator, or Gradle run was performed locally; Xcode Cloud `Test - iOS` owns compilation of this target and is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)