### PR TITLE
Explain when an accessibility identifier reaches XCUITest

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -113,7 +113,9 @@ The iOS app uses native Apple test tooling only:
 
 - FSRS parity and scheduler-focused tests live in `apps/ios/Flashcards/FlashcardsTests/Review` as targeted native verification, not as an exhaustive safety net
 - release-gate UI coverage lives in the grouped `apps/ios/Flashcards/FlashcardsUITests/LiveSmoke*Tests.swift` files, with shared smoke infrastructure in `apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport`
-- accessibility identifiers used by the live smoke flows live in `apps/ios/Flashcards/Flashcards/UITestIdentifiers.swift`
+- accessibility identifiers used by the live smoke flows live in `apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift`, and because the test target cannot import the app target, `apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift` re-declares only the identifiers its own flows use, where a value present in both must match exactly
+
+An accessibility identifier reaches XCUITest only on an accessibility element, usually a leaf such as `Text`, `Button`, or `TextField`, or a plain container whose descendants inherit it. A system container such as `ContentUnavailableView` can merge its subtree and drop the identifier, even from a `Text` inside it, so the smoke query silently finds nothing. `.accessibilityElement(children: .contain)` is the container pattern, used in `apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatMessageViews.swift`, but on some surfaces it fails to expose the identifier or crashes the app outright, so confirm a new identifier on a simulator before a live smoke flow uses it.
 
 The iOS release-gate smoke coverage is split into independent grouped flows across Review, Cards, AI, and Settings. Only one grouped smoke signs into the linked review account and verifies linked workspace lifecycle. The remaining grouped smokes stay guest/local and do not perform login.
 


### PR DESCRIPTION
Two AI chat identifiers stopped reaching XCUITest without any check failing, which is how the guest AI chat reset smoke step ended up red against a screen that rendered correctly.

## Rule recorded

`.accessibilityIdentifier` only lands on a view that is its own accessibility element. On a plain container it does not stick and the descendants keep reporting the nearest ancestor identifier, so the smoke query silently finds nothing instead of failing. A system container such as `ContentUnavailableView` can merge its subtree and drop the identifier even from a `Text` inside it.

`.accessibilityElement(children: .contain)` is named as the container pattern, with the working in-repo example, and hedged honestly: on some surfaces it fails to expose the identifier or crashes the app outright. Applying it to the AI chat empty state crashed deterministically inside `View.overlay` on iOS 26.5, twice out of two runs. Hence the instruction to confirm a new identifier on a simulator before a live smoke flow depends on it.

## Path corrected

The bullet pointed at `apps/ios/Flashcards/Flashcards/UITestIdentifiers.swift`, which does not exist. The file is under `App/`. The bullet now also names the test-target list: the UI test target has no `TEST_HOST`/`BUNDLE_LOADER` and no `@testable import`, so it cannot import the app target and re-declares only the identifiers its own flows use.

Documentation only. The prose names no specific identifier, so it stays true after the follow-up PR removes the two dead ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)