### PR TITLE
Record one telemetry event per authenticated MCP request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Swift builds and tests run in Xcode Cloud, whose workflow definitions live in Ap
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.
 Xcode Cloud iOS test and build workflows are manually started and monitored by a human. Do not trigger or monitor them unless the user explicitly authorizes that exact action. Do not trigger `Android Release` or `MCP Registry Publish` unless the user explicitly authorizes that exact action; agents may monitor and fix automatically triggered GitHub Actions.
 Details, rollback rules, and live smoke references: [docs/release-gates.md](docs/release-gates.md).
-Agent SQL executions emit one structured CloudWatch record per run on every surface; the record fields and the failure-rate queries live in [docs/agent-sql-telemetry.md](docs/agent-sql-telemetry.md).
+Agent SQL executions emit one structured CloudWatch record per run on every surface, and every authenticated `/mcp` request emits one more; the record fields and the queries live in [docs/agent-sql-telemetry.md](docs/agent-sql-telemetry.md).
 iOS `WatchdogTermination` events carry no stack trace by design; the memory fields carried on the app's own breadcrumbs and the decision tree for reading such an event live in [docs/ios-memory-diagnostics.md](docs/ios-memory-diagnostics.md).
 
 ## Repository Strategy

--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -21,7 +21,9 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { authenticateMcpBearerToken } from "../auth/mcpTokens";
 import { createMcpServer } from "../mcp/server";
+import { normalizeMcpTelemetryHeader, runWithMcpRequestId } from "../mcp/requestTelemetry";
 import { HttpError } from "../shared/errors";
+import { logMcpRequestEvent } from "../server/logging";
 import { getHttpErrorResponseHeaders } from "../server/httpErrorResponseHeaders";
 import { parsePublicOrigin } from "../shared/publicUrls";
 import {
@@ -36,6 +38,17 @@ import { hasReportedBackendException } from "../observability/reporting";
 initializeBackendSentry("backend-api");
 
 const supportedScopes = ["flashcards"] as const;
+
+/**
+ * Per-request context, mirroring apps/backend/src/server/app.ts: one request id
+ * is generated per request and read back by `app.onError`, so every response
+ * and every observation of the same request carries the same id.
+ */
+type McpAppEnv = {
+  Variables: {
+    requestId: string;
+  };
+};
 
 /**
  * Resolves the public base domain from the environment. Backend Lambdas are
@@ -134,6 +147,119 @@ function extractBearerToken(authorization: string | undefined): string | null {
 }
 
 /**
+ * Character length of the response body, measured without disturbing the
+ * response the client receives. The transport runs with `enableJsonResponse`,
+ * so a buffered JSON body can be read from a clone; anything else is left
+ * unmeasured rather than risk consuming a stream the client needs.
+ */
+async function measureResponseBodyChars(response: Response): Promise<number | null> {
+  if (response.body === null) {
+    return 0;
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (contentType === null || contentType.toLowerCase().includes("application/json") === false) {
+    return null;
+  }
+
+  return (await response.clone().text()).length;
+}
+
+/**
+ * `measureResponseBodyChars` with its own failure boundary, and `null` when the
+ * branch produced no response at all. A clone or a body read that rejects costs
+ * this one field of one record, never the record itself, which is why the
+ * emitter below resolves the size here before it decides to emit.
+ */
+async function resolveResponseBodyChars(response: Response | null): Promise<number | null> {
+  if (response === null) {
+    return null;
+  }
+
+  try {
+    return await measureResponseBodyChars(response);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The authenticated connection (user + selected workspace) a `/mcp` request
+ * runs under, resolved from the request's OAuth Bearer token.
+ */
+type AuthenticatedMcpConnection = Awaited<ReturnType<typeof authenticateMcpBearerToken>>;
+
+type McpRequestRecordInput = Readonly<{
+  request: Request;
+  connection: AuthenticatedMcpConnection;
+  requestId: string;
+  startedAtMs: number;
+  statusCode: number;
+  response: Response | null;
+  toolName: string | null;
+}>;
+
+/**
+ * Emits the one `mcp_request` record of an authenticated `/mcp` request. Every
+ * branch of the route below that answers an authenticated client calls this
+ * exactly once -- the transport response, the transport fault, and the non-POST
+ * rejection alike -- so the record count is the authenticated request count.
+ * The unauthenticated branches (no token, rejected token, auth-layer failure)
+ * emit nothing: they have no connection, and this record is about traffic that
+ * reached the resource.
+ *
+ * Its inputs are the request headers the MCP spec defines
+ * (`MCP-Protocol-Version`, `Mcp-Method`, `User-Agent`, and `Mcp-Name` through
+ * the caller-resolved `toolName`) plus the tool name the handlers report in
+ * process, because `Mcp-Name` is only REQUIRED from MCP revision 2026-07-28 and
+ * most live clients are older. Header values are client-controlled, so they are
+ * normalized for telemetry and never validated: a missing or surprising header
+ * must not change how a request that works today is served. The JSON-RPC body
+ * is deliberately not parsed here; the transport owns it.
+ *
+ * Reading the response body and writing the record are purely observational, so
+ * both are fenced, in two phases that keep the invariant above unconditional.
+ * Phase one resolves the field values: every step that can fail -- today only
+ * the response body measurement -- carries its own boundary and degrades to
+ * `null`, so a value we could not resolve costs its field and not the record.
+ * Phase two is the emit, and nothing awaited, optional, or computed for a field
+ * sits inside it: once phase one has run, the record is written. Its fence
+ * exists only so writing the record can neither fail a request that was already
+ * answered, nor escape into a caller's catch and produce a second record for
+ * one request.
+ */
+async function emitMcpRequestRecord(input: McpRequestRecordInput): Promise<void> {
+  // Phase one: resolve the field values. The duration is taken before the body
+  // is measured, so it stays the time spent serving the request rather than the
+  // time spent observing it.
+  const durationMs = Date.now() - input.startedAtMs;
+  const responseChars = await resolveResponseBodyChars(input.response);
+  const record = {
+    requestId: input.requestId,
+    httpMethod: input.request.method,
+    userId: input.connection.userId,
+    workspaceId: input.connection.selectedWorkspaceId,
+    connectionId: input.connection.connectionId,
+    caller: normalizeMcpTelemetryHeader(input.request.headers.get("user-agent")),
+    protocolVersion: normalizeMcpTelemetryHeader(
+      input.request.headers.get("mcp-protocol-version"),
+    ),
+    jsonRpcMethod: normalizeMcpTelemetryHeader(input.request.headers.get("mcp-method")),
+    toolName: input.toolName,
+    statusCode: input.statusCode,
+    durationMs,
+    responseChars,
+  };
+
+  // Phase two: emit the resolved record.
+  try {
+    logMcpRequestEvent(record);
+  } catch {
+    // Observability must not change the response the client receives.
+  }
+}
+
+/**
  * Runs one stateless MCP request: a fresh server + Web Standard Streamable HTTP
  * transport per call, with `enableJsonResponse` so the buffered API Gateway
  * Lambda integration returns a single JSON-RPC response instead of an SSE
@@ -146,22 +272,40 @@ function extractBearerToken(authorization: string | undefined): string | null {
  * used by real clients because issued tokens bind to the custom-domain
  * `resource` and would 401 on any other host.
  *
- * The request `User-Agent` is handed to the server as the caller label for SQL
- * telemetry. Because the transport is stateless, a `tools/call` never carries
- * the client's `initialize` clientInfo, so the header is the only caller signal
- * available here (see `resolveMcpCaller` in apps/backend/src/mcp/server.ts).
+ * Exactly one `mcp_request` telemetry record is emitted per request through the
+ * shared `emitMcpRequestRecord` above, on the response path and on the
+ * transport-fault path alike. The record names the tool the handlers report in
+ * process, falling back to the `Mcp-Name` header when no handler ran.
+ *
+ * The request id is the one the `X-Request-Id` middleware below generated for
+ * this request, so it is on every response of this surface including the ones
+ * `app.onError` builds. It is published for the duration of the transport call,
+ * so the `agent_sql` records the SQL tools emit underneath it and the Sentry
+ * captures the tool layer makes both carry it and join to this record.
  */
 async function handleMcpTransportRequest(
   request: Request,
-  connection: Awaited<ReturnType<typeof authenticateMcpBearerToken>>,
+  connection: AuthenticatedMcpConnection,
   baseDomain: string,
+  requestId: string,
+  startedAtMs: number,
 ): Promise<Response> {
+  const caller = normalizeMcpTelemetryHeader(request.headers.get("user-agent"));
+  const headerToolName = normalizeMcpTelemetryHeader(request.headers.get("mcp-name"));
+  // Every tool the request runs, in call order. The last one is what the record
+  // names, so a batched request still produces exactly one record.
+  const invokedToolNames: Array<string> = [];
   const server = createMcpServer(
     connection,
     getResourceUrl(baseDomain),
     getWebsiteUrl(baseDomain),
     getIconUrl(baseDomain),
-    request.headers.get("user-agent"),
+    {
+      caller,
+      recordInvokedTool: (toolName) => {
+        invokedToolNames.push(toolName);
+      },
+    },
   );
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
@@ -169,17 +313,39 @@ async function handleMcpTransportRequest(
     enableDnsRebindingProtection: true,
     allowedHosts: [`mcp.${baseDomain}`],
   });
+  const emitRequestRecord = (statusCode: number, response: Response | null): Promise<void> =>
+    emitMcpRequestRecord({
+      request,
+      connection,
+      requestId,
+      startedAtMs,
+      statusCode,
+      response,
+      toolName: invokedToolNames.at(-1) ?? headerToolName,
+    });
 
   try {
     await server.connect(transport);
-    return await transport.handleRequest(request);
+    const response = await runWithMcpRequestId(requestId, () => transport.handleRequest(request));
+    // The transport builds its own Response rather than one built through the
+    // Hono context, so the middleware's request id is carried over onto it.
+    response.headers.set("X-Request-Id", requestId);
+    await emitRequestRecord(response.status, response);
+
+    return response;
+  } catch (error) {
+    // A transport-layer fault produces no response here; app.onError below turns
+    // it into the client-facing status this records.
+    await emitRequestRecord(error instanceof HttpError ? error.statusCode : 500, null);
+
+    throw error;
   } finally {
     await transport.close();
     await server.close();
   }
 }
 
-function buildMcpRoutes(app: Hono): Hono {
+function buildMcpRoutes(app: Hono<McpAppEnv>): Hono<McpAppEnv> {
   app.get("/health", (c) => c.json({ status: "ok" }));
 
   // Serve PRM at both the RFC 9728 path-aware location (`/mcp` suffix, used by
@@ -198,7 +364,7 @@ function buildMcpRoutes(app: Hono): Hono {
       return buildBearerChallenge(c, baseDomain);
     }
 
-    let connection: Awaited<ReturnType<typeof authenticateMcpBearerToken>>;
+    let connection: AuthenticatedMcpConnection;
     try {
       connection = await authenticateMcpBearerToken(token, getResourceUrl(baseDomain));
     } catch (error) {
@@ -209,12 +375,17 @@ function buildMcpRoutes(app: Hono): Hono {
       throw error;
     }
 
+    const requestId = c.get("requestId");
+    // One clock for both branches below, started where the request is known to
+    // be authenticated, so `durationMs` measures the same thing on every record.
+    const startedAtMs = Date.now();
+
     // Stateless JSON mode only services request/response POSTs. A GET would make
     // the transport open a never-ending SSE stream that the buffered Lambda then
     // closes empty, and DELETE has no session to terminate, so reject non-POST
     // methods cleanly instead of routing them into the transport.
     if (c.req.method !== "POST") {
-      return c.json(
+      const response = c.json(
         {
           error: "method_not_allowed",
           error_description: "The MCP resource only accepts POST in stateless JSON mode.",
@@ -222,18 +393,46 @@ function buildMcpRoutes(app: Hono): Hono {
         405,
         { Allow: "POST" },
       );
+      // MCP revisions 2025-03-26 through 2025-11-25 let a client open the
+      // standalone notification stream with `GET /mcp`, so a client that keeps
+      // attempting it and accepting the rejection is ordinary authenticated
+      // traffic here, and exactly the client-compatibility signal this record
+      // exists to surface. Emitted from the route because the transport helper
+      // never sees these requests, and awaited before returning so one
+      // authenticated request still means exactly one record.
+      await emitMcpRequestRecord({
+        request: c.req.raw,
+        connection,
+        requestId,
+        startedAtMs,
+        statusCode: 405,
+        response,
+        toolName: null,
+      });
+
+      return response;
     }
 
-    return handleMcpTransportRequest(c.req.raw, connection, baseDomain);
+    return handleMcpTransportRequest(c.req.raw, connection, baseDomain, requestId, startedAtMs);
   });
 
   return app;
 }
 
-const app = new Hono();
+const app = new Hono<McpAppEnv>();
+// Mirrors the HTTP surface (apps/backend/src/server/app.ts): the request id is
+// generated and put on the response before any handler runs, so it survives
+// onto the error responses `app.onError` builds below and not only onto the
+// successful transport response.
+app.use("*", async (context, next) => {
+  const requestId = crypto.randomUUID();
+  context.set("requestId", requestId);
+  context.header("X-Request-Id", requestId);
+  await next();
+});
 // Mount at `/` (custom domain root) and `/v1` (execute-api stage path).
-app.route("/", buildMcpRoutes(new Hono()));
-app.route("/", buildMcpRoutes(new Hono().basePath("/v1")));
+app.route("/", buildMcpRoutes(new Hono<McpAppEnv>()));
+app.route("/", buildMcpRoutes(new Hono<McpAppEnv>().basePath("/v1")));
 
 // Mirror the HTTP agent surface (apps/backend/src/server/app.ts `app.onError`):
 // errors that escape the tool try/catch -- transport-layer faults
@@ -262,7 +461,7 @@ app.onError((error, context) => {
       error: normalizedError,
       scope: createBackendObservationScope(
         "backend-api",
-        null,
+        context.get("requestId"),
         "mcp",
         context.req.method,
         null,

--- a/apps/backend/src/mcp/requestTelemetry.ts
+++ b/apps/backend/src/mcp/requestTelemetry.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-request telemetry plumbing for the MCP surface: the normalizer every
+ * client-controlled label goes through, and the request id that joins the
+ * `mcp_request` record with the `agent_sql` records emitted underneath it.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const MAX_MCP_TELEMETRY_HEADER_CHARS = 120;
+
+type McpRequestTelemetryContext = Readonly<{
+  requestId: string;
+}>;
+
+const mcpRequestTelemetryStorage = new AsyncLocalStorage<McpRequestTelemetryContext>();
+
+/**
+ * Normalizes a client-controlled header value into what a telemetry record may
+ * carry: trimmed, capped, and null when absent or empty. Purely observational,
+ * so a missing or unexpected value is recorded as null and never rejected.
+ */
+export function normalizeMcpTelemetryHeader(headerValue: string | null): string | null {
+  if (headerValue === null) {
+    return null;
+  }
+
+  const trimmedValue = headerValue.trim();
+  if (trimmedValue === "") {
+    return null;
+  }
+
+  return trimmedValue.length <= MAX_MCP_TELEMETRY_HEADER_CHARS
+    ? trimmedValue
+    : trimmedValue.slice(0, MAX_MCP_TELEMETRY_HEADER_CHARS);
+}
+
+/**
+ * Publishes the MCP request id for the duration of one transport request, so
+ * everything the request runs underneath -- the SQL telemetry and the MCP tool
+ * layer's Sentry captures alike -- records the same id. The SQL executors are
+ * shared with the REST and chat surfaces, so their telemetry cannot take an
+ * MCP-specific argument; the id travels out of band instead, the way the
+ * repository already carries per-request context (see
+ * apps/backend/src/server/mediaRequests/multipartCompletionRequestTiming.ts).
+ */
+export function runWithMcpRequestId<Result>(
+  requestId: string,
+  callback: () => Promise<Result>,
+): Promise<Result> {
+  return mcpRequestTelemetryStorage.run({ requestId }, callback);
+}
+
+/**
+ * The MCP request id of the request currently being served, or null outside the
+ * MCP transport.
+ */
+export function getMcpRequestId(): string | null {
+  return mcpRequestTelemetryStorage.getStore()?.requestId ?? null;
+}

--- a/apps/backend/src/mcp/server.test.ts
+++ b/apps/backend/src/mcp/server.test.ts
@@ -12,6 +12,7 @@ import type { WorkspaceRequestContext } from "../server/requestContext";
 import type { WorkspaceSummaryWithStats } from "../workspaces";
 import {
   createMcpServerWithDependencies,
+  type McpRequestTelemetryChannel,
   type McpServerDependencies,
 } from "./server";
 
@@ -155,6 +156,15 @@ function readWorkspaceIdInputSchema(tool: ListedTool): JsonObject {
   return readJsonObject(properties, "workspaceId");
 }
 
+function createTelemetryChannel(invokedToolNames: Array<string>): McpRequestTelemetryChannel {
+  return {
+    caller: CALLER_USER_AGENT,
+    recordInvokedTool: (toolName) => {
+      invokedToolNames.push(toolName);
+    },
+  };
+}
+
 function createFakeDependencyCalls(): FakeDependencyCalls {
   return {
     resolveAccessibleMcpWorkspaceIds: [],
@@ -262,12 +272,13 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
     lastActivityAt: null,
   }];
   const calls = createFakeDependencyCalls();
+  const invokedToolNames: Array<string> = [];
   const server = createMcpServerWithDependencies(
     connection,
     RESOURCE_URL,
     WEBSITE_URL,
     ICON_URL,
-    CALLER_USER_AGENT,
+    createTelemetryChannel(invokedToolNames),
     createFakeDependencies(calls, workspaces),
   );
   const client = new Client({ name: "mcp-protocol-smoke", version: "1.0.0" });
@@ -383,6 +394,11 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
       },
       sql: executeSql,
     }]);
+    assert.deepEqual(invokedToolNames, [
+      LIST_WORKSPACES_TOOL_NAME,
+      SQL_QUERY_TOOL_NAME,
+      SQL_EXECUTE_TOOL_NAME,
+    ]);
   } finally {
     await client.close();
     await server.close();
@@ -402,7 +418,7 @@ test("MCP SQL tools reject malformed workspace IDs before access resolution", as
     RESOURCE_URL,
     WEBSITE_URL,
     ICON_URL,
-    CALLER_USER_AGENT,
+    createTelemetryChannel([]),
     createFakeDependencies(calls, []),
   );
   const client = new Client({ name: "mcp-protocol-smoke", version: "1.0.0" });

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -17,6 +17,7 @@ import {
   type WorkspaceRequestContext,
 } from "../server/requestContext";
 import { createAgentEnvelope, createAgentErrorEnvelope } from "../agent/envelope";
+import { getMcpRequestId } from "./requestTelemetry";
 import { createPublicHttpErrorDetails, HttpError } from "../shared/errors";
 import {
   listUserWorkspacesWithStatsForSelectedWorkspace,
@@ -86,35 +87,28 @@ const DEFAULT_MCP_SERVER_DEPENDENCIES: McpServerDependencies = {
   listUserWorkspacesWithStatsForSelectedWorkspace,
 };
 
-const MAX_MCP_CALLER_CHARS = 120;
-
 /**
- * Caller label recorded on the agent SQL telemetry record so the dialect
- * failure rate can be split per MCP client.
+ * Per-request telemetry channel handed to the server by the entrypoint, which
+ * builds one server per transport request (see
+ * apps/backend/src/entrypoints/lambda-mcp.ts).
  *
- * The `initialize` clientInfo is not reachable here: the MCP Lambda runs the
- * transport statelessly (`sessionIdGenerator: undefined` in
- * apps/backend/src/entrypoints/lambda-mcp.ts), so a `tools/call` arrives as its
- * own HTTP request on a freshly built server that never saw the client's
- * `initialize`. The request `User-Agent` is the one caller signal that is
- * observable without restructuring the entrypoint, so it is what gets recorded,
- * trimmed and capped. Clients that send no `User-Agent` are recorded as null
- * rather than guessed at.
+ * `caller` labels the calling MCP client on the records this request emits. It
+ * is the normalized request `User-Agent`: the `initialize` clientInfo is not
+ * reachable here because the transport runs statelessly
+ * (`sessionIdGenerator: undefined`), so a `tools/call` arrives as its own HTTP
+ * request on a freshly built server that never saw the client's `initialize`.
+ *
+ * `recordInvokedTool` reports the tool a handler is about to run, so the
+ * transport record names the invoked tool whatever the client's protocol
+ * revision is: the `Mcp-Name` header only becomes REQUIRED in MCP revision
+ * 2026-07-28 and most live callers are older. A batched request reports each
+ * tool it runs, and the entrypoint keeps the last one so it still emits exactly
+ * one record.
  */
-function resolveMcpCaller(callerUserAgent: string | null): string | null {
-  if (callerUserAgent === null) {
-    return null;
-  }
-
-  const trimmedCaller = callerUserAgent.trim();
-  if (trimmedCaller === "") {
-    return null;
-  }
-
-  return trimmedCaller.length <= MAX_MCP_CALLER_CHARS
-    ? trimmedCaller
-    : trimmedCaller.slice(0, MAX_MCP_CALLER_CHARS);
-}
+export type McpRequestTelemetryChannel = Readonly<{
+  caller: string | null;
+  recordInvokedTool: (toolName: string) => void;
+}>;
 
 /**
  * Serializes compactly on purpose: a tool result is read by programs and
@@ -208,6 +202,10 @@ async function buildToolErrorResult(
   dependencies: McpServerDependencies,
 ): Promise<CallToolResult> {
   const userId = connection.userId;
+  // A failing tool call is the frequent failure on this surface, so it carries
+  // the id of the MCP transport request it ran in and joins to that request's
+  // `mcp_request` record (see ./requestTelemetry). Null outside the transport.
+  const requestId = getMcpRequestId();
   if (error instanceof HttpError) {
     // Mirror app.onError's shouldCaptureRequestFailureException: report only
     // genuine 5xx HttpErrors (e.g. createWorkspaceInvariantError HttpError(500),
@@ -223,7 +221,7 @@ async function buildToolErrorResult(
           error: normalizedError,
           scope: createBackendObservationScope(
             "backend-api",
-            null,
+            requestId,
             `mcp/${toolName}`,
             "POST",
             userId,
@@ -293,7 +291,7 @@ async function buildToolErrorResult(
           action: "mcp_workspace_selection_enrichment_failed",
           scope: createBackendObservationScope(
             "backend-api",
-            null,
+            requestId,
             `mcp/${toolName}`,
             "POST",
             userId,
@@ -333,7 +331,7 @@ async function buildToolErrorResult(
       error: normalizedError,
       scope: createBackendObservationScope(
         "backend-api",
-        null,
+        requestId,
         `mcp/${toolName}`,
         "POST",
         userId,
@@ -385,23 +383,22 @@ const LIST_WORKSPACES_RESULT_INSTRUCTIONS =
  * (env-driven, see lambda-mcp.ts) surfaced in the MCP implementation metadata.
  * `iconUrl` is the absolute https URL of the served branded SVG icon
  * (`/icon.svg`), advertised as the server `icons` entry so spec-current MCP
- * clients and auto-ingesting catalogs can render the brand.
- * `callerUserAgent` is the request `User-Agent` (see `resolveMcpCaller`), used
- * only to label the SQL telemetry record with the calling client.
+ * clients and auto-ingesting catalogs can render the brand. `telemetry` is the
+ * per-request observation channel (see `McpRequestTelemetryChannel`).
  */
 export function createMcpServer(
   connection: AuthenticatedMcpAccessToken,
   resourceUrl: string,
   websiteUrl: string,
   iconUrl: string,
-  callerUserAgent: string | null,
+  telemetry: McpRequestTelemetryChannel,
 ): McpServer {
   return createMcpServerWithDependencies(
     connection,
     resourceUrl,
     websiteUrl,
     iconUrl,
-    callerUserAgent,
+    telemetry,
     DEFAULT_MCP_SERVER_DEPENDENCIES,
   );
 }
@@ -411,10 +408,10 @@ export function createMcpServerWithDependencies(
   resourceUrl: string,
   websiteUrl: string,
   iconUrl: string,
-  callerUserAgent: string | null,
+  telemetry: McpRequestTelemetryChannel,
   dependencies: McpServerDependencies,
 ): McpServer {
-  const caller = resolveMcpCaller(callerUserAgent);
+  const caller = telemetry.caller;
   const server = new McpServer(
     {
       name: SERVER_NAME,
@@ -465,6 +462,7 @@ export function createMcpServerWithDependencies(
       annotations: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
     },
     async ({ sql, workspaceId: requestedWorkspaceId }): Promise<CallToolResult> => {
+      telemetry.recordInvokedTool(SQL_QUERY_TOOL_NAME);
       try {
         const workspaceId = await resolveWorkspaceId(requestedWorkspaceId);
         const result = await dependencies.runSqlQuery({
@@ -516,6 +514,7 @@ export function createMcpServerWithDependencies(
       annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
     },
     async ({ sql, workspaceId: requestedWorkspaceId }): Promise<CallToolResult> => {
+      telemetry.recordInvokedTool(SQL_EXECUTE_TOOL_NAME);
       try {
         const workspaceId = await resolveWorkspaceId(requestedWorkspaceId);
         const result = await dependencies.runSqlExecute({
@@ -551,6 +550,7 @@ export function createMcpServerWithDependencies(
       annotations: { readOnlyHint: true, openWorldHint: false, idempotentHint: true },
     },
     async (): Promise<CallToolResult> => {
+      telemetry.recordInvokedTool(LIST_WORKSPACES_TOOL_NAME);
       try {
         const workspaces = await dependencies.listUserWorkspacesWithStatsForSelectedWorkspace(
           connection.userId,

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -102,6 +102,7 @@ export type {
   GlobalMetricsS3RetryDetails,
   GlobalMetricsSnapshotFailureDetails,
   GlobalMetricsSnapshotGeneratedDetails,
+  McpRequestDetails,
   MediaAssetStorageRetryDetails,
   MediaAssetStorageTerminalDetails,
   MediaBlobCleanupBatchDetails,

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -42,6 +42,37 @@ export type AgentSqlDetails = Readonly<{
   errorClass: string | null;
 }>;
 
+/**
+ * One record per authenticated `/mcp` request, emitted whatever the request
+ * turned out to be -- a transport response, a transport fault, or the 405 that
+ * rejects a non-POST request -- so protocol traffic (`initialize`,
+ * `tools/list`), non-SQL tools, and requests that never reach the transport are
+ * visible instead of being invisible between the `agent_sql` records. The scope
+ * `requestId` is what joins this record to the `agent_sql` records the SQL tools
+ * emit underneath it.
+ *
+ * `protocolVersion` and `jsonRpcMethod` come from the `MCP-Protocol-Version`
+ * and `Mcp-Method` request headers, so both are null when the client sends
+ * them empty or not at all (`Mcp-Method` is only REQUIRED from MCP revision
+ * 2026-07-28). `toolName` is observed in process from the tool handler, so it
+ * is present for a tool call regardless of the client's protocol revision, and
+ * falls back to the client's unvalidated `Mcp-Name` header when no handler ran.
+ *
+ * No body content is carried: the transport owns the body, and tool arguments
+ * and results carry flashcard content. `responseChars` is a length measured off
+ * the response and never any of what it contains.
+ */
+export type McpRequestDetails = Readonly<{
+  protocolVersion: string | null;
+  jsonRpcMethod: string | null;
+  toolName: string | null;
+  caller: string | null;
+  connectionId: string;
+  statusCode: number;
+  durationMs: number;
+  responseChars: number | null;
+}>;
+
 export type GlobalMetricsSnapshotGeneratedDetails = Readonly<{
   bucketName: string;
   objectKey: string;
@@ -300,6 +331,7 @@ export type MigrationFailureDetails = Readonly<{
 export type OperationsBreadcrumbEvent =
   | EventByAction<"admin_query", AdminQueryDetails>
   | EventByAction<"agent_sql", AgentSqlDetails>
+  | EventByAction<"mcp_request", McpRequestDetails>
   | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -1,4 +1,5 @@
 import { AuthError, authVerificationTemporarilyUnavailableCode } from "../auth";
+import { getMcpRequestId } from "../mcp/requestTelemetry";
 import { HttpError } from "../shared/errors";
 import { createBackendFailureDetails } from "../observability/failureDetails";
 import { sanitizeBackendTelemetryValue } from "../observability/sanitizer";
@@ -12,6 +13,7 @@ import {
   type BackendObservationScope,
   type BackendService,
   type BackendErrorLogDetails,
+  type McpRequestDetails,
   type RequestErrorDetails,
 } from "../observability/sentry";
 
@@ -34,6 +36,13 @@ type AgentSqlLogPayload = Readonly<{
   userId: string;
   workspaceId: string;
 }> & AgentSqlDetails;
+
+type McpRequestLogPayload = Readonly<{
+  requestId: string;
+  httpMethod: string;
+  userId: string;
+  workspaceId: string | null;
+}> & McpRequestDetails;
 
 export function getErrorLogContext(error: unknown): ErrorLogContext {
   return getBackendErrorLogDetails(error);
@@ -223,7 +232,10 @@ function getAgentSqlService(surface: AgentSqlDetails["surface"]): BackendService
 export function logAgentSqlEvent(payload: AgentSqlLogPayload): void {
   const scope: BackendObservationScope = createBackendObservationScope(
     getAgentSqlService(payload.surface),
-    null,
+    // Only the MCP surface publishes a request id, and it is what joins this
+    // record to the `mcp_request` record for the same transport request. The
+    // REST and chat surfaces publish none, so they keep recording null.
+    getMcpRequestId(),
     `agent-sql/${payload.surface}`,
     "POST",
     payload.userId,
@@ -253,6 +265,49 @@ export function logAgentSqlEvent(payload: AgentSqlLogPayload): void {
 
   addBackendBreadcrumb({
     action: "agent_sql",
+    scope,
+    details,
+  });
+}
+
+/**
+ * Emits the single structured record for one authenticated `/mcp` request,
+ * following the `logAgentSqlEvent` convention above. It covers what `agent_sql`
+ * cannot see: the negotiated protocol version, the JSON-RPC method, non-SQL
+ * tools such as `list_workspaces`, requests that never reach the transport, and
+ * the size of the response the client received. The shared `requestId` joins
+ * the two record types.
+ *
+ * The scope carries the request's own HTTP method rather than a fixed `POST`,
+ * because a non-POST `/mcp` request is answered with 405 and records too.
+ */
+export function logMcpRequestEvent(payload: McpRequestLogPayload): void {
+  const scope: BackendObservationScope = createBackendObservationScope(
+    "backend-api",
+    payload.requestId,
+    "mcp",
+    payload.httpMethod,
+    payload.userId,
+    payload.workspaceId,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  const details: McpRequestDetails = {
+    protocolVersion: payload.protocolVersion,
+    jsonRpcMethod: payload.jsonRpcMethod,
+    toolName: payload.toolName,
+    caller: payload.caller,
+    connectionId: payload.connectionId,
+    statusCode: payload.statusCode,
+    durationMs: payload.durationMs,
+    responseChars: payload.responseChars,
+  };
+
+  addBackendBreadcrumb({
+    action: "mcp_request",
     scope,
     details,
   });

--- a/docs/agent-sql-telemetry.md
+++ b/docs/agent-sql-telemetry.md
@@ -1,15 +1,19 @@
-# Agent SQL Telemetry
+# Agent SQL and MCP Telemetry
 
 Every agent SQL execution emits exactly one structured CloudWatch record, on
 success and on failure alike, so the failure rate of foreign models against our
-SQL dialect is measurable.
+SQL dialect is measurable. Every authenticated `/mcp` request emits one more
+record, so the MCP traffic that runs no SQL is measurable too.
 
 The record is emitted by `withAgentSqlTelemetry` in
 `apps/backend/src/aiTools/agentSql.ts`, which wraps `executeAgentSql`,
 `runSqlQuery`, and `runSqlExecute`. It sits below the MCP tool handlers' own
 `catch`, which answers with a `CallToolResult` and therefore never reaches
-`app.onError`: without this record an MCP dialect rejection produces no
-CloudWatch event, no Sentry event, and no Langfuse trace.
+`app.onError`: without this record an MCP dialect rejection produces no record
+that identifies the failure, no Sentry event, and no Langfuse trace. The
+`mcp_request` record the same request emits counts the request but reports the
+transport's own `statusCode` 200, because a rejected tool call is a successful
+JSON-RPC response.
 
 ## Where the records are
 
@@ -45,7 +49,9 @@ to compare surfaces.
 | `errorClass` | `error.name` on failure, else `null`; coarse by design, so group failures by `errorCode` and `dialectReason` |
 
 `userId`, `workspaceId`, and the synthetic route `agent-sql/<surface>` come from
-the shared observation scope on every record.
+the shared observation scope on every record, and so does `requestId`: the MCP
+surface publishes one per transport request, so `agent_sql` records emitted
+there carry it and the REST and chat surfaces record null.
 
 Raw SQL text is never logged. `sqlFingerprint` plus `errorCode` and
 `dialectReason` are what make repeated failures groupable, the same choice the
@@ -72,6 +78,79 @@ Lambda runs the transport statelessly (`sessionIdGenerator: undefined` in
 own HTTP request on a freshly built server that never saw the client's
 `initialize`. Reaching clientInfo would mean restructuring the entrypoint into a
 session-bearing transport.
+
+## The MCP request record
+
+`agent_sql` only sees SQL, so MCP requests that run none were invisible:
+`initialize`, `tools/list`, and the `list_workspaces` tool produced no record at
+all. Each authenticated `/mcp` request therefore emits exactly one
+`action = "mcp_request"` record into the MCP Lambda log group
+(`service = "backend-api"`), from the `/mcp` route in
+`apps/backend/src/entrypoints/lambda-mcp.ts`. Every branch that answers an
+authenticated client emits it once: the transport response, a transport fault,
+and the 405 that rejects a non-POST request alike.
+
+Requests that never authenticate emit none, because the Bearer 401 challenge and
+an auth-layer failure have no connection to record. So the record count is the
+authenticated request count on this surface, not the total request count.
+Observing a request can only degrade a field of its record, never remove the
+record: a response body that could not be measured is recorded as a `null`
+`responseChars`.
+
+| Field | Meaning |
+| --- | --- |
+| `protocolVersion` | `MCP-Protocol-Version` request header; `null` when the client sends none, which includes the `initialize` request that negotiates it |
+| `jsonRpcMethod` | `Mcp-Method` request header, so `initialize`, `tools/list`, `tools/call`; `null` on clients older than MCP revision 2026-07-28, which is where the header became REQUIRED |
+| `toolName` | Tool the request ran, observed in process from the tool handler, so it is present for a tool call whatever the client's protocol revision is; when no handler ran it falls back to the client's own unvalidated `Mcp-Name` header, so a `tools/call` the SDK rejected before any handler is still named on a client new enough to send that header; `null` when no handler ran and no `Mcp-Name` was sent, and always `null` on a non-POST request |
+| `caller` | Calling client label, normalized like the `agent_sql` one |
+| `connectionId` | Agent connection the request ran under |
+| `statusCode` | HTTP status the client received, including the 405 a non-POST request gets |
+| `durationMs` | Wall-clock duration of serving the request after authentication |
+| `responseChars` | Character length of the response body; `null` when the body was not a buffered JSON document, when reading it failed, and on the transport-fault branch, where the record is emitted before `app.onError` builds the body the client receives |
+
+`requestId`, `userId`, `workspaceId`, the route `mcp`, and `method` (the
+request's own HTTP method, so non-POST traffic is groupable) come from the
+shared observation scope. Every `/mcp` response returns that id as the
+`X-Request-Id` response header, error responses included, because the entrypoint
+sets it before the handler runs. The same id is carried by every `agent_sql`
+record and every Sentry capture the request produced, which is what joins them
+to this record.
+
+Header values are client-controlled, so they are trimmed, capped at 120
+characters, and recorded as `null` when absent or empty. They are never
+validated: a missing or unexpected header changes nothing about how the request
+is served.
+
+No body content is recorded. The JSON-RPC body belongs to the transport and is
+never parsed for telemetry, and tool arguments and results carry flashcard
+content; `responseChars` is a length measured off the response and never any of
+what it contains.
+
+A `method = "GET"` row is a client trying to open the standalone SSE stream that
+MCP revisions 2025-03-26 through 2025-11-25 allow and revision 2026-07-28
+removed. This surface runs the transport statelessly and answers 405, which
+those clients accept, so a run of such rows is a client-compatibility signal
+rather than an incident.
+
+## Request mix on the MCP surface
+
+```
+filter domain = "backend" and action = "mcp_request"
+| stats count(*) as requests,
+        avg(responseChars) as avgResponseChars,
+        avg(durationMs) as avgDurationMs
+  by method, jsonRpcMethod, toolName, protocolVersion, caller
+| sort requests desc
+| limit 20
+```
+
+`jsonRpcMethod` is `null` for every client older than MCP revision 2026-07-28,
+so today the split is carried by the other fields: a tool call is named by
+`toolName`, an `initialize`, or any request from a client that sends no
+`MCP-Protocol-Version`, is a row with no `protocolVersion`, a non-POST `method`
+is the rejected stream attempt above, and the remaining protocol traffic
+(`tools/list`, `ping`, `notifications/initialized`) shares one unnamed bucket
+until callers start sending `Mcp-Method`.
 
 ## Failure share by surface
 


### PR DESCRIPTION
Closes the observability gap behind the MCP work in #1532, #1533, #1534 and #1537.

## What was invisible

Only the SQL tools emitted telemetry on the MCP surface. So `list_workspaces`, `tools/list` and `initialize` produced no record at all, and nothing anywhere recorded which JSON-RPC method ran, which protocol revision the client negotiated, or how large the response was. `logAgentSqlEvent` also passed `null` for `requestId` unconditionally, so an MCP record could not be joined to a Sentry capture or to a request the user reports.

Measured before this change: 964 `agent_sql` executions over 30 days across 10 distinct clients, and no way to tell what the rest of the traffic on that endpoint was doing.

## What changed

- Every authenticated `/mcp` request emits one `mcp_request` record: protocol version, JSON-RPC method, invoked tool name, caller, request id, user, connection, HTTP method and status, duration, response size.
- The request id is minted in middleware **before** any handler, so it survives onto the responses `app.onError` builds, and it reaches the `agent_sql` records and all three Sentry captures on this surface.
- `X-Request-Id` is returned on every `/mcp` response, matching the convention in `server/app.ts`.

## Two details that decide whether this actually works

**The tool name does not come from the header.** `Mcp-Name` is only mandatory from MCP revision 2026-07-28, and every live caller predates that. A header-only implementation would have left `toolName` null on effectively all traffic — the exact blind spot this change exists to close. The handlers report the tool themselves, so `list_workspaces` is visible regardless of the client's protocol revision.

**Authenticated non-POST requests are recorded too.** Revisions 2025-03-26 through 2025-11-25 let a client open a standalone SSE stream with `GET`, and 2026-07-28 removed it. An older client attempting that and receiving 405 is a client-compatibility signal, not noise, so the record carries the HTTP method to keep those rows separable.

## Observation cannot affect the request

Every field value is resolved first, then a single fenced call writes the record. Nothing fallible sits between the decision to emit and the write, so observation can neither alter the response, change the status, emit a second record, nor drop the record when a measurement fails — it can only degrade a field to `null`.

Unauthenticated branches emit nothing by design: the payload's user and connection fields are non-nullable, so the record count is the authenticated request count.

## Not in this PR

`jsonRpcMethod` comes from the `Mcp-Method` header, which pre-2026-07-28 clients do not send, so `tools/list`, `ping` and `notifications/initialized` share one unnamed bucket for now. Reading it from in-process SDK hooks was deferred rather than guessed at; the documentation states the limitation instead of implying a resolution the field cannot deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)