### PR TITLE
fix(web): handle chat warm-start storage quota

### DIFF
--- a/apps/web/src/chat/sessionController/lifecycle/warmStart.ts
+++ b/apps/web/src/chat/sessionController/lifecycle/warmStart.ts
@@ -52,6 +52,23 @@ function getBrowserStorage(): Storage | null {
   return storageValue;
 }
 
+function isQuotaExceededError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "QuotaExceededError";
+}
+
+function toPersistableMessages(
+  messages: ChatSessionSnapshot["conversation"]["messages"],
+): ChatSessionSnapshot["conversation"]["messages"] {
+  return messages.map((message) => ({
+    ...message,
+    content: message.content.map((part) => (
+      part.type === "image" || part.type === "file"
+        ? { ...part, base64Data: "" }
+        : part
+    )),
+  }));
+}
+
 function parsePersistedChatSessionWarmStartSnapshot(
   rawValue: string | null,
 ): PersistedChatSessionWarmStartSnapshot | null {
@@ -144,12 +161,25 @@ export function storeChatSessionWarmStartSnapshot(
     pendingToolRunPostSync,
     snapshot: {
       ...snapshot,
+      conversation: {
+        ...snapshot.conversation,
+        messages: toPersistableMessages(snapshot.conversation.messages),
+      },
       composerSuggestions: [],
       activeRun: null,
     },
   };
 
-  browserStorage.setItem(CHAT_SESSION_WARM_START_STORAGE_KEY, JSON.stringify(persistedSnapshot));
+  const serializedSnapshot = JSON.stringify(persistedSnapshot);
+  try {
+    browserStorage.setItem(CHAT_SESSION_WARM_START_STORAGE_KEY, serializedSnapshot);
+  } catch (error) {
+    if (isQuotaExceededError(error) === false) {
+      throw error;
+    }
+
+    browserStorage.removeItem(CHAT_SESSION_WARM_START_STORAGE_KEY);
+  }
 }
 
 export function clearChatSessionWarmStartSnapshot(): void {


### PR DESCRIPTION
## Cause

Sentry FLASHCARDS-WEB-1S showed a synchronous QuotaExceededError from the optional AI chat warm-start localStorage write after the final chat request had already succeeded. Because the write was not handled, the error reached AppCrashFallback and crashed the web app.

## Fix

- Persist a compact warm-start projection that blanks base64Data for image and file message parts while preserving their metadata and all non-binary content.
- Catch only DOMException errors named QuotaExceededError from localStorage.setItem.
- Remove only the chat warm-start storage key on that expected capacity failure and continue without the advisory cache.
- Re-throw every unexpected storage error.

## Validation

A fresh independent static review found no P0-P4 issues and no additional notes. No local tests, lint, typecheck, build, formatter, or smoke checks were run; GitHub CI owns executable validation.