### PR TITLE
Mark dropped rows structurally on degraded writes

### DIFF
--- a/apps/backend/src/aiTools/agentSql.ts
+++ b/apps/backend/src/aiTools/agentSql.ts
@@ -100,6 +100,19 @@ function measureAgentSqlEnvelopeChars(result: AgentSqlExecutionResult, requestUr
 }
 
 /**
+ * One execution's emitted result paired with the size the budget helpers below
+ * measured for it, so telemetry records the payload the surface really sent
+ * without measuring it a second, possibly different way.
+ *
+ * `resultChars` is null on the in-app chat surface, which builds no agent
+ * envelope and therefore has no emitted envelope to measure.
+ */
+type AgentSqlEmission<Result extends AgentSqlExecutionResult> = Readonly<{
+  result: Result;
+  resultChars: number | null;
+}>;
+
+/**
  * Read-path result-size budget shared by the MCP surface (`sql_query`) and the
  * REST surface (`POST /agent/sql/query`).
  *
@@ -114,17 +127,17 @@ function measureAgentSqlEnvelopeChars(result: AgentSqlExecutionResult, requestUr
 function assertSqlResultWithinSizeBudget<T extends AgentSqlExecutionResult>(
   result: T,
   requestUrl: string,
-): T {
-  const serializedLength = measureAgentSqlEnvelopeChars(result, requestUrl);
-  if (serializedLength > MAX_SQL_RESULT_CHARS) {
+): AgentSqlEmission<T> {
+  const resultChars = measureAgentSqlEnvelopeChars(result, requestUrl);
+  if (resultChars > MAX_SQL_RESULT_CHARS) {
     throw new HttpError(
       400,
-      `The result payload is too large (${serializedLength} characters, limit ${MAX_SQL_RESULT_CHARS}). Narrow the query and retry: add or lower LIMIT, SELECT fewer columns, or add WHERE filters to return fewer or smaller rows.`,
+      `The result payload is too large (${resultChars} characters, limit ${MAX_SQL_RESULT_CHARS}). Narrow the query and retry: add or lower LIMIT, SELECT fewer columns, or add WHERE filters to return fewer or smaller rows.`,
       "QUERY_RESULT_TOO_LARGE",
     );
   }
 
-  return result;
+  return { result, resultChars };
 }
 
 /**
@@ -141,42 +154,74 @@ const OMITTED_MUTATION_ROWS_INSTRUCTION =
  * transaction committed, so answering with `QUERY_RESULT_TOO_LARGE` would report
  * a successful write as a failure and invite the caller to retry it and
  * duplicate the data. Only the returned rows are dropped; the counts, the echoed
- * SQL, and the atomicity contract stay intact.
+ * SQL, and the atomicity contract stay intact, and `data.rowsOmitted` records
+ * the reduction structurally so a model and our telemetry can both read it
+ * without parsing the appended instruction prose.
+ *
+ * The rows are the only thing this reducer can drop, so a write that returned
+ * none, such as a DELETE without a RETURNING clause, is emitted untouched with
+ * `rowsOmitted: false` and a `resultChars` above the budget. The marker and the
+ * appended prose report a reduction that happened, never the budget verdict
+ * that asked for one, so they cannot claim rows the caller never had.
  */
 function reduceMutationResultToSizeBudget(
   result: AgentSqlMutationExecutionResult,
   requestUrl: string,
-): AgentSqlMutationExecutionResult {
-  if (measureAgentSqlEnvelopeChars(result, requestUrl) <= MAX_SQL_RESULT_CHARS) {
-    return result;
+): AgentSqlEmission<AgentSqlMutationExecutionResult> {
+  const resultChars = measureAgentSqlEnvelopeChars(result, requestUrl);
+  const hasRowsToDrop = result.data.rows.length > 0;
+  if (resultChars <= MAX_SQL_RESULT_CHARS || !hasRowsToDrop) {
+    return { result, resultChars };
   }
 
-  return {
+  const reducedResult: AgentSqlMutationExecutionResult = {
     data: {
       ...result.data,
       rows: [],
+      rowsOmitted: true,
     },
     instructions: `${result.instructions} ${OMITTED_MUTATION_ROWS_INSTRUCTION}`,
   };
+
+  return {
+    result: reducedResult,
+    resultChars: measureAgentSqlEnvelopeChars(reducedResult, requestUrl),
+  };
 }
 
+/**
+ * Batch counterpart of the reducer above. The reduction is all-or-nothing: the
+ * budget covers the whole emitted payload, so every statement loses its rows
+ * even when its own rows were small, and the single `data.rowsOmitted` marker
+ * describes exactly that. A batch in which no statement returned a row is
+ * emitted untouched for the same reason the single reducer leaves such a write
+ * alone.
+ */
 function reduceBatchMutationResultToSizeBudget(
   result: AgentSqlBatchExecutionResult,
   requestUrl: string,
-): AgentSqlBatchExecutionResult {
-  if (measureAgentSqlEnvelopeChars(result, requestUrl) <= MAX_SQL_RESULT_CHARS) {
-    return result;
+): AgentSqlEmission<AgentSqlBatchExecutionResult> {
+  const resultChars = measureAgentSqlEnvelopeChars(result, requestUrl);
+  const hasRowsToDrop = result.data.statements.some((statement) => statement.rows.length > 0);
+  if (resultChars <= MAX_SQL_RESULT_CHARS || !hasRowsToDrop) {
+    return { result, resultChars };
   }
 
-  return {
+  const reducedResult: AgentSqlBatchExecutionResult = {
     data: {
       ...result.data,
       statements: result.data.statements.map((statement) => ({
         ...statement,
         rows: [],
       })),
+      rowsOmitted: true,
     },
     instructions: `${result.instructions} ${OMITTED_MUTATION_ROWS_INSTRUCTION}`,
+  };
+
+  return {
+    result: reducedResult,
+    resultChars: measureAgentSqlEnvelopeChars(reducedResult, requestUrl),
   };
 }
 
@@ -203,6 +248,14 @@ function getAgentSqlRowOrAffectedCount(payload: AgentSqlPayload): number {
 
 function getAgentSqlStatementCount(payload: AgentSqlPayload): number {
   return payload.statementType === "batch" ? payload.statementCount : 1;
+}
+
+/**
+ * Reads the payload's own omission marker. Read payloads carry none, and a read
+ * never omits rows: it rejects an oversized result instead.
+ */
+function getAgentSqlRowsOmitted(payload: AgentSqlPayload): boolean {
+  return "rowsOmitted" in payload ? payload.rowsOmitted : false;
 }
 
 function getAgentSqlErrorCode(error: unknown): string | null {
@@ -254,13 +307,17 @@ function getAgentSqlErrorClass(error: unknown): string {
  * reach Sentry with their full message and stack through
  * `captureBackendException`, so nothing debuggable is lost.
  *
+ * `execute` hands over the emitted result together with the size the budget
+ * helpers already measured for it, so `resultChars` is the size of the payload
+ * the surface really sent and can never drift from the size the guard enforces.
+ *
  * Instrumentation only: the caller's result is returned and the caller's error
  * is rethrown untouched.
  */
 async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
   context: AgentSqlContext,
   sql: string,
-  execute: () => Promise<Result>,
+  execute: () => Promise<AgentSqlEmission<Result>>,
 ): Promise<Result> {
   const startedAt = Date.now();
   const executionDetails = {
@@ -274,7 +331,7 @@ async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
   };
 
   try {
-    const result = await execute();
+    const { result, resultChars } = await execute();
     logAgentSqlEvent({
       ...executionDetails,
       succeeded: true,
@@ -282,6 +339,8 @@ async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
       resource: result.data.resource,
       statementCount: getAgentSqlStatementCount(result.data),
       rowOrAffectedCount: getAgentSqlRowOrAffectedCount(result.data),
+      resultChars,
+      rowsOmitted: getAgentSqlRowsOmitted(result.data),
       durationMs: Date.now() - startedAt,
       errorCode: null,
       dialectReason: null,
@@ -297,6 +356,8 @@ async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
       resource: null,
       statementCount: null,
       rowOrAffectedCount: null,
+      resultChars: null,
+      rowsOmitted: null,
       durationMs: Date.now() - startedAt,
       errorCode: getAgentSqlErrorCode(error),
       dialectReason: getAgentSqlDialectReason(error),
@@ -307,33 +368,47 @@ async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
   }
 }
 
+async function executeAgentSqlStatements(
+  dependencies: AgentToolOperationDependencies,
+  context: AgentSqlContext,
+  sql: string,
+): Promise<AgentSqlExecutionResult> {
+  const statements = parseSqlBatch(sql);
+  const statementSqls = toStatementSqls(sql, statements);
+
+  if (statements.every(isSqlReadStatement)) {
+    if (statements.length === 1) {
+      return executeSqlReadStatement(dependencies, context, sql, statements[0]);
+    }
+
+    return executeSqlReadBatch(dependencies, context, sql, statements, statementSqls);
+  }
+
+  if (statements.every(isSqlMutationStatement)) {
+    if (statements.length === 1) {
+      return executeSqlMutationStatement(dependencies, context, sql, statements[0]);
+    }
+
+    return executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls);
+  }
+
+  throw buildInvalidSqlError("SQL batch must contain only read statements or only mutation statements");
+}
+
+/**
+ * Combined entrypoint for the in-app chat `sql` tool. It builds no agent
+ * envelope and has no result-size budget of its own (the chat surface truncates
+ * the tool output separately), so it reports no emitted size.
+ */
 export async function executeAgentSql(
   context: AgentSqlContext,
   sql: string,
   dependencies: AgentToolOperationDependencies = DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
 ) {
-  return withAgentSqlTelemetry(context, sql, async () => {
-    const statements = parseSqlBatch(sql);
-    const statementSqls = toStatementSqls(sql, statements);
-
-    if (statements.every(isSqlReadStatement)) {
-      if (statements.length === 1) {
-        return executeSqlReadStatement(dependencies, context, sql, statements[0]);
-      }
-
-      return executeSqlReadBatch(dependencies, context, sql, statements, statementSqls);
-    }
-
-    if (statements.every(isSqlMutationStatement)) {
-      if (statements.length === 1) {
-        return executeSqlMutationStatement(dependencies, context, sql, statements[0]);
-      }
-
-      return executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls);
-    }
-
-    throw buildInvalidSqlError("SQL batch must contain only read statements or only mutation statements");
-  });
+  return withAgentSqlTelemetry(context, sql, async (): Promise<AgentSqlEmission<AgentSqlExecutionResult>> => ({
+    result: await executeAgentSqlStatements(dependencies, context, sql),
+    resultChars: null,
+  }));
 }
 
 /**
@@ -357,7 +432,7 @@ export async function runSqlQuery(
   requestUrl: string,
   dependencies: AgentToolOperationDependencies = DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
 ) {
-  return withAgentSqlTelemetry(context, sql, async () => {
+  return withAgentSqlTelemetry(context, sql, async (): Promise<AgentSqlEmission<AgentSqlExecutionResult>> => {
     const statements = parseSqlBatch(sql);
     const statementSqls = toStatementSqls(sql, statements);
 
@@ -396,7 +471,7 @@ export async function runSqlExecute(
   requestUrl: string,
   dependencies: AgentToolOperationDependencies = DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
 ) {
-  return withAgentSqlTelemetry(context, sql, async () => {
+  return withAgentSqlTelemetry(context, sql, async (): Promise<AgentSqlEmission<AgentSqlExecutionResult>> => {
     const statements = parseSqlBatch(sql);
     const statementSqls = toStatementSqls(sql, statements);
 

--- a/apps/backend/src/aiTools/agentSql/batchMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.ts
@@ -444,6 +444,7 @@ export async function executeSqlMutationBatch(
         statements: payloads,
         statementCount: payloads.length,
         affectedCountTotal,
+        rowsOmitted: false,
       },
       instructions: buildBatchMutationInstructions(),
     };

--- a/apps/backend/src/aiTools/agentSql/readExecution.ts
+++ b/apps/backend/src/aiTools/agentSql/readExecution.ts
@@ -263,6 +263,7 @@ export async function executeSqlReadBatch(
       statements: payloads,
       statementCount: payloads.length,
       affectedCountTotal: null,
+      rowsOmitted: false,
     },
     instructions: buildBatchReadInstructions(),
   };

--- a/apps/backend/src/aiTools/agentSql/shared.ts
+++ b/apps/backend/src/aiTools/agentSql/shared.ts
@@ -69,9 +69,26 @@ type AgentSqlSubmittedSql = Readonly<{
   normalizedSql: string;
 }>;
 
+/**
+ * Structural record that the returned rows were dropped to fit the result-size
+ * budget, carried by the whole result rather than by one statement: the batch
+ * reducer in `apps/backend/src/aiTools/agentSql.ts` clears the rows of every
+ * statement at once, so a batch either keeps all of its rows or none of them.
+ *
+ * Counts are never reduced, which is what separates a payload whose rows were
+ * dropped from one whose statement returned no rows of its own. `false` means
+ * no row was dropped rather than that the payload fit, because a write with no
+ * rows to drop is emitted over budget and still marked `false`. Read batches
+ * carry `false` always and single read payloads omit the field entirely, since
+ * an oversized read is rejected instead of shrunk.
+ */
+type AgentSqlRowsOmitted = Readonly<{
+  rowsOmitted: boolean;
+}>;
+
 export type AgentSqlReadPayload = AgentSqlReadStatementPayload & AgentSqlSubmittedSql;
 
-export type AgentSqlMutationPayload = AgentSqlMutationStatementPayload & AgentSqlSubmittedSql;
+export type AgentSqlMutationPayload = AgentSqlMutationStatementPayload & AgentSqlSubmittedSql & AgentSqlRowsOmitted;
 
 export type AgentSqlSinglePayload = AgentSqlReadStatementPayload | AgentSqlMutationStatementPayload;
 
@@ -83,7 +100,7 @@ export type AgentSqlBatchPayload = Readonly<{
   statements: ReadonlyArray<AgentSqlSinglePayload>;
   statementCount: number;
   affectedCountTotal: number | null;
-}>;
+}> & AgentSqlRowsOmitted;
 
 export type AgentSqlPayload = AgentSqlReadPayload | AgentSqlMutationPayload | AgentSqlBatchPayload;
 
@@ -484,7 +501,7 @@ export function buildReadInstructions(statementType: "show_tables" | "describe" 
 }
 
 export function buildMutationInstructions(): string {
-  return "The mutation succeeded. Read data.affectedCount for the summary. INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. Without a RETURNING clause, INSERT and UPDATE return only the identifier column in data.rows and DELETE returns no rows. This endpoint supports the published SQL dialect, not full PostgreSQL. Use docs.discoveryUrl for runtime routes and docs.source.agentRoutesUrl for implementation details.";
+  return "The mutation succeeded. Read data.affectedCount for the summary. INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. Without a RETURNING clause, INSERT and UPDATE return only the identifier column in data.rows and DELETE returns no rows. data.rowsOmitted reports whether the returned rows were dropped to fit the result-size budget; the write succeeded either way. This endpoint supports the published SQL dialect, not full PostgreSQL. Use docs.discoveryUrl for runtime routes and docs.source.agentRoutesUrl for implementation details.";
 }
 
 export function buildBatchReadInstructions(): string {
@@ -492,7 +509,7 @@ export function buildBatchReadInstructions(): string {
 }
 
 export function buildBatchMutationInstructions(): string {
-  return "The batch mutation succeeded. Read data.statements for per-statement results and data.affectedCountTotal for the summary. INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. Without a RETURNING clause, INSERT and UPDATE return only the identifier column in each entry's rows and DELETE returns no rows. This endpoint supports the published SQL dialect, not full PostgreSQL. Use docs.discoveryUrl for runtime routes and docs.source.agentRoutesUrl for implementation details.";
+  return "The batch mutation succeeded. Read data.statements for per-statement results and data.affectedCountTotal for the summary. INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. Without a RETURNING clause, INSERT and UPDATE return only the identifier column in each entry's rows and DELETE returns no rows. data.rowsOmitted reports whether the returned rows of every statement were dropped to fit the result-size budget; the batch succeeded either way. This endpoint supports the published SQL dialect, not full PostgreSQL. Use docs.discoveryUrl for runtime routes and docs.source.agentRoutesUrl for implementation details.";
 }
 
 export function assertSqlMutationRecordLimit(

--- a/apps/backend/src/aiTools/agentSql/singleMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/singleMutation.ts
@@ -77,6 +77,7 @@ export async function executeSqlMutationStatement(
         normalizedSql: statement.normalizedSql,
         rows: toCardMutationRows(payload.cards, statement.returning),
         affectedCount: payload.createdCount,
+        rowsOmitted: false,
       },
       instructions: buildMutationInstructions(),
     };
@@ -100,6 +101,7 @@ export async function executeSqlMutationStatement(
         normalizedSql: statement.normalizedSql,
         rows: toDeckMutationRows(payload.decks, statement.returning),
         affectedCount: payload.createdCount,
+        rowsOmitted: false,
       },
       instructions: buildMutationInstructions(),
     };
@@ -131,6 +133,7 @@ export async function executeSqlMutationStatement(
         normalizedSql: statement.normalizedSql,
         rows: toCardMutationRows(payload.cards, statement.returning),
         affectedCount: payload.updatedCount,
+        rowsOmitted: false,
       },
       instructions: buildMutationInstructions(),
     };
@@ -153,6 +156,7 @@ export async function executeSqlMutationStatement(
         normalizedSql: statement.normalizedSql,
         rows: toDeckMutationRows(payload.decks, statement.returning),
         affectedCount: payload.updatedCount,
+        rowsOmitted: false,
       },
       instructions: buildMutationInstructions(),
     };
@@ -175,6 +179,7 @@ export async function executeSqlMutationStatement(
         normalizedSql: statement.normalizedSql,
         rows: toDeletedMutationRows("cards", payload.deletedCardIds, matchedRows, statement.returning),
         affectedCount: payload.deletedCount,
+        rowsOmitted: false,
       },
       instructions: buildMutationInstructions(),
     };
@@ -196,6 +201,7 @@ export async function executeSqlMutationStatement(
       normalizedSql: statement.normalizedSql,
       rows: toDeletedMutationRows("decks", payload.deletedDeckIds, matchedRows, statement.returning),
       affectedCount: payload.deletedCount,
+      rowsOmitted: false,
     },
     instructions: buildMutationInstructions(),
   };

--- a/apps/backend/src/mcp/server.test.ts
+++ b/apps/backend/src/mcp/server.test.ts
@@ -224,6 +224,7 @@ function createFakeDependencies(
           normalizedSql: sql,
           rows: [],
           affectedCount: 1,
+          rowsOmitted: false,
         },
         instructions: "The mutation completed.",
       };

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -17,6 +17,12 @@ export type AdminQueryDetails = Readonly<{
  * validation-issue code carried by the failure, recorded as an opaque value:
  * the dialect owns that vocabulary and may change it.
  *
+ * `resultChars` and `rowsOmitted` describe the emitted result: the size the
+ * result-size budget measured for the payload the surface really sent, and
+ * whether that payload is a committed write whose rows the budget dropped. Both
+ * are null on failure, and `resultChars` is null on the `chat-tool` surface,
+ * which builds no agent envelope to measure.
+ *
  * Raw SQL text is deliberately absent; `sqlFingerprint` plus `sqlLength` are
  * what make repeated failures groupable, matching `AdminQueryDetails`.
  *
@@ -34,6 +40,8 @@ export type AgentSqlDetails = Readonly<{
   resource: string | null;
   statementCount: number | null;
   rowOrAffectedCount: number | null;
+  resultChars: number | null;
+  rowsOmitted: boolean | null;
   durationMs: number;
   sqlLength: number;
   sqlFingerprint: string;

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -243,6 +243,8 @@ export function logAgentSqlEvent(payload: AgentSqlLogPayload): void {
     resource: payload.resource,
     statementCount: payload.statementCount,
     rowOrAffectedCount: payload.rowOrAffectedCount,
+    resultChars: payload.resultChars,
+    rowsOmitted: payload.rowsOmitted,
     durationMs: payload.durationMs,
     sqlLength: payload.sqlLength,
     sqlFingerprint: payload.sqlFingerprint,

--- a/docs/agent-sql-telemetry.md
+++ b/docs/agent-sql-telemetry.md
@@ -37,6 +37,8 @@ to compare surfaces.
 | `resource` | `cards`, `decks`, and so on; `null` for batches and on failure |
 | `statementCount` | Statements in the submitted SQL; `null` on failure |
 | `rowOrAffectedCount` | Rows read or records affected; `null` on failure |
+| `resultChars` | Characters of the emitted agent envelope, as measured against the result-size budget; `null` on failure and on `chat-tool`, which builds no envelope |
+| `rowsOmitted` | `true` when a committed write's rows were dropped to fit that budget; `null` on failure |
 | `durationMs` | Wall-clock duration of the execution |
 | `sqlLength` | Character length of the submitted SQL |
 | `sqlFingerprint` | SHA-256 hex digest of the submitted SQL |
@@ -60,6 +62,14 @@ needs to be read rather than counted.
 `dialectReason` is recorded as an opaque value. The SQL dialect owns that
 vocabulary and will make it more specific over time; nothing in this record
 depends on which values appear.
+
+A write whose result overflowed the budget still succeeds: `sql_execute` drops
+the returned rows of the already committed write instead of failing it, so such
+an execution is recorded as `succeeded = 1`, with `rowsOmitted = 1` whenever it
+had rows to drop. Reads never omit rows; an oversized read fails with
+`errorCode = "QUERY_RESULT_TOO_LARGE"`.
+`resultChars` is the same measurement the budget enforces, taken on the payload
+that was actually emitted, so it is the post-reduction size on a degraded write.
 
 ## The MCP caller label
 
@@ -95,5 +105,23 @@ filter domain = "backend" and action = "agent_sql" and succeeded = 0
 | limit 20
 ```
 
-If a log group renders `succeeded` as `true`/`false` instead of `1`/`0`, use
-`succeeded = "false"` in both queries.
+## Degraded writes and payload size
+
+```
+filter domain = "backend" and action = "agent_sql" and succeeded = 1
+| stats count(*) as executions,
+        sum(rowsOmitted = 1) as degradedWrites,
+        pct(resultChars, 50) as p50ResultChars,
+        pct(resultChars, 90) as p90ResultChars,
+        max(resultChars) as maxResultChars
+  by surface
+```
+
+`degradedWrites` counts successful writes that answered without their rows. The
+percentiles skip the `chat-tool` surface, whose `resultChars` is always `null`.
+A write that returned no rows has nothing to drop and is emitted untouched, so
+`resultChars` above the 48,000-character budget with `rowsOmitted = 0` is
+expected rather than a broken guard.
+
+If a log group renders `succeeded` and `rowsOmitted` as `true`/`false` instead
+of `1`/`0`, compare them against `"true"` and `"false"` in the queries above.


### PR DESCRIPTION
Follow-up to #1532, #1533 and #1534.

## Why

An oversized committed write drops its returned rows instead of failing (#1532), because the transaction is already committed by the time the size is measured and reporting it as a failure invited retries that duplicated data.

Until now the only trace of that reduction was a sentence appended to `instructions`. A model could not detect it reliably, and the `agent_sql` record could not detect it at all — a degraded write looked exactly like an ordinary successful one, which makes the write-side payload profile unmeasurable.

## What changed

- Mutation payloads carry `rowsOmitted`. It sits at the whole-result level, never per batch entry, because the batch reduction is all-or-nothing across statements.
- The `agent_sql` record carries `rowsOmitted` and `resultChars` — the size of the result the surface actually emitted, measured with the same helper the budget guard enforces with, so the two cannot drift.
- `resultChars` is `null` on the in-app chat surface, which builds no agent envelope and has its own separate budget. It is not fabricated.

## The marker records a reduction, not a verdict

The submitted `sql` is echoed back as `data.sql` and `data.normalizedSql`, and its length is uncapped. So a legitimate bulk delete — 50 statements of `DELETE FROM cards WHERE card_id IN (…)`, ~195k characters of SQL, and `rows: []` everywhere because `DELETE` without `RETURNING` returns none — exceeds the budget with nothing to drop.

Setting the marker from the budget verdict would have reported that write as degraded and counted it in the `degradedWrites` query, corrupting the signal this change exists to create. Each reducer now checks whether any row is actually present before it clears anything, marks, or appends the prose. A write with nothing to drop is emitted untouched, over budget, with `rowsOmitted: false`.

## Unchanged

The post-commit guarantee: an oversized committed write still degrades and never fails. The read path still rejects with `QUERY_RESULT_TOO_LARGE`, because nothing is committed there and narrowing the query is a real remedy. The marker is additive — callers that ignore it behave exactly as before, and no web, iOS or Android client parses this payload shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)