### PR TITLE
Remove the AI chat identifiers XCUITest never receives

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -425,7 +425,6 @@ struct AIChatView: View {
     var emptyChatState: some View {
         ContentUnavailableView {
             Text(aiSettingsLocalized("ai.emptyState.title", "Start a new AI chat"))
-                .accessibilityIdentifier(UITestIdentifier.aiEmptyState)
         } description: {
             Text(
                 aiSettingsLocalized(
@@ -437,7 +436,6 @@ struct AIChatView: View {
             .multilineTextAlignment(.center)
         }
         .padding(.horizontal, aiChatMessageListHorizontalPadding)
-        .accessibilityIdentifier(UITestIdentifier.aiEmptyState)
     }
 
     func acceptExternalAIConsent() {

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
@@ -11,7 +11,6 @@ extension AIChatView {
         // the top instead of resolving the tail.
         ScrollViewReader { proxy in
             self.chatScrollContent
-                .accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)
                 .defaultScrollAnchor(.bottom, for: .initialOffset)
                 .defaultScrollAnchor(.bottom, for: .alignment)
                 .contentMargins(.horizontal, aiChatMessageListHorizontalPadding, for: .scrollContent)

--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -174,8 +174,6 @@ enum UITestIdentifier {
     static let reviewRateGoodButton: String = "review.rateGoodButton"
     static let aiConsentAcceptButton: String = "ai.consentAcceptButton"
     static let aiNewChatButton: String = "ai.newChatButton"
-    static let aiEmptyState: String = "ai.emptyState"
-    static let aiConversationScrollSurface: String = "ai.conversationScrollSurface"
     static let aiMessageRow: String = "ai.messageRow"
     static let aiComposerTextField: String = "ai.composerTextField"
     static let aiComposerSendButton: String = "ai.composerSendButton"

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -112,8 +112,6 @@ enum LiveSmokeIdentifier {
     static let reviewRateGoodButton: String = "review.rateGoodButton"
     static let aiConsentAcceptButton: String = "ai.consentAcceptButton"
     static let aiNewChatButton: String = "ai.newChatButton"
-    static let aiEmptyState: String = "ai.emptyState"
-    static let aiConversationScrollSurface: String = "ai.conversationScrollSurface"
     static let aiMessageRow: String = "ai.messageRow"
     static let aiComposerTextField: String = "ai.composerTextField"
     static let aiComposerSendButton: String = "ai.composerSendButton"

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingScreenshotFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingScreenshotFixtures.swift
@@ -644,9 +644,6 @@ extension MarketingManualScreenshotTestCase {
         let dismissalSurface = self.app.descendants(matching: .any)
             .matching(identifier: LiveSmokeIdentifier.aiScreen)
             .firstMatch
-        let emptyStateLabel = self.app.staticTexts
-            .matching(identifier: LiveSmokeIdentifier.aiEmptyState)
-            .element(boundBy: 0)
         let navigationBar = self.app.navigationBars.firstMatch
         let composerTextField = self.app.descendants(matching: .any)
             .matching(identifier: LiveSmokeIdentifier.aiComposerTextField)
@@ -658,8 +655,6 @@ extension MarketingManualScreenshotTestCase {
                 dismissalSurface.coordinate(
                     withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)
                 ).tap()
-            } else if emptyStateLabel.exists && emptyStateLabel.isHittable {
-                emptyStateLabel.tap()
             } else if navigationBar.exists && navigationBar.isHittable {
                 navigationBar.tap()
             } else {


### PR DESCRIPTION
Follow-up to #1540. Deletions only: 5 files, 12 lines, 0 insertions.

## Why

`ai.emptyState` and `ai.conversationScrollSurface` never reached XCUITest. A local probe on an iPhone 17 / iOS 26.5 simulator, on unmodified sources, resolved 0 elements for each while the AI empty state rendered normally, against 1 for `ai.composerTextField` as a control. Both empty-state static texts and the transcript `CollectionView` carried `ai.screen` instead.

`.accessibilityIdentifier` only lands on a view that is its own accessibility element. `ai.emptyState` sat on a `ContentUnavailableView` inside `List { ... }.overlay { ... }` (and on a `Text` inside its label builder, which the container merges away); `ai.conversationScrollSurface` sat on the `List`. Leaving them in place advertises a contract the app does not honour.

## What

- both `.accessibilityIdentifier(UITestIdentifier.aiEmptyState)` applications in `emptyChatState`
- the `.accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)` line in `chatScrollSurface`
- both constants from `UITestIdentifiers.swift` and from `LiveSmokeIdentifiers.swift`
- the `emptyStateLabel` branch in `dismissAiComposerKeyboardIfVisible`, which could never match; the surface, navigation-bar and coordinate-tap fallbacks are untouched

`#1540` already removed every read of both identifiers from the smoke flows, so nothing references them at merge time.

## Not touched

`"ai.emptyState.title"` and `"ai.emptyState.description"` are localization keys, not identifiers. They and their translations in all eight localized `AISettings.strings` files are unchanged — the empty state renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)