### PR TITLE
Extract backend provider test support

### DIFF
--- a/apps/backend/src/chat/cardImages/provider/openaiAdapter.test.ts
+++ b/apps/backend/src/chat/cardImages/provider/openaiAdapter.test.ts
@@ -1,22 +1,11 @@
 import assert from "node:assert/strict";
-import {
-  createServer,
-  type IncomingMessage,
-  type Server,
-  type ServerResponse,
-} from "node:http";
-import type { AddressInfo } from "node:net";
 import test from "node:test";
 import type { LangfuseObservation } from "@langfuse/tracing";
-import * as Sentry from "@sentry/aws-serverless";
 import OpenAI from "openai";
 import { maximumImageIngestionOriginalBytes } from "../../../mediaAssets/validators";
 import {
   createBackendObservationScope,
 } from "../../../observability/sentry";
-import {
-  sentryModule,
-} from "../../../observability/sentry/testHelpers";
 import { buildOpenAISafetyIdentifier } from "../../openai/safetyIdentifier";
 import {
   decodeGeneratedCardImageBase64,
@@ -32,53 +21,17 @@ import type {
   OpenAIImageGenerationInput,
 } from "./providerTypes";
 import { GeneratedCardImageDeadlineExceededError } from "../providerTypes";
-
-type CapturedProviderRequest = Readonly<{
-  method: string | null;
-  path: string | null;
-  authorization: string | null;
-  contentType: string | null;
-  body: unknown;
-}>;
-
-type ProviderRequestResponder = (
-  request: CapturedProviderRequest,
-  requestNumber: number,
-  response: ServerResponse,
-) => void | Promise<void>;
-
-type ProviderTestServer = Readonly<{
-  baseURL: string;
-  requests: Array<CapturedProviderRequest>;
-  handlerErrors: Array<Error>;
-  waitForRequestCount: (expectedCount: number) => Promise<void>;
-  close: () => Promise<void>;
-}>;
-
-type ProviderTelemetryCapture = Readonly<{
-  cloudWatchLogs: Array<string>;
-  cloudWatchWarnings: Array<string>;
-  sentryBreadcrumbs: Array<Parameters<typeof Sentry.addBreadcrumb>[0]>;
-  sentryContexts: Array<Readonly<{
-    name: string;
-    context: Parameters<Sentry.Scope["setContext"]>[1];
-  }>>;
-}>;
-
-type MutableSentryTelemetryModule = typeof sentryModule & Readonly<{
-  addBreadcrumb: typeof Sentry.addBreadcrumb;
-}>;
-
-type RecordedLangfuseTelemetry = Readonly<{
-  rootObservation: LangfuseObservation;
-  starts: Array<Readonly<{
-    name: string;
-    attributes: unknown;
-    options: unknown;
-  }>>;
-  updates: Array<unknown>;
-  getEndCount: () => number;
-}>;
+import {
+  createRecordedLangfuseTelemetry,
+  type RecordedLangfuseTelemetry,
+  withProviderTelemetryCapture,
+} from "./providerTelemetryCapture.testSupport";
+import {
+  withProviderTestServer,
+  writeJsonResponse,
+  writeJsonResponseWithHeaders,
+  writeRawResponse,
+} from "./providerTestServer.testSupport";
 
 const providerRequestWaitTimeoutMs = 2_000;
 
@@ -93,187 +46,6 @@ function toRecord(value: unknown): Readonly<Record<string, unknown>> {
 function parseJsonObject(value: string): Readonly<Record<string, unknown>> {
   const parsed: unknown = JSON.parse(value);
   return toRecord(parsed);
-}
-
-async function readRequestBody(request: IncomingMessage): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const chunks: Array<Buffer> = [];
-    request.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-    request.once("end", () => {
-      resolve(Buffer.concat(chunks).toString("utf8"));
-    });
-    request.once("error", reject);
-  });
-}
-
-function normalizeServerHandlerError(error: unknown): Error {
-  return error instanceof Error
-    ? error
-    : new Error(`Provider test server handler threw a non-Error value: ${String(error)}`);
-}
-
-async function captureProviderRequest(request: IncomingMessage): Promise<CapturedProviderRequest> {
-  const requestBody = await readRequestBody(request);
-  return {
-    method: request.method ?? null,
-    path: request.url ?? null,
-    authorization: request.headers.authorization ?? null,
-    contentType: request.headers["content-type"] ?? null,
-    body: parseJsonObject(requestBody),
-  };
-}
-
-function createRequestCountWaiter(
-  requests: ReadonlyArray<CapturedProviderRequest>,
-  requestListeners: Set<() => void>,
-  expectedCount: number,
-): Promise<void> {
-  if (requests.length >= expectedCount) {
-    return Promise.resolve();
-  }
-
-  return new Promise<void>((resolve, reject) => {
-    const handleRequest = (): void => {
-      if (requests.length < expectedCount) {
-        return;
-      }
-
-      clearTimeout(timeout);
-      requestListeners.delete(handleRequest);
-      resolve();
-    };
-    const timeout = setTimeout(() => {
-      requestListeners.delete(handleRequest);
-      reject(
-        new Error(
-          `Timed out waiting for ${expectedCount} provider requests; received ${requests.length}.`,
-        ),
-      );
-    }, providerRequestWaitTimeoutMs);
-
-    requestListeners.add(handleRequest);
-  });
-}
-
-async function closeProviderTestServer(server: Server): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error !== undefined) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-    server.closeAllConnections();
-  });
-}
-
-async function startProviderTestServer(
-  responder: ProviderRequestResponder,
-): Promise<ProviderTestServer> {
-  const requests: Array<CapturedProviderRequest> = [];
-  const handlerErrors: Array<Error> = [];
-  const requestListeners: Set<() => void> = new Set();
-  const server = createServer((request, response) => {
-    void (async (): Promise<void> => {
-      const capturedRequest = await captureProviderRequest(request);
-      requests.push(capturedRequest);
-      for (const listener of requestListeners) {
-        listener();
-      }
-
-      await responder(capturedRequest, requests.length, response);
-    })().catch((error: unknown) => {
-      const handlerError = normalizeServerHandlerError(error);
-      handlerErrors.push(handlerError);
-      response.destroy(handlerError);
-    });
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.removeListener("error", reject);
-      resolve();
-    });
-  });
-
-  const address = server.address();
-  if (address === null || typeof address === "string") {
-    await closeProviderTestServer(server);
-    throw new Error("Provider test server did not expose a TCP address.");
-  }
-
-  const tcpAddress = address as AddressInfo;
-  return {
-    baseURL: `http://127.0.0.1:${tcpAddress.port}/v1`,
-    requests,
-    handlerErrors,
-    waitForRequestCount: async (expectedCount: number): Promise<void> => {
-      await createRequestCountWaiter(requests, requestListeners, expectedCount);
-    },
-    close: async (): Promise<void> => {
-      await closeProviderTestServer(server);
-    },
-  };
-}
-
-async function withProviderTestServer<Result>(
-  responder: ProviderRequestResponder,
-  run: (server: ProviderTestServer) => Promise<Result>,
-): Promise<Result> {
-  const server = await startProviderTestServer(responder);
-  try {
-    const result = await run(server);
-    if (server.handlerErrors.length > 0) {
-      throw server.handlerErrors[0];
-    }
-
-    return result;
-  } finally {
-    await server.close();
-  }
-}
-
-function writeJsonResponse(
-  response: ServerResponse,
-  statusCode: number,
-  requestId: string,
-  body: Readonly<Record<string, unknown>>,
-): void {
-  writeJsonResponseWithHeaders(response, statusCode, requestId, body, {});
-}
-
-function writeJsonResponseWithHeaders(
-  response: ServerResponse,
-  statusCode: number,
-  requestId: string,
-  body: Readonly<Record<string, unknown>>,
-  headers: Readonly<Record<string, string>>,
-): void {
-  response.writeHead(statusCode, {
-    "content-type": "application/json",
-    "x-request-id": requestId,
-    ...headers,
-  });
-  response.end(JSON.stringify(body));
-}
-
-function writeRawResponse(
-  response: ServerResponse,
-  statusCode: number,
-  requestId: string,
-  contentType: string,
-  body: string,
-): void {
-  response.writeHead(statusCode, {
-    "content-type": contentType,
-    "x-request-id": requestId,
-  });
-  response.end(body);
 }
 
 function createProvider(baseURL: string): OpenAIGeneratedCardImageProvider {
@@ -317,88 +89,6 @@ function createProviderInput(
     signal,
     operationDeadlineMs: Date.now() + 120_000,
   };
-}
-
-function createRecordedLangfuseTelemetry(): RecordedLangfuseTelemetry {
-  const starts: RecordedLangfuseTelemetry["starts"] = [];
-  const updates: RecordedLangfuseTelemetry["updates"] = [];
-  let endCount = 0;
-  const childObservation = {
-    updateOtelSpanAttributes: (attributes: unknown): void => {
-      updates.push(attributes);
-    },
-    end: (): void => {
-      endCount += 1;
-    },
-  };
-  const rootObservation = {
-    startObservation: (name: string, attributes: unknown, options: unknown) => {
-      starts.push({
-        name,
-        attributes,
-        options,
-      });
-      return childObservation;
-    },
-  } as unknown as LangfuseObservation;
-
-  return {
-    rootObservation,
-    starts,
-    updates,
-    getEndCount: (): number => endCount,
-  };
-}
-
-async function withProviderTelemetryCapture<Result>(
-  run: (capture: ProviderTelemetryCapture) => Promise<Result>,
-): Promise<Readonly<{
-  capture: ProviderTelemetryCapture;
-  result: Result;
-}>> {
-  const capture: ProviderTelemetryCapture = {
-    cloudWatchLogs: [],
-    cloudWatchWarnings: [],
-    sentryBreadcrumbs: [],
-    sentryContexts: [],
-  };
-  const mutableSentryModule = sentryModule as MutableSentryTelemetryModule;
-  const originalLog = console.log;
-  const originalWarn = console.warn;
-  const originalAddBreadcrumb = mutableSentryModule.addBreadcrumb;
-  const originalCaptureMessage = sentryModule.captureMessage;
-  const originalSetContext = Sentry.Scope.prototype.setContext;
-
-  console.log = (message?: unknown): void => {
-    capture.cloudWatchLogs.push(typeof message === "string" ? message : String(message));
-  };
-  console.warn = (message?: unknown): void => {
-    capture.cloudWatchWarnings.push(typeof message === "string" ? message : String(message));
-  };
-  mutableSentryModule.addBreadcrumb = (breadcrumb): void => {
-    capture.sentryBreadcrumbs.push(breadcrumb);
-  };
-  sentryModule.captureMessage = (_message, _captureContext) => "provider-test-sentry-event";
-  Sentry.Scope.prototype.setContext = function setContext(name, context) {
-    capture.sentryContexts.push({
-      name,
-      context,
-    });
-    return this;
-  };
-
-  try {
-    return {
-      capture,
-      result: await run(capture),
-    };
-  } finally {
-    console.log = originalLog;
-    console.warn = originalWarn;
-    mutableSentryModule.addBreadcrumb = originalAddBreadcrumb;
-    sentryModule.captureMessage = originalCaptureMessage;
-    Sentry.Scope.prototype.setContext = originalSetContext;
-  }
 }
 
 async function captureThrownError(promise: Promise<unknown>): Promise<Error> {

--- a/apps/backend/src/chat/cardImages/provider/providerTelemetryCapture.testSupport.ts
+++ b/apps/backend/src/chat/cardImages/provider/providerTelemetryCapture.testSupport.ts
@@ -1,0 +1,112 @@
+import type { LangfuseObservation } from "@langfuse/tracing";
+import * as Sentry from "@sentry/aws-serverless";
+import {
+  sentryModule,
+} from "../../../observability/sentry/testHelpers";
+
+export type ProviderTelemetryCapture = Readonly<{
+  cloudWatchLogs: Array<string>;
+  cloudWatchWarnings: Array<string>;
+  sentryBreadcrumbs: Array<Parameters<typeof Sentry.addBreadcrumb>[0]>;
+  sentryContexts: Array<Readonly<{
+    name: string;
+    context: Parameters<Sentry.Scope["setContext"]>[1];
+  }>>;
+}>;
+
+type MutableSentryTelemetryModule = typeof sentryModule & Readonly<{
+  addBreadcrumb: typeof Sentry.addBreadcrumb;
+}>;
+
+export type RecordedLangfuseTelemetry = Readonly<{
+  rootObservation: LangfuseObservation;
+  starts: Array<Readonly<{
+    name: string;
+    attributes: unknown;
+    options: unknown;
+  }>>;
+  updates: Array<unknown>;
+  getEndCount: () => number;
+}>;
+
+export function createRecordedLangfuseTelemetry(): RecordedLangfuseTelemetry {
+  const starts: RecordedLangfuseTelemetry["starts"] = [];
+  const updates: RecordedLangfuseTelemetry["updates"] = [];
+  let endCount = 0;
+  const childObservation = {
+    updateOtelSpanAttributes: (attributes: unknown): void => {
+      updates.push(attributes);
+    },
+    end: (): void => {
+      endCount += 1;
+    },
+  };
+  const rootObservation = {
+    startObservation: (name: string, attributes: unknown, options: unknown) => {
+      starts.push({
+        name,
+        attributes,
+        options,
+      });
+      return childObservation;
+    },
+  } as unknown as LangfuseObservation;
+
+  return {
+    rootObservation,
+    starts,
+    updates,
+    getEndCount: (): number => endCount,
+  };
+}
+
+export async function withProviderTelemetryCapture<Result>(
+  run: (capture: ProviderTelemetryCapture) => Promise<Result>,
+): Promise<Readonly<{
+  capture: ProviderTelemetryCapture;
+  result: Result;
+}>> {
+  const capture: ProviderTelemetryCapture = {
+    cloudWatchLogs: [],
+    cloudWatchWarnings: [],
+    sentryBreadcrumbs: [],
+    sentryContexts: [],
+  };
+  const mutableSentryModule = sentryModule as MutableSentryTelemetryModule;
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalAddBreadcrumb = mutableSentryModule.addBreadcrumb;
+  const originalCaptureMessage = sentryModule.captureMessage;
+  const originalSetContext = Sentry.Scope.prototype.setContext;
+
+  try {
+    console.log = (message?: unknown): void => {
+      capture.cloudWatchLogs.push(typeof message === "string" ? message : String(message));
+    };
+    console.warn = (message?: unknown): void => {
+      capture.cloudWatchWarnings.push(typeof message === "string" ? message : String(message));
+    };
+    mutableSentryModule.addBreadcrumb = (breadcrumb): void => {
+      capture.sentryBreadcrumbs.push(breadcrumb);
+    };
+    sentryModule.captureMessage = (_message, _captureContext) => "provider-test-sentry-event";
+    Sentry.Scope.prototype.setContext = function setContext(name, context) {
+      capture.sentryContexts.push({
+        name,
+        context,
+      });
+      return this;
+    };
+
+    return {
+      capture,
+      result: await run(capture),
+    };
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    mutableSentryModule.addBreadcrumb = originalAddBreadcrumb;
+    sentryModule.captureMessage = originalCaptureMessage;
+    Sentry.Scope.prototype.setContext = originalSetContext;
+  }
+}

--- a/apps/backend/src/chat/cardImages/provider/providerTestServer.testSupport.ts
+++ b/apps/backend/src/chat/cardImages/provider/providerTestServer.testSupport.ts
@@ -1,0 +1,236 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+export type CapturedProviderRequest = Readonly<{
+  method: string | null;
+  path: string | null;
+  authorization: string | null;
+  contentType: string | null;
+  body: unknown;
+}>;
+
+type ProviderRequestResponder = (
+  request: CapturedProviderRequest,
+  requestNumber: number,
+  response: ServerResponse,
+) => void | Promise<void>;
+
+type ProviderTestServer = Readonly<{
+  baseURL: string;
+  requests: Array<CapturedProviderRequest>;
+  waitForRequestCount: (expectedCount: number) => Promise<void>;
+}>;
+
+type RunningProviderTestServer = ProviderTestServer & Readonly<{
+  handlerErrors: Array<Error>;
+  close: () => Promise<void>;
+}>;
+
+const providerRequestWaitTimeoutMs = 2_000;
+
+function toRecord(value: unknown): Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Expected a JSON object.");
+  }
+
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function parseJsonObject(value: string): Readonly<Record<string, unknown>> {
+  const parsed: unknown = JSON.parse(value);
+  return toRecord(parsed);
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Array<Buffer> = [];
+    request.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    request.once("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    request.once("error", reject);
+  });
+}
+
+function normalizeServerHandlerError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error(`Provider test server handler threw a non-Error value: ${String(error)}`);
+}
+
+async function captureProviderRequest(request: IncomingMessage): Promise<CapturedProviderRequest> {
+  const requestBody = await readRequestBody(request);
+  return {
+    method: request.method ?? null,
+    path: request.url ?? null,
+    authorization: request.headers.authorization ?? null,
+    contentType: request.headers["content-type"] ?? null,
+    body: parseJsonObject(requestBody),
+  };
+}
+
+function createRequestCountWaiter(
+  requests: ReadonlyArray<CapturedProviderRequest>,
+  requestListeners: Set<() => void>,
+  expectedCount: number,
+): Promise<void> {
+  if (requests.length >= expectedCount) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const handleRequest = (): void => {
+      if (requests.length < expectedCount) {
+        return;
+      }
+
+      clearTimeout(timeout);
+      requestListeners.delete(handleRequest);
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      requestListeners.delete(handleRequest);
+      reject(
+        new Error(
+          `Timed out waiting for ${expectedCount} provider requests; received ${requests.length}.`,
+        ),
+      );
+    }, providerRequestWaitTimeoutMs);
+
+    requestListeners.add(handleRequest);
+  });
+}
+
+async function closeProviderTestServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+    server.closeAllConnections();
+  });
+}
+
+async function startProviderTestServer(
+  responder: ProviderRequestResponder,
+): Promise<RunningProviderTestServer> {
+  const requests: Array<CapturedProviderRequest> = [];
+  const handlerErrors: Array<Error> = [];
+  const requestListeners: Set<() => void> = new Set();
+  const server = createServer((request, response) => {
+    void (async (): Promise<void> => {
+      const capturedRequest = await captureProviderRequest(request);
+      requests.push(capturedRequest);
+      for (const listener of requestListeners) {
+        listener();
+      }
+
+      await responder(capturedRequest, requests.length, response);
+    })().catch((error: unknown) => {
+      const handlerError = normalizeServerHandlerError(error);
+      handlerErrors.push(handlerError);
+      response.destroy(handlerError);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    await closeProviderTestServer(server);
+    throw new Error("Provider test server did not expose a TCP address.");
+  }
+
+  const tcpAddress = address as AddressInfo;
+  return {
+    baseURL: `http://127.0.0.1:${tcpAddress.port}/v1`,
+    requests,
+    handlerErrors,
+    waitForRequestCount: async (expectedCount: number): Promise<void> => {
+      await createRequestCountWaiter(requests, requestListeners, expectedCount);
+    },
+    close: async (): Promise<void> => {
+      await closeProviderTestServer(server);
+    },
+  };
+}
+
+export async function withProviderTestServer<Result>(
+  responder: ProviderRequestResponder,
+  run: (server: ProviderTestServer) => Promise<Result>,
+): Promise<Result> {
+  const server = await startProviderTestServer(responder);
+  try {
+    try {
+      const result = await run(server);
+      if (server.handlerErrors.length > 0) {
+        throw server.handlerErrors[0];
+      }
+
+      return result;
+    } catch (error) {
+      if (server.handlerErrors.length > 0) {
+        throw server.handlerErrors[0];
+      }
+
+      throw error;
+    }
+  } finally {
+    await server.close();
+  }
+}
+
+export function writeJsonResponse(
+  response: ServerResponse,
+  statusCode: number,
+  requestId: string,
+  body: Readonly<Record<string, unknown>>,
+): void {
+  writeJsonResponseWithHeaders(response, statusCode, requestId, body, {});
+}
+
+export function writeJsonResponseWithHeaders(
+  response: ServerResponse,
+  statusCode: number,
+  requestId: string,
+  body: Readonly<Record<string, unknown>>,
+  headers: Readonly<Record<string, string>>,
+): void {
+  response.writeHead(statusCode, {
+    "content-type": "application/json",
+    "x-request-id": requestId,
+    ...headers,
+  });
+  response.end(JSON.stringify(body));
+}
+
+export function writeRawResponse(
+  response: ServerResponse,
+  statusCode: number,
+  requestId: string,
+  contentType: string,
+  body: string,
+): void {
+  response.writeHead(statusCode, {
+    "content-type": contentType,
+    "x-request-id": requestId,
+  });
+  response.end(body);
+}


### PR DESCRIPTION
## Summary

- extract the provider HTTP test-server lifecycle into a sibling test-support module
- extract provider telemetry capture and recorded Langfuse support into a sibling test-support module
- keep all fourteen provider scenarios and production behavior unchanged

## Validation

- independent static review passed with no P0-P4 findings
- local project checks intentionally not run; cloud CI owns executable validation