### PR TITLE
Allow crawlers on the MCP host

### DIFF
--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -347,6 +347,11 @@ async function handleMcpTransportRequest(
 
 function buildMcpRoutes(app: Hono<McpAppEnv>): Hono<McpAppEnv> {
   app.get("/health", (c) => c.json({ status: "ok" }));
+  app.get("/robots.txt", (c) =>
+    c.body("User-agent: *\nDisallow:\n", 200, {
+      "Content-Type": "text/plain; charset=utf-8",
+    }),
+  );
 
   // Serve PRM at both the RFC 9728 path-aware location (`/mcp` suffix, used by
   // spec-current clients) and the legacy path-less location (older clients).

--- a/infra/aws/lib/gateways/mcp-gateway.test.ts
+++ b/infra/aws/lib/gateways/mcp-gateway.test.ts
@@ -70,6 +70,9 @@ test("MCP HTTP API synthesizes explicit public routes and default mapped-path ro
   template.hasResourceProperties("AWS::ApiGatewayV2::Route", {
     RouteKey: "GET /health",
   });
+  template.hasResourceProperties("AWS::ApiGatewayV2::Route", {
+    RouteKey: "GET /robots.txt",
+  });
 });
 
 test("MCP HTTP API mappings synthesize for public route prefixes without a v2 custom domain", () => {
@@ -80,6 +83,7 @@ test("MCP HTTP API mappings synthesize for public route prefixes without a v2 cu
   for (const apiMappingKey of [
     "mcp",
     "health",
+    "robots.txt",
     ".well-known/oauth-protected-resource",
     ".well-known/oauth-protected-resource/mcp",
   ]) {

--- a/infra/aws/lib/gateways/mcp-gateway.ts
+++ b/infra/aws/lib/gateways/mcp-gateway.ts
@@ -50,6 +50,10 @@ const mcpHttpApiMappings: ReadonlyArray<McpHttpApiMapping> = [
     apiMappingKey: "health",
   },
   {
+    constructId: "McpHttpRobotsApiMapping",
+    apiMappingKey: "robots.txt",
+  },
+  {
     constructId: "McpHttpProtectedResourceApiMapping",
     apiMappingKey: ".well-known/oauth-protected-resource",
   },
@@ -172,6 +176,11 @@ export function addMcpHttpApiRoutes(
   });
   httpApi.addRoutes({
     path: "/health",
+    methods: [apigwv2.HttpMethod.GET],
+    integration,
+  });
+  httpApi.addRoutes({
+    path: "/robots.txt",
     methods: [apigwv2.HttpMethod.GET],
     integration,
   });


### PR DESCRIPTION
## Summary
- serve an explicit allow-all robots.txt from the MCP Lambda
- map robots.txt through the MCP HTTP API custom domain
- extend synthesized route and mapping expectations

## Validation
- local project checks not run; GitHub PR checks own validation