### PR TITLE
Validate sync installation UUIDs

### DIFF
--- a/apps/backend/src/routes/sync/index.test.ts
+++ b/apps/backend/src/routes/sync/index.test.ts
@@ -11,6 +11,7 @@ import { createSyncRoutes } from "./index";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
+const installationId = "22222222-2222-4222-8222-222222222222";
 
 function createCodedError(code: string, message: string): Error & Readonly<{ code: string }> {
   const error = new Error(message) as Error & { code: string };
@@ -157,7 +158,7 @@ test("POST /sync/push accepts card payloads without legacy effortLevel", async (
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      installationId: "install-1",
+      installationId,
       platform: "web",
       appVersion: "1.0.0",
       operations: [
@@ -205,6 +206,44 @@ test("POST /sync/push accepts card payloads without legacy effortLevel", async (
   assert.equal(processCalls, 1);
 });
 
+test("POST /sync/push rejects malformed installationId before sync processing", async () => {
+  let processCalls = 0;
+  const routes = createSyncRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => {},
+    processSyncPushFn: async () => {
+      processCalls += 1;
+      throw new Error("Malformed installationId should be rejected before sync processing");
+    },
+  });
+  const app = createSyncTestApp(routes);
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/sync/push`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      installationId: "flashcards-review-bff-v1",
+      platform: "web",
+      appVersion: "1.0.0",
+      operations: [],
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Cloud sync failed. Try again.",
+    requestId: "request-1",
+    code: "SYNC_INVALID_INPUT",
+  });
+  assert.equal(processCalls, 0);
+});
+
 test("POST /sync/bootstrap preserves a legacy PostgreSQL workspace ID", async () => {
   let accessCheckCalls = 0;
   let processCalls = 0;
@@ -245,7 +284,7 @@ test("POST /sync/bootstrap preserves a legacy PostgreSQL workspace ID", async ()
       },
       body: JSON.stringify({
         mode: "pull",
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         cursor: null,
@@ -302,7 +341,7 @@ test("sync routes reject guest web platform before creating a workspace replica"
       name: "push",
       path: `/workspaces/${workspaceId}/sync/push`,
       body: {
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         operations: [],
@@ -312,7 +351,7 @@ test("sync routes reject guest web platform before creating a workspace replica"
       name: "pull",
       path: `/workspaces/${workspaceId}/sync/pull`,
       body: {
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         afterHotChangeId: 0,
@@ -324,7 +363,7 @@ test("sync routes reject guest web platform before creating a workspace replica"
       path: `/workspaces/${workspaceId}/sync/bootstrap`,
       body: {
         mode: "pull",
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         cursor: null,
@@ -335,7 +374,7 @@ test("sync routes reject guest web platform before creating a workspace replica"
       name: "review-history pull",
       path: `/workspaces/${workspaceId}/sync/review-history/pull`,
       body: {
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         afterReviewSequenceId: 0,
@@ -346,7 +385,7 @@ test("sync routes reject guest web platform before creating a workspace replica"
       name: "review-history import",
       path: `/workspaces/${workspaceId}/sync/review-history/import`,
       body: {
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         reviewEvents: [],
@@ -409,7 +448,7 @@ for (const platform of ["ios", "android"] as const) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        installationId: "install-1",
+        installationId,
         platform,
         appVersion: "1.0.0",
         afterHotChangeId: 0,
@@ -457,7 +496,7 @@ test("POST /sync/pull rejects guest platform mismatch before sync processing", a
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      installationId: "install-1",
+      installationId,
       platform: "android",
       appVersion: "1.0.0",
       afterHotChangeId: 0,
@@ -514,7 +553,7 @@ test("POST /sync/pull binds a legacy guest session to the first mobile platform"
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      installationId: "install-1",
+      installationId,
       platform: "ios",
       appVersion: "1.0.0",
       afterHotChangeId: 0,
@@ -569,7 +608,7 @@ test("POST /sync/pull allows signed-in web sync without guest platform binding",
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      installationId: "install-1",
+      installationId,
       platform: "web",
       appVersion: "1.0.0",
       afterHotChangeId: 0,
@@ -627,7 +666,7 @@ test("POST /sync/pull retries transient database failures during request preflig
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      installationId: "install-1",
+      installationId,
       platform: "web",
       appVersion: "1.0.0",
       afterHotChangeId: 7,
@@ -686,7 +725,7 @@ test("POST /sync/review-history/pull retries transient database failures during 
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      installationId: "install-1",
+      installationId,
       platform: "web",
       appVersion: "1.0.0",
       afterReviewSequenceId: 11,
@@ -749,7 +788,7 @@ test("POST /sync/bootstrap logs successful pull timing and cursor details", asyn
       },
       body: JSON.stringify({
         mode: "pull",
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         cursor: null,
@@ -807,7 +846,7 @@ test("POST /sync/bootstrap rejects pull limit above bootstrap max", async () => 
     },
     body: JSON.stringify({
       mode: "pull",
-      installationId: "install-1",
+      installationId,
       platform: "web",
       appVersion: "1.0.0",
       cursor: null,
@@ -851,7 +890,7 @@ test("POST /sync/bootstrap logs failure timing before returning sync errors", as
       },
       body: JSON.stringify({
         mode: "push",
-        installationId: "install-1",
+        installationId,
         platform: "web",
         appVersion: "1.0.0",
         entries: [],

--- a/apps/backend/src/sync/contracts/input.cardsDecksLegacy.test.ts
+++ b/apps/backend/src/sync/contracts/input.cardsDecksLegacy.test.ts
@@ -28,6 +28,8 @@ import {
   toDeckSnapshotInput,
 } from "./snapshots";
 
+const installationId = "22222222-2222-4222-8222-222222222222";
+
 type CardSyncPushPayload = Omit<CardSnapshotInput, "cardType" | "metadata"> & Readonly<{
   cardType?: string;
   metadata?: CardMetadata;
@@ -94,7 +96,7 @@ function createCardSyncPushInput(fixture: CardDueAtFixture): CardSyncPushInput {
 
 function createCardSyncPushInputWithPayload(payload: CardSyncPushPayload): CardSyncPushInput {
   return {
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     operations: [
       {
@@ -121,7 +123,7 @@ function createDeckSnapshotPayload(filterDefinition: DeckSyncFilterDefinition): 
 
 function createDeckSyncPushInputWithPayload(payload: DeckSyncPushPayload): DeckSyncPushInput {
   return {
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     operations: [
       {

--- a/apps/backend/src/sync/contracts/input.mediaAssets.test.ts
+++ b/apps/backend/src/sync/contracts/input.mediaAssets.test.ts
@@ -12,10 +12,11 @@ import {
 } from "./inputTestSupport";
 
 const mediaAssetSha256 = createMediaAssetPayload(null).sha256;
+const installationId = "22222222-2222-4222-8222-222222222222";
 
 test("parseSyncPushInput accepts media_asset metadata operations", () => {
   const parsedInput = parseSyncPushInput({
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     operations: [
       {
@@ -53,7 +54,7 @@ test("parseSyncPushInput accepts media_asset metadata operations", () => {
 test("parseSyncPushInput rejects non-http media_asset source URLs", () => {
   assert.throws(
     () => parseSyncPushInput({
-      installationId: "installation-1",
+      installationId,
       platform: "ios",
       operations: [
         {
@@ -97,13 +98,13 @@ test("parseSyncPushInput rejects non-http media_asset source URLs", () => {
 
 test("parseSyncPullInput accepts media asset opt-in without requiring it", () => {
   const legacyInput = parseSyncPullInput({
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     afterHotChangeId: 0,
     limit: 100,
   });
   const mediaInput = parseSyncPullInput({
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     afterHotChangeId: 0,
     limit: 100,
@@ -117,7 +118,7 @@ test("parseSyncPullInput accepts media asset opt-in without requiring it", () =>
 test("parseSyncBootstrapInput accepts media asset opt-in for pull", () => {
   const input = parseSyncBootstrapInput({
     mode: "pull",
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     cursor: null,
     limit: 100,
@@ -134,7 +135,7 @@ test("parseSyncBootstrapInput accepts media asset opt-in for pull", () => {
 test("parseSyncBootstrapInput accepts media asset opt-in for push with empty entries", () => {
   const input = parseSyncBootstrapInput({
     mode: "push",
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     includeMediaAssets: true,
     entries: [],
@@ -151,7 +152,7 @@ test("parseSyncBootstrapInput accepts media asset opt-in for push with empty ent
 test("parseSyncBootstrapInput accepts media_asset metadata entries for push", () => {
   const input = parseSyncBootstrapInput({
     mode: "push",
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     entries: [
       {

--- a/apps/backend/src/sync/contracts/input.reviewEvents.test.ts
+++ b/apps/backend/src/sync/contracts/input.reviewEvents.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import { HttpError } from "../../shared/errors";
 import { parseSyncPushInput } from "./input";
 
+const installationId = "22222222-2222-4222-8222-222222222222";
+
 type ReviewEventTimestampFixture = Readonly<{
   clientUpdatedAt: string;
   reviewedAtClient: string;
@@ -31,7 +33,7 @@ function createSyncPushInput(
   }>>;
 }> {
   return {
-    installationId: "installation-1",
+    installationId,
     platform: "ios",
     operations: [
       {

--- a/apps/backend/src/sync/contracts/input.ts
+++ b/apps/backend/src/sync/contracts/input.ts
@@ -14,6 +14,7 @@ const effortLevelSchema = z.enum(["fast", "medium", "long"]);
 const fsrsCardStateSchema = z.enum(["new", "learning", "review", "relearning"]);
 const reviewRatingSchema = z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]);
 const platformSchema = z.enum(["ios", "android", "web"]);
+const installationIdSchema = z.string().uuid();
 const isoTimestampStringSchema = z.string().datetime();
 const cardTypeSchema = z.string();
 const mediaAssetMimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
@@ -351,7 +352,7 @@ const syncPushOperationSchema = z.discriminatedUnion("entityType", [
 ]);
 
 const syncPushInputBaseSchema = z.object({
-  installationId: z.string().min(1),
+  installationId: installationIdSchema,
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   operations: z.array(syncPushOperationSchema),
@@ -385,7 +386,7 @@ function validateSyncPushReviewEventTimestamps(
 const syncPushInputSchema = syncPushInputBaseSchema.superRefine(validateSyncPushReviewEventTimestamps);
 
 const syncPullInputSchema = z.object({
-  installationId: z.string().min(1),
+  installationId: installationIdSchema,
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   afterHotChangeId: z.number().int().nonnegative(),
@@ -395,7 +396,7 @@ const syncPullInputSchema = z.object({
 
 const syncBootstrapPullInputSchema = z.object({
   mode: z.literal("pull"),
-  installationId: z.string().min(1),
+  installationId: installationIdSchema,
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   cursor: z.string().min(1).nullable(),
@@ -405,7 +406,7 @@ const syncBootstrapPullInputSchema = z.object({
 
 const syncBootstrapPushInputSchema = z.object({
   mode: z.literal("push"),
-  installationId: z.string().min(1),
+  installationId: installationIdSchema,
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   includeMediaAssets: z.boolean().optional(),
@@ -440,7 +441,7 @@ const syncBootstrapPushInputSchema = z.object({
 });
 
 const syncReviewHistoryPullInputSchema = z.object({
-  installationId: z.string().min(1),
+  installationId: installationIdSchema,
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   afterReviewSequenceId: z.number().int().nonnegative(),
@@ -448,7 +449,7 @@ const syncReviewHistoryPullInputSchema = z.object({
 });
 
 const syncReviewHistoryImportInputSchema = z.object({
-  installationId: z.string().min(1),
+  installationId: installationIdSchema,
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   reviewEvents: z.array(reviewEventImportPayloadSchema),

--- a/docs/sync-identity-model.md
+++ b/docs/sync-identity-model.md
@@ -4,7 +4,7 @@ The sync layer now treats installation identity and workspace actor identity as 
 
 ## Installation Id
 
-`installationId` is a stable physical app or browser identity.
+`installationId` is a stable UUID identifying a physical app installation or browser profile.
 
 - It is generated once per Android install, iOS install, or browser profile.
 - It is global across users and workspaces.


### PR DESCRIPTION
## Summary
- validate installationId as a UUID across all external sync request contracts
- return SYNC_INVALID_INPUT before sync processing for malformed identities
- document the stable UUID identity contract and update parser-facing fixtures

## Validation
- Local project checks were not run; cloud CI owns validation.
- Fresh static review found no P0-P4 issues.