### PR TITLE
Persist the cleared AI chat state when starting a new chat

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
@@ -117,6 +117,7 @@ extension AIChatStore {
             inputText: inputText,
             pendingAttachments: pendingAttachments
         )
+        self.persistStateSynchronously(state: self.currentPersistedState())
     }
 
     func clearLocalHistory() {


### PR DESCRIPTION
## Problem

`startFreshLocalSession` — the path the toolbar **New** button reaches via `clearHistory()` — only *scheduled* a debounced, off-main persist of the cleared conversation. Its sibling `startFreshLocalDraftSession`, two functions above it in the same file, already persists synchronously.

That asymmetry is a real race: `activateAccessContext(force: true)` calls `historyStore.loadState()` and then `restorePersistedState(...)`, which assigns `self.messages = persistedState.messages`. If that reload runs before the scheduled persist flushes, the just-cleared conversation is repopulated from stale on-disk state and the reset is silently undone.

## Change

One line: persist the cleared state synchronously at the tail of `startFreshLocalSession`, matching the established sibling idiom.

## Why this is safe

Verified by an independent reviewer against the persist coordinator internals:

- **No double-write.** `persistStateSynchronously` removes the entry `resetConversationForNewSession` just enqueued. `AIChatStore` is `@MainActor` and the drain task yields before dequeuing, so the whole call is one uninterrupted MainActor turn. An in-flight earlier write is suppressed by `saveIfCurrent` version checks.
- **Cheap on all three callers.** `saveStateSynchronously` is `JSONEncoder.encode` + `UserDefaults.set` — no file I/O, no `synchronize()` — and the encoded state here has `messages == []`.
- **Snapshot is correct.** It is taken after `messages = []`, the new `chatSessionId`, and `requiresRemoteSessionProvisioning = true`. The provisioning `Task` is MainActor-isolated so it cannot begin until this turn ends, and its later persist reserves a strictly higher version.

## Relationship to the build 569 smoke failure

`LiveSmokeAiTests.testLiveSmokeGuestAiChatResetFlow()` failed in Xcode Cloud build 569. Three hypotheses remain consistent with that failure and repository evidence cannot discriminate them — this persistence race is one of them, but **this PR does not claim to fix that test**. It ships because the asymmetry between the two sibling reset entry points is a genuine defect on its own merits.

## Testing

Static review only. Per repository rules no `xcodebuild`, simulator, or Gradle run was performed locally; Xcode Cloud `Test - iOS` owns validation of this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)