### PR TITLE
Restore catalog endpoint headroom

### DIFF
--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -120,7 +120,7 @@ test("backend, direct ingestion, and chat worker package sharp with ARM64 Docker
 
   assert.match(
     backendConfiguration,
-    /mediaAssetsBucket: props\.mediaAssetsBucket[\s\S]*memorySize: 1024[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
+    /mediaAssetsBucket: props\.mediaAssetsBucket[\s\S]*memorySize: 2048[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
   );
   assert.match(
     chatWorkerConfiguration,

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -806,7 +806,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       snapshotObjectKey: props.globalMetricsSnapshotObjectKey,
     },
     mediaAssetsBucket: props.mediaAssetsBucket,
-    memorySize: 1024,
+    memorySize: 2048,
     architecture: lambda.Architecture.ARM_64,
     bundling: createLambdaBundling({
       nodeModules: ["sharp"],


### PR DESCRIPTION
## Summary
- increase only the main backend Lambda memory from 1,024 MB to 2,048 MB
- update the existing matching infrastructure assertion

## Validation
- `npm run build` in `infra/aws`
- filtered existing infrastructure assertion: `backend, direct ingestion, and chat worker package sharp with ARM64 Docker bundling`
- fresh independent static review: no P0-P4 findings