### PR TITLE
chore: bump version to 1.23.0

### DIFF
--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-admin",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "d3": "^7.9.0",
         "react": "^19.2.8",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -142,7 +142,7 @@ android {
         minSdk = androidMinSdk
         targetSdk = 37
         versionCode = androidVersionCode ?: 1
-        versionName = "1.22.0"
+        versionName = "1.23.0"
         testInstrumentationRunner = "com.flashcardsopensourceapp.app.FlashcardsAndroidTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         buildConfigField("int", "ANDROID_MIN_SDK", androidMinSdk.toString())

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-auth",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-auth",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1113.0",
         "@hono/node-server": "^2.1.1",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-auth",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-backend",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1113.0",
         "@aws-sdk/client-lambda": "^3.1113.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/entrypoints/index.ts",

--- a/apps/ios/Flashcards/Config/Base.xcconfig
+++ b/apps/ios/Flashcards/Config/Base.xcconfig
@@ -1,6 +1,6 @@
 APP_DISPLAY_NAME = Flashcards
 APP_BUNDLE_IDENTIFIER = com.flashcards-open-source-app.app
-APP_MARKETING_VERSION = 1.22.0
+APP_MARKETING_VERSION = 1.23.0
 // Keep the repository default build number stable. Signed archives should
 // override this locally or in CI when a higher App Store Connect build number is required.
 APP_CURRENT_PROJECT_VERSION = 1

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-web",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.9",
         "@sentry/react": "^10.70.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-aws",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.2",
         "@aws-sdk/client-cloudwatch": "^3.1113.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.flashcards-open-source-app/flashcards",
   "title": "Flashcards Open Source App",
   "description": "Read and write open-source flashcards through split read/write MCP tools.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "websiteUrl": "https://flashcards-open-source-app.com",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- move the shared project version from 1.22.0 to 1.23.0
- keep backend, admin, auth, AWS infra, web, Android, iOS, and the MCP manifest aligned
- leave Android and iOS build-number ownership unchanged

## Validation
- local project checks were not run; cloud PR CI owns validation per repository workflow