### PR TITLE
Fetch one catalog version on the web import screen

### DIFF
--- a/apps/backend/src/catalog/distribution/public/browse.ts
+++ b/apps/backend/src/catalog/distribution/public/browse.ts
@@ -19,6 +19,7 @@ import type {
   CatalogPublicPackageDetail,
   CatalogPublicPackageListInput,
   CatalogPublicPackageSummary,
+  CatalogPublicPackageVersionDetail,
   CatalogPublicPackageVersionSummary,
   TimestampValue,
 } from "../../types";
@@ -55,6 +56,21 @@ type CatalogPublicPackageRow = Readonly<{
   published_at: TimestampValue;
 }>;
 
+type CatalogPublicPackageVersionDetailRow = Readonly<{
+  package_version_id: string;
+  package_id: string;
+  version_number: string | number;
+  slug: string;
+  title: string;
+  summary: string;
+  language_tags: ReadonlyArray<string>;
+  card_count: string | number;
+  published_at: TimestampValue;
+  author_id: string;
+  author_slug: string;
+  author_display_name: string;
+}>;
+
 type CatalogPublicPackageCardPreviewRow = Readonly<{
   ordinal: string | number;
   front_text: string;
@@ -85,6 +101,21 @@ const publicCatalogPackageSelectColumns = [
   "versions.card_count AS card_count",
   "versions.updated_at AS updated_at",
   "versions.published_at AS published_at",
+].join(", ");
+
+const publicCatalogPackageVersionDetailSelectColumns = [
+  "versions.package_version_id AS package_version_id",
+  "versions.package_id AS package_id",
+  "versions.version_number AS version_number",
+  "versions.slug AS slug",
+  "versions.title AS title",
+  "versions.summary AS summary",
+  "versions.language_tags AS language_tags",
+  "versions.card_count AS card_count",
+  "versions.published_at AS published_at",
+  "authors.author_id AS author_id",
+  "authors.slug AS author_slug",
+  "authors.display_name AS author_display_name",
 ].join(", ");
 
 const latestPublishedVersionsCte = [
@@ -282,6 +313,32 @@ function mapCatalogPublicPackageVersionSummary(
   };
 }
 
+function mapCatalogPublicPackageVersionDetail(
+  row: CatalogPublicPackageVersionDetailRow,
+): CatalogPublicPackageVersionDetail {
+  assertPublicCatalogTextSafe(row.package_version_id, row.title);
+  assertPublicCatalogTextSafe(row.package_version_id, row.summary);
+  assertPublicCatalogTextArraySafe(row.package_version_id, row.language_tags);
+  assertPublicCatalogTextSafe(row.package_version_id, row.author_display_name);
+
+  return {
+    packageVersionId: row.package_version_id,
+    packageId: row.package_id,
+    versionNumber: toSafeNumber(row.version_number, "version_number"),
+    slug: row.slug,
+    title: row.title,
+    summary: row.summary,
+    languageTags: [...row.language_tags],
+    cardCount: toSafeNumber(row.card_count, "card_count"),
+    publishedAt: toIsoString(row.published_at),
+    author: {
+      authorId: row.author_id,
+      slug: row.author_slug,
+      displayName: row.author_display_name,
+    },
+  };
+}
+
 function mapCatalogPublicPackageSummary(row: CatalogPublicPackageRow): CatalogPublicPackageSummary {
   const latestVersion = mapCatalogPublicPackageVersionSummary(row);
   return {
@@ -401,6 +458,36 @@ export async function loadPublicCatalogPackageDetailInExecutor(
   };
 }
 
+export async function loadPublicCatalogPackageVersionInExecutor(
+  executor: DatabaseExecutor,
+  packageVersionId: string,
+): Promise<CatalogPublicPackageVersionDetail> {
+  await assertPublicPackageVersionPublishedInExecutor(executor, packageVersionId);
+  const result = await executor.query<CatalogPublicPackageVersionDetailRow>(
+    [
+      "SELECT",
+      publicCatalogPackageVersionDetailSelectColumns,
+      "FROM catalog.package_versions AS versions",
+      "INNER JOIN catalog.packages AS packages",
+      "ON packages.package_id = versions.package_id",
+      "INNER JOIN catalog.authors AS authors",
+      "ON authors.author_id = packages.author_id",
+      "WHERE versions.package_version_id = $1",
+      "LIMIT 1",
+    ].join(" "),
+    [packageVersionId],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(
+      `Expected published catalog package version to return a row. packageVersionId=${packageVersionId}`,
+    );
+  }
+
+  return mapCatalogPublicPackageVersionDetail(row);
+}
+
 export async function loadPublicCatalogPackageVersionCardPreviewInExecutor(
   executor: DatabaseExecutor,
   input: CatalogPublicPackageCardPreviewInput,
@@ -436,6 +523,14 @@ export async function loadPublicCatalogPackageDetail(
 ): Promise<CatalogPublicPackageDetail> {
   return unsafeRepeatableReadReadOnlyTransaction(async (executor) => (
     loadPublicCatalogPackageDetailInExecutor(executor, packageSlug)
+  ));
+}
+
+export async function loadPublicCatalogPackageVersion(
+  packageVersionId: string,
+): Promise<CatalogPublicPackageVersionDetail> {
+  return unsafeRepeatableReadReadOnlyTransaction(async (executor) => (
+    loadPublicCatalogPackageVersionInExecutor(executor, packageVersionId)
   ));
 }
 

--- a/apps/backend/src/catalog/distribution/public/index.ts
+++ b/apps/backend/src/catalog/distribution/public/index.ts
@@ -3,8 +3,10 @@ export {
   listPublicCatalogPackagesInExecutor,
   loadPublicCatalogPackageDetail,
   loadPublicCatalogPackageDetailInExecutor,
+  loadPublicCatalogPackageVersion,
   loadPublicCatalogPackageVersionCardPreview,
   loadPublicCatalogPackageVersionCardPreviewInExecutor,
+  loadPublicCatalogPackageVersionInExecutor,
   normalizeCatalogPublicPackageCardPreviewInput,
   normalizeCatalogPublicPackageListInput,
 } from "./browse";

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -56,8 +56,10 @@ export {
   loadPublicCatalogPackageDetailInExecutor,
   loadPublicCatalogPackageMediaForDownload,
   loadPublicCatalogPackageMediaForDownloadInExecutor,
+  loadPublicCatalogPackageVersion,
   loadPublicCatalogPackageVersionCardPreview,
   loadPublicCatalogPackageVersionCardPreviewInExecutor,
+  loadPublicCatalogPackageVersionInExecutor,
 } from "./distribution/public";
 export {
   catalogPackageInstallOperationIdPrefixMaximumLength,

--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -232,6 +232,25 @@ export type CatalogPublicPackageVersionSummary = Readonly<{
   publishedAt: string;
 }>;
 
+export type CatalogPublicPackageVersionAuthor = Readonly<{
+  authorId: string;
+  slug: string;
+  displayName: string;
+}>;
+
+export type CatalogPublicPackageVersionDetail = Readonly<{
+  packageVersionId: string;
+  packageId: string;
+  versionNumber: number;
+  slug: string;
+  title: string;
+  summary: string;
+  languageTags: ReadonlyArray<string>;
+  cardCount: number;
+  publishedAt: string;
+  author: CatalogPublicPackageVersionAuthor;
+}>;
+
 export type CatalogPublicPackageSummary = Readonly<{
   packageId: string;
   slug: string;

--- a/apps/backend/src/routes/catalog/public.ts
+++ b/apps/backend/src/routes/catalog/public.ts
@@ -5,6 +5,7 @@ import {
   loadPublicCatalogSnapshot,
   loadPublicCatalogPackageDetail,
   loadPublicCatalogPackageMediaForDownload,
+  loadPublicCatalogPackageVersion,
   loadPublicCatalogPackageVersionCardPreview,
 } from "../../catalog";
 import {
@@ -23,6 +24,7 @@ import type {
   CatalogPublicPackageListInput,
   CatalogPublicPackageMediaDownloadSource,
   CatalogPublicPackageSummary,
+  CatalogPublicPackageVersionDetail,
   CatalogPublicSnapshot,
 } from "../../catalog/types";
 import {
@@ -51,6 +53,9 @@ type CatalogPublicRoutesOptions = Readonly<{
     input: CatalogPublicPackageListInput,
   ) => Promise<ReadonlyArray<CatalogPublicPackageSummary>>;
   loadPublicCatalogPackageDetailFn?: (packageSlug: string) => Promise<CatalogPublicPackageDetail>;
+  loadPublicCatalogPackageVersionFn?: (
+    packageVersionId: string,
+  ) => Promise<CatalogPublicPackageVersionDetail>;
   loadPublicCatalogPackageVersionCardPreviewFn?: (
     input: Readonly<{ packageVersionId: string; limit: number }>,
   ) => Promise<ReadonlyArray<CatalogPublicPackageCardPreview>>;
@@ -278,6 +283,8 @@ export function createCatalogPublicRoutes(options: CatalogPublicRoutesOptions): 
   const listPublicCatalogPackagesFn = options.listPublicCatalogPackagesFn ?? listPublicCatalogPackages;
   const loadPublicCatalogPackageDetailFn = options.loadPublicCatalogPackageDetailFn
     ?? loadPublicCatalogPackageDetail;
+  const loadPublicCatalogPackageVersionFn = options.loadPublicCatalogPackageVersionFn
+    ?? loadPublicCatalogPackageVersion;
   const loadPublicCatalogPackageVersionCardPreviewFn = options.loadPublicCatalogPackageVersionCardPreviewFn
     ?? loadPublicCatalogPackageVersionCardPreview;
   const loadPublicCatalogPackageMediaForDownloadFn = options.loadPublicCatalogPackageMediaForDownloadFn
@@ -306,6 +313,12 @@ export function createCatalogPublicRoutes(options: CatalogPublicRoutesOptions): 
     const packageSlug = parsePackageSlugParam(context.req.param("packageSlug"));
     const catalogPackage = await loadPublicCatalogPackageDetailFn(packageSlug);
     return context.json({ catalogPackage });
+  });
+
+  app.get("/catalog/package-versions/:packageVersionId", async (context) => {
+    const packageVersionId = parsePackageVersionIdParam(context.req.param("packageVersionId"));
+    const catalogPackageVersion = await loadPublicCatalogPackageVersionFn(packageVersionId);
+    return context.json({ catalogPackageVersion });
   });
 
   app.get("/catalog/package-versions/:packageVersionId/cards", async (context) => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -73,7 +73,7 @@ export {
 } from "./api/endpoints/workspacePackageImport";
 export {
   confirmCatalogPackageInstall,
-  loadPublicCatalog,
+  loadPublicCatalogPackageVersion,
   previewCatalogPackageInstall,
 } from "./api/endpoints/catalog";
 export {

--- a/apps/web/src/api/endpoints/catalog.test.ts
+++ b/apps/web/src/api/endpoints/catalog.test.ts
@@ -9,7 +9,7 @@ import type {
 import { primeSessionCsrfToken } from "../transport/transport";
 import {
   confirmCatalogPackageInstall,
-  loadPublicCatalog,
+  loadPublicCatalogPackageVersion,
   previewCatalogPackageInstall,
 } from "./catalog";
 
@@ -17,7 +17,6 @@ const workspaceId = "11111111-1111-4111-8111-111111111111";
 const packageVersionId = "22222222-2222-4222-8222-222222222222";
 const packageId = "33333333-3333-4333-8333-333333333333";
 const authorId = "44444444-4444-4444-8444-444444444444";
-const collectionId = "99999999-9999-4999-8999-999999999999";
 
 function createPackageVersion(): CatalogPackageInstallPackageVersion {
   return {
@@ -44,7 +43,23 @@ function createPackageVersion(): CatalogPackageInstallPackageVersion {
 }
 
 describe("catalog API endpoints", () => {
-  it("validates the public snapshot and exact-version preview and confirm responses", async () => {
+  it("validates the public package version lookup and exact-version preview and confirm responses", async () => {
+    const catalogPackageVersion = {
+      packageVersionId,
+      packageId,
+      versionNumber: 1,
+      slug: "test-package",
+      title: "тест",
+      summary: "Test package",
+      languageTags: ["ru"],
+      cardCount: 2,
+      publishedAt: "2026-08-01T10:00:00.000Z",
+      author: {
+        authorId,
+        slug: "test-author",
+        displayName: "Test Author",
+      },
+    };
     const previewResponse = {
       packageVersion: createPackageVersion(),
       summary: { cardCount: 2, mediaAssetCount: 0 },
@@ -76,60 +91,7 @@ describe("catalog API endpoints", () => {
       },
     };
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
-      .mockResolvedValueOnce(new Response(JSON.stringify({
-        schemaVersion: 2,
-        generatedAt: "2026-08-02T10:00:00.000Z",
-        authors: [{
-          authorId,
-          slug: "test-author",
-          displayName: "Test Author",
-          bio: null,
-          websiteUrl: null,
-        }],
-        packages: [{
-          packageId,
-          authorId,
-          slug: "test-package",
-          status: "published",
-          latestPackageVersionId: packageVersionId,
-          versionCount: 1,
-          publishedAt: "2026-08-01T10:00:00.000Z",
-        }],
-        packageVersions: [{
-          ...createPackageVersion(),
-          status: "published",
-          coverMediaAssetId: null,
-          updatedAt: "2026-08-01T10:00:00.000Z",
-          installUrl: `http://localhost:3000/catalog/import/${packageVersionId}`,
-        }],
-        cards: [],
-        mediaAssets: [],
-        collections: [{
-          collectionId,
-          slug: "test-collection",
-          title: "Test collection",
-          summary: "Test collection",
-          description: "Test collection",
-          languageTags: ["en"],
-          coverPackageId: packageId,
-          coverDownloadUrl: `http://localhost:8080/v1/catalog/collections/${collectionId}/cover/download`,
-          status: "published",
-          updatedAt: "2026-08-01T10:00:00.000Z",
-          publishedAt: "2026-08-01T10:00:00.000Z",
-        }, {
-          collectionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-          slug: "legacy-collection",
-          title: "Legacy collection",
-          summary: "Legacy collection",
-          description: "Legacy collection",
-          languageTags: ["en"],
-          coverPackageId: packageId,
-          status: "published",
-          updatedAt: "2026-08-01T10:00:00.000Z",
-          publishedAt: "2026-08-01T10:00:00.000Z",
-        }],
-        collectionPackages: [],
-      }), {
+      .mockResolvedValueOnce(new Response(JSON.stringify({ catalogPackageVersion }), {
         status: 200,
         headers: {
           "Access-Control-Allow-Origin": "http://localhost:3000",
@@ -153,18 +115,13 @@ describe("catalog API endpoints", () => {
       operationIdPrefix: "77777777-7777-4777-8777-777777777777",
     };
 
-    const catalog = await loadPublicCatalog();
-    expect(catalog).toMatchObject({ schemaVersion: 2 });
-    expect(catalog.collections[0]?.coverDownloadUrl).toBe(
-      `http://localhost:8080/v1/catalog/collections/${collectionId}/cover/download`,
-    );
-    expect("coverDownloadUrl" in (catalog.collections[1] ?? {})).toBe(false);
+    await expect(loadPublicCatalogPackageVersion(packageVersionId)).resolves.toEqual(catalogPackageVersion);
     await expect(previewCatalogPackageInstall(workspaceId, packageVersionId)).resolves.toEqual(previewResponse);
     await expect(confirmCatalogPackageInstall(workspaceId, packageVersionId, options)).resolves.toEqual(confirmResponse);
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "http://localhost:8080/v1/catalog",
+      `http://localhost:8080/v1/catalog/package-versions/${packageVersionId}`,
       expect.objectContaining({
         credentials: "omit",
         method: "GET",
@@ -205,9 +162,9 @@ describe("catalog API endpoints", () => {
       }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(loadPublicCatalog()).rejects.toMatchObject({
+    await expect(loadPublicCatalogPackageVersion(packageVersionId)).rejects.toMatchObject({
       code: "INVALID_CATALOG_REQUEST",
-      endpoint: "GET /catalog",
+      endpoint: `GET /catalog/package-versions/${packageVersionId}`,
       message: "Catalog request is invalid.",
       requestId: "header-request-id",
       responseBodyKind: "json",
@@ -216,7 +173,7 @@ describe("catalog API endpoints", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8080/v1/catalog",
+      `http://localhost:8080/v1/catalog/package-versions/${packageVersionId}`,
       expect.objectContaining({
         credentials: "omit",
         method: "GET",

--- a/apps/web/src/api/endpoints/catalog.ts
+++ b/apps/web/src/api/endpoints/catalog.ts
@@ -1,13 +1,13 @@
 import {
   parseCatalogPackageInstallConfirmResponse,
   parseCatalogPackageInstallPreviewResponse,
-  parseCatalogPublicSnapshotResponse,
+  parseCatalogPublicPackageVersionResponse,
 } from "../../apiContracts/catalog";
 import type {
   CatalogPackageInstallConfirmOptions,
   CatalogPackageInstallConfirmResponse,
   CatalogPackageInstallPreviewResponse,
-  CatalogPublicSnapshot,
+  CatalogPublicPackageVersion,
 } from "../../types";
 import { parseContractResponse } from "../transport/response";
 import {
@@ -20,12 +20,16 @@ function encodePathSegment(value: string): string {
   return encodeURIComponent(value);
 }
 
-export async function loadPublicCatalog(): Promise<CatalogPublicSnapshot> {
-  return parseContractResponse(
-    await requestPublicJson("/catalog"),
-    "GET /catalog",
-    parseCatalogPublicSnapshotResponse,
+export async function loadPublicCatalogPackageVersion(
+  packageVersionId: string,
+): Promise<CatalogPublicPackageVersion> {
+  const pathname = `/catalog/package-versions/${encodePathSegment(packageVersionId)}`;
+  const payload = parseContractResponse(
+    await requestPublicJson(pathname),
+    "GET /catalog/package-versions/{id}",
+    parseCatalogPublicPackageVersionResponse,
   );
+  return payload.catalogPackageVersion;
 }
 
 export async function previewCatalogPackageInstall(

--- a/apps/web/src/apiContracts.ts
+++ b/apps/web/src/apiContracts.ts
@@ -53,7 +53,7 @@ export {
 export {
   parseCatalogPackageInstallConfirmResponse,
   parseCatalogPackageInstallPreviewResponse,
-  parseCatalogPublicSnapshotResponse,
+  parseCatalogPublicPackageVersionResponse,
 } from "./apiContracts/catalog";
 export {
   parseProgressReviewScheduleResponse,

--- a/apps/web/src/apiContracts/catalog.ts
+++ b/apps/web/src/apiContracts/catalog.ts
@@ -5,25 +5,17 @@ import type {
   CatalogPackageInstallPackageVersion,
   CatalogPackageInstallPreviewResponse,
   CatalogPackageInstallTagCount,
-  CatalogPublicSnapshot,
-  CatalogPublicSnapshotAuthor,
-  CatalogPublicSnapshotCard,
-  CatalogPublicSnapshotCollection,
-  CatalogPublicSnapshotCollectionPackage,
-  CatalogPublicSnapshotMediaAsset,
-  CatalogPublicSnapshotPackage,
-  CatalogPublicSnapshotPackageVersion,
+  CatalogPublicPackageVersion,
+  CatalogPublicPackageVersionAuthor,
 } from "../types";
 import {
   ApiContractError,
   type JsonObject,
   parseArray,
   parseBoolean,
-  parseLiteral,
   parseNonNegativeInteger,
   parseNullableString,
   parseObject,
-  parseOptionalField,
   parseRequiredField,
   parseString,
   parseStringArray,
@@ -36,157 +28,6 @@ function parsePositiveInteger(value: unknown, endpoint: string, path: string): n
   }
 
   return parsedValue;
-}
-
-function parseCatalogPublicSnapshotAuthor(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotAuthor {
-  const objectValue = parseObject(value, endpoint, path);
-  return {
-    authorId: parseRequiredField(objectValue, "authorId", endpoint, path, parseString),
-    slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
-    displayName: parseRequiredField(objectValue, "displayName", endpoint, path, parseString),
-    bio: parseRequiredField(objectValue, "bio", endpoint, path, parseNullableString),
-    websiteUrl: parseRequiredField(objectValue, "websiteUrl", endpoint, path, parseNullableString),
-  };
-}
-
-function parseCatalogPublicSnapshotPackage(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotPackage {
-  const objectValue = parseObject(value, endpoint, path);
-  return {
-    packageId: parseRequiredField(objectValue, "packageId", endpoint, path, parseString),
-    authorId: parseRequiredField(objectValue, "authorId", endpoint, path, parseString),
-    slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
-    status: parseLiteral(
-      parseRequiredField(objectValue, "status", endpoint, path, parseString),
-      endpoint,
-      `${path}.status`,
-      "published",
-    ),
-    latestPackageVersionId: parseRequiredField(objectValue, "latestPackageVersionId", endpoint, path, parseString),
-    versionCount: parseRequiredField(objectValue, "versionCount", endpoint, path, parsePositiveInteger),
-    publishedAt: parseRequiredField(objectValue, "publishedAt", endpoint, path, parseString),
-  };
-}
-
-function parseCatalogPublicSnapshotPackageVersion(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotPackageVersion {
-  const objectValue = parseObject(value, endpoint, path);
-  return {
-    packageVersionId: parseRequiredField(objectValue, "packageVersionId", endpoint, path, parseString),
-    packageId: parseRequiredField(objectValue, "packageId", endpoint, path, parseString),
-    versionNumber: parseRequiredField(objectValue, "versionNumber", endpoint, path, parsePositiveInteger),
-    status: parseLiteral(
-      parseRequiredField(objectValue, "status", endpoint, path, parseString),
-      endpoint,
-      `${path}.status`,
-      "published",
-    ),
-    slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
-    title: parseRequiredField(objectValue, "title", endpoint, path, parseString),
-    summary: parseRequiredField(objectValue, "summary", endpoint, path, parseString),
-    description: parseRequiredField(objectValue, "description", endpoint, path, parseString),
-    languageTags: parseRequiredField(objectValue, "languageTags", endpoint, path, parseStringArray),
-    license: parseRequiredField(objectValue, "license", endpoint, path, parseString),
-    contentWarning: parseRequiredField(objectValue, "contentWarning", endpoint, path, parseNullableString),
-    coverMediaAssetId: parseRequiredField(objectValue, "coverMediaAssetId", endpoint, path, parseNullableString),
-    cardCount: parseRequiredField(objectValue, "cardCount", endpoint, path, parseNonNegativeInteger),
-    updatedAt: parseRequiredField(objectValue, "updatedAt", endpoint, path, parseString),
-    publishedAt: parseRequiredField(objectValue, "publishedAt", endpoint, path, parseString),
-    installUrl: parseRequiredField(objectValue, "installUrl", endpoint, path, parseString),
-  };
-}
-
-function parseCatalogPublicSnapshotCard(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotCard {
-  const objectValue = parseObject(value, endpoint, path);
-  return {
-    packageCardId: parseRequiredField(objectValue, "packageCardId", endpoint, path, parseString),
-    packageVersionId: parseRequiredField(objectValue, "packageVersionId", endpoint, path, parseString),
-    ordinal: parseRequiredField(objectValue, "ordinal", endpoint, path, parsePositiveInteger),
-    frontText: parseRequiredField(objectValue, "frontText", endpoint, path, parseString),
-    backText: parseRequiredField(objectValue, "backText", endpoint, path, parseString),
-    cardType: parseRequiredField(objectValue, "cardType", endpoint, path, parseString),
-    tags: parseRequiredField(objectValue, "tags", endpoint, path, parseStringArray),
-    mediaAssetIds: parseRequiredField(objectValue, "mediaAssetIds", endpoint, path, parseStringArray),
-  };
-}
-
-function parseCatalogPublicSnapshotMediaAsset(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotMediaAsset {
-  const objectValue = parseObject(value, endpoint, path);
-  return {
-    packageMediaAssetId: parseRequiredField(objectValue, "packageMediaAssetId", endpoint, path, parseString),
-    packageVersionId: parseRequiredField(objectValue, "packageVersionId", endpoint, path, parseString),
-    packageMediaKey: parseRequiredField(objectValue, "packageMediaKey", endpoint, path, parseString),
-    altText: parseRequiredField(objectValue, "altText", endpoint, path, parseNullableString),
-    credit: parseRequiredField(objectValue, "credit", endpoint, path, parseNullableString),
-    license: parseRequiredField(objectValue, "license", endpoint, path, parseNullableString),
-    mimeType: parseRequiredField(objectValue, "mimeType", endpoint, path, parseString),
-    sizeBytes: parseRequiredField(objectValue, "sizeBytes", endpoint, path, parseNonNegativeInteger),
-    downloadUrl: parseRequiredField(objectValue, "downloadUrl", endpoint, path, parseString),
-  };
-}
-
-function parseCatalogPublicSnapshotCollection(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotCollection {
-  const objectValue = parseObject(value, endpoint, path);
-  const coverDownloadUrl = parseOptionalField(
-    objectValue,
-    "coverDownloadUrl",
-    endpoint,
-    path,
-    parseString,
-  );
-  return {
-    collectionId: parseRequiredField(objectValue, "collectionId", endpoint, path, parseString),
-    slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
-    title: parseRequiredField(objectValue, "title", endpoint, path, parseString),
-    summary: parseRequiredField(objectValue, "summary", endpoint, path, parseString),
-    description: parseRequiredField(objectValue, "description", endpoint, path, parseString),
-    languageTags: parseRequiredField(objectValue, "languageTags", endpoint, path, parseStringArray),
-    coverPackageId: parseRequiredField(objectValue, "coverPackageId", endpoint, path, parseNullableString),
-    ...(coverDownloadUrl === undefined ? {} : { coverDownloadUrl }),
-    status: parseLiteral(
-      parseRequiredField(objectValue, "status", endpoint, path, parseString),
-      endpoint,
-      `${path}.status`,
-      "published",
-    ),
-    updatedAt: parseRequiredField(objectValue, "updatedAt", endpoint, path, parseString),
-    publishedAt: parseRequiredField(objectValue, "publishedAt", endpoint, path, parseString),
-  };
-}
-
-function parseCatalogPublicSnapshotCollectionPackage(
-  value: unknown,
-  endpoint: string,
-  path: string,
-): CatalogPublicSnapshotCollectionPackage {
-  const objectValue = parseObject(value, endpoint, path);
-  return {
-    collectionId: parseRequiredField(objectValue, "collectionId", endpoint, path, parseString),
-    packageId: parseRequiredField(objectValue, "packageId", endpoint, path, parseString),
-    ordinal: parseRequiredField(objectValue, "ordinal", endpoint, path, parsePositiveInteger),
-  };
 }
 
 function parseCatalogArray<ParsedValue>(
@@ -204,23 +45,51 @@ function parseCatalogArray<ParsedValue>(
   );
 }
 
-export function parseCatalogPublicSnapshotResponse(value: unknown, endpoint: string): CatalogPublicSnapshot {
+function parseCatalogPublicPackageVersionAuthor(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): CatalogPublicPackageVersionAuthor {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    authorId: parseRequiredField(objectValue, "authorId", endpoint, path, parseString),
+    slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
+    displayName: parseRequiredField(objectValue, "displayName", endpoint, path, parseString),
+  };
+}
+
+function parseCatalogPublicPackageVersion(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): CatalogPublicPackageVersion {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    packageVersionId: parseRequiredField(objectValue, "packageVersionId", endpoint, path, parseString),
+    packageId: parseRequiredField(objectValue, "packageId", endpoint, path, parseString),
+    versionNumber: parseRequiredField(objectValue, "versionNumber", endpoint, path, parsePositiveInteger),
+    slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
+    title: parseRequiredField(objectValue, "title", endpoint, path, parseString),
+    summary: parseRequiredField(objectValue, "summary", endpoint, path, parseString),
+    languageTags: parseRequiredField(objectValue, "languageTags", endpoint, path, parseStringArray),
+    cardCount: parseRequiredField(objectValue, "cardCount", endpoint, path, parseNonNegativeInteger),
+    publishedAt: parseRequiredField(objectValue, "publishedAt", endpoint, path, parseString),
+    author: parseRequiredField(objectValue, "author", endpoint, path, parseCatalogPublicPackageVersionAuthor),
+  };
+}
+
+export function parseCatalogPublicPackageVersionResponse(value: unknown, endpoint: string): Readonly<{
+  catalogPackageVersion: CatalogPublicPackageVersion;
+}> {
   const objectValue = parseObject(value, endpoint, "");
   return {
-    schemaVersion: parseLiteral(
-      parseRequiredField(objectValue, "schemaVersion", endpoint, "", parseNonNegativeInteger),
+    catalogPackageVersion: parseRequiredField(
+      objectValue,
+      "catalogPackageVersion",
       endpoint,
-      "schemaVersion",
-      2,
+      "",
+      parseCatalogPublicPackageVersion,
     ),
-    generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
-    authors: parseCatalogArray(objectValue, "authors", endpoint, parseCatalogPublicSnapshotAuthor),
-    packages: parseCatalogArray(objectValue, "packages", endpoint, parseCatalogPublicSnapshotPackage),
-    packageVersions: parseCatalogArray(objectValue, "packageVersions", endpoint, parseCatalogPublicSnapshotPackageVersion),
-    cards: parseCatalogArray(objectValue, "cards", endpoint, parseCatalogPublicSnapshotCard),
-    mediaAssets: parseCatalogArray(objectValue, "mediaAssets", endpoint, parseCatalogPublicSnapshotMediaAsset),
-    collections: parseCatalogArray(objectValue, "collections", endpoint, parseCatalogPublicSnapshotCollection),
-    collectionPackages: parseCatalogArray(objectValue, "collectionPackages", endpoint, parseCatalogPublicSnapshotCollectionPackage),
   };
 }
 

--- a/apps/web/src/screens/catalog/CatalogImportAuthenticatedFlow.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportAuthenticatedFlow.tsx
@@ -316,9 +316,9 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       userId: session?.userId ?? null,
       workspaceId: identity.workspaceId,
       installationId: identity.installationId,
-      entityId: catalogContext.packageVersion.packageVersionId,
+      entityId: catalogContext.packageVersionId,
     });
-  }, [catalogContext.packageVersion.packageVersionId, session?.userId]);
+  }, [catalogContext.packageVersionId, session?.userId]);
 
   const runPostInstallSync = useCallback(async function runPostInstallSync(
     identity: CatalogWorkspaceIdentity,
@@ -412,12 +412,12 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       indexedDbOpenRecoveryState.throwIfFailed();
       const response = await previewCatalogPackageInstall(
         requestIdentity.workspaceId,
-        catalogContext.packageVersion.packageVersionId,
+        catalogContext.packageVersionId,
       );
       indexedDbOpenRecoveryState.throwIfFailed();
-      if (response.packageVersion.packageVersionId !== catalogContext.packageVersion.packageVersionId) {
+      if (response.packageVersion.packageVersionId !== catalogContext.packageVersionId) {
         throw new Error(
-          `Catalog install preview returned a different package version. expected=${catalogContext.packageVersion.packageVersionId} actual=${response.packageVersion.packageVersionId}`,
+          `Catalog install preview returned a different package version. expected=${catalogContext.packageVersionId} actual=${response.packageVersion.packageVersionId}`,
         );
       }
       if (
@@ -467,7 +467,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     }
   }, [
     captureCatalogImportError,
-    catalogContext.packageVersion.packageVersionId,
+    catalogContext.packageVersionId,
     indexedDbOpenRecoveryState,
     isImportAvailable,
     showCapturedTechnicalError,
@@ -668,7 +668,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       indexedDbOpenRecoveryState.throwIfFailed();
       const result = await confirmCatalogPackageInstall(
         requestAttempt.identity.workspaceId,
-        catalogContext.packageVersion.packageVersionId,
+        catalogContext.packageVersionId,
         requestAttempt.options,
       );
       indexedDbOpenRecoveryState.throwIfFailed();
@@ -678,9 +678,9 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       ) {
         return;
       }
-      if (result.packageVersion.packageVersionId !== catalogContext.packageVersion.packageVersionId) {
+      if (result.packageVersion.packageVersionId !== catalogContext.packageVersionId) {
         throw new Error(
-          `Catalog install returned a different package version. expected=${catalogContext.packageVersion.packageVersionId} actual=${result.packageVersion.packageVersionId}`,
+          `Catalog install returned a different package version. expected=${catalogContext.packageVersionId} actual=${result.packageVersion.packageVersionId}`,
         );
       }
       if (result.summary.installId !== requestAttempt.options.installId) {

--- a/apps/web/src/screens/catalog/CatalogImportScreen.test.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.test.tsx
@@ -12,7 +12,7 @@ import type {
   CatalogPackageInstallConfirmOptions,
   CatalogPackageInstallConfirmResponse,
   CatalogPackageInstallPreviewResponse,
-  CatalogPublicSnapshot,
+  CatalogPublicPackageVersion,
   Deck,
   ResetWorkspaceProgressResponse,
   ReviewFilter,
@@ -31,7 +31,7 @@ const {
   buildLoginUrlMock,
   confirmCatalogPackageInstallMock,
   getOptionalSessionMock,
-  loadPublicCatalogMock,
+  loadPublicCatalogPackageVersionMock,
   previewCatalogPackageInstallMock,
   useAppDataMock,
 } = vi.hoisted(() => ({
@@ -42,7 +42,9 @@ const {
     options: CatalogPackageInstallConfirmOptions,
   ) => Promise<CatalogPackageInstallConfirmResponse>>(),
   getOptionalSessionMock: vi.fn<() => Promise<SessionInfo | null>>(),
-  loadPublicCatalogMock: vi.fn<() => Promise<CatalogPublicSnapshot>>(),
+  loadPublicCatalogPackageVersionMock: vi.fn<(
+    requestedPackageVersionId: string,
+  ) => Promise<CatalogPublicPackageVersion>>(),
   previewCatalogPackageInstallMock: vi.fn<(
     workspaceId: string,
     requestedPackageVersionId: string,
@@ -58,7 +60,7 @@ vi.mock("../../api", async (importOriginal) => {
     confirmCatalogPackageInstall: confirmCatalogPackageInstallMock,
     getOptionalSession: getOptionalSessionMock,
     isAuthRedirectError: (_error: unknown): boolean => false,
-    loadPublicCatalog: loadPublicCatalogMock,
+    loadPublicCatalogPackageVersion: loadPublicCatalogPackageVersionMock,
     previewCatalogPackageInstall: previewCatalogPackageInstallMock,
   };
 });
@@ -100,48 +102,22 @@ function createWorkspace(workspaceId: string, name: string, isSelected: boolean)
   };
 }
 
-function createCatalogSnapshot(includeVersion: boolean): CatalogPublicSnapshot {
+function createCatalogPackageVersion(): CatalogPublicPackageVersion {
   return {
-    schemaVersion: 2,
-    generatedAt: "2026-08-02T10:00:00.000Z",
-    authors: [{
+    packageVersionId,
+    packageId,
+    versionNumber: 1,
+    slug: "test-package",
+    title: "тест",
+    summary: "Test package",
+    languageTags: ["ru"],
+    cardCount: 2,
+    publishedAt: "2026-08-01T10:00:00.000Z",
+    author: {
       authorId,
       slug: "test-author",
       displayName: "Test Author",
-      bio: null,
-      websiteUrl: null,
-    }],
-    packages: [{
-      packageId,
-      authorId,
-      slug: "test-package",
-      status: "published",
-      latestPackageVersionId: packageVersionId,
-      versionCount: 1,
-      publishedAt: "2026-08-01T10:00:00.000Z",
-    }],
-    packageVersions: includeVersion ? [{
-      packageVersionId,
-      packageId,
-      versionNumber: 1,
-      status: "published",
-      slug: "test-package",
-      title: "тест",
-      summary: "Test package",
-      description: "Test package",
-      languageTags: ["ru"],
-      license: "CC0-1.0",
-      contentWarning: null,
-      coverMediaAssetId: null,
-      cardCount: 2,
-      updatedAt: "2026-08-01T10:00:00.000Z",
-      publishedAt: "2026-08-01T10:00:00.000Z",
-      installUrl: `http://localhost:3000/catalog/import/${packageVersionId}`,
-    }] : [],
-    cards: [],
-    mediaAssets: [],
-    collections: [],
-    collectionPackages: [],
+    },
   };
 }
 
@@ -228,6 +204,18 @@ function createDeferred<Result>(): Deferred<Result> {
       rejectPromise(error);
     },
   };
+}
+
+function createCatalogPublicVersionNotFoundError(): ApiError {
+  return new ApiError({
+    statusCode: 404,
+    message: "Published catalog package version not found.",
+    code: "CATALOG_PUBLIC_PACKAGE_VERSION_NOT_FOUND",
+    requestId: "request-1",
+    retryAfterMs: null,
+    endpoint: `GET /catalog/package-versions/${packageVersionId}`,
+    responseBodyKind: "json",
+  });
 }
 
 function createCatalogInstallConflict(code: string): ApiError {
@@ -335,8 +323,8 @@ describe("CatalogImportScreen", () => {
     useAppDataMock.mockImplementation(() => appData);
     buildLoginUrlMock.mockReset();
     buildLoginUrlMock.mockReturnValue("https://auth.example.test/login");
-    loadPublicCatalogMock.mockReset();
-    loadPublicCatalogMock.mockResolvedValue(createCatalogSnapshot(true));
+    loadPublicCatalogPackageVersionMock.mockReset();
+    loadPublicCatalogPackageVersionMock.mockResolvedValue(createCatalogPackageVersion());
     getOptionalSessionMock.mockReset();
     getOptionalSessionMock.mockResolvedValue(createSession());
     previewCatalogPackageInstallMock.mockReset();
@@ -388,11 +376,11 @@ describe("CatalogImportScreen", () => {
     await waitForCondition("Malformed version error was not rendered", () => (
       container.querySelector("[data-testid='catalog-import-error']") !== null
     ));
-    expect(loadPublicCatalogMock).not.toHaveBeenCalled();
+    expect(loadPublicCatalogPackageVersionMock).not.toHaveBeenCalled();
   });
 
   it("reports a missing exact version before loading auth", async () => {
-    loadPublicCatalogMock.mockResolvedValue(createCatalogSnapshot(false));
+    loadPublicCatalogPackageVersionMock.mockRejectedValue(createCatalogPublicVersionNotFoundError());
     await renderRoute(`/catalog/import/${packageVersionId}`);
     await waitForCondition("Missing version state was not rendered", () => (
       container.querySelector("[data-testid='catalog-import-not-found']") !== null

--- a/apps/web/src/screens/catalog/CatalogImportScreen.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.tsx
@@ -4,19 +4,20 @@ import {
   buildLoginUrl,
   getOptionalSession,
   isAuthRedirectError,
-  loadPublicCatalog,
+  loadPublicCatalogPackageVersion,
 } from "../../api";
 import {
   markIndexedDbOpenRecoveryFailureAndCheckActive,
   useAppErrorDialog,
 } from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
-import type { CatalogPublicSnapshot, SessionInfo } from "../../types";
+import type { SessionInfo } from "../../types";
 import { CatalogImportAuthenticatedFlow } from "./CatalogImportAuthenticatedFlow";
 import {
   CatalogImportContextCard,
   CatalogImportStatePanel,
   getCatalogImportErrorMessage,
+  isCatalogPublicVersionNotFoundError,
   type CatalogImportContext,
 } from "./catalogImportShared";
 
@@ -30,28 +31,6 @@ function parsePackageVersionId(value: string | undefined): string | null {
   }
 
   return value.toLowerCase();
-}
-
-function resolveCatalogImportContext(
-  snapshot: CatalogPublicSnapshot,
-  packageVersionId: string,
-): CatalogImportContext | null {
-  const packageVersion = snapshot.packageVersions.find((version) => version.packageVersionId === packageVersionId) ?? null;
-  if (packageVersion === null) {
-    return null;
-  }
-
-  const catalogPackage = snapshot.packages.find((item) => item.packageId === packageVersion.packageId) ?? null;
-  if (catalogPackage === null) {
-    throw new Error(`Catalog snapshot package is missing. packageId=${packageVersion.packageId}`);
-  }
-
-  const author = snapshot.authors.find((item) => item.authorId === catalogPackage.authorId) ?? null;
-  if (author === null) {
-    throw new Error(`Catalog snapshot author is missing. authorId=${catalogPackage.authorId}`);
-  }
-
-  return { author, catalogPackage, packageVersion };
 }
 
 function CatalogImportSignedOutScreen(props: Readonly<{ catalogContext: CatalogImportContext }>): ReactElement {
@@ -107,14 +86,9 @@ export function CatalogImportScreen(): ReactElement {
     setErrorMessage("");
     try {
       indexedDbOpenRecoveryState.throwIfFailed();
-      const snapshot = await loadPublicCatalog();
+      const packageVersion = await loadPublicCatalogPackageVersion(packageVersionId);
       indexedDbOpenRecoveryState.throwIfFailed();
       if (loadRequestGenerationRef.current !== requestGeneration) {
-        return;
-      }
-      const nextCatalogContext = resolveCatalogImportContext(snapshot, packageVersionId);
-      if (nextCatalogContext === null) {
-        setLoadState("not_found");
         return;
       }
 
@@ -123,7 +97,12 @@ export function CatalogImportScreen(): ReactElement {
       if (loadRequestGenerationRef.current !== requestGeneration) {
         return;
       }
-      setCatalogContext(nextCatalogContext);
+      setCatalogContext({
+        packageVersionId: packageVersion.packageVersionId,
+        title: packageVersion.title,
+        cardCount: packageVersion.cardCount,
+        authorDisplayName: packageVersion.author.displayName,
+      });
       setSession(optionalSession);
       setLoadState(optionalSession === null ? "signed_out" : "signed_in");
     } catch (error) {
@@ -134,6 +113,10 @@ export function CatalogImportScreen(): ReactElement {
         return;
       }
       if (isAuthRedirectError(error)) {
+        return;
+      }
+      if (isCatalogPublicVersionNotFoundError(error)) {
+        setLoadState("not_found");
         return;
       }
       const wasCaptured = showTechnicalError(error, {

--- a/apps/web/src/screens/catalog/catalogImportShared.tsx
+++ b/apps/web/src/screens/catalog/catalogImportShared.tsx
@@ -1,20 +1,20 @@
 import type { ReactElement } from "react";
 import { ApiError } from "../../api";
 import { useI18n } from "../../i18n";
-import type {
-  CatalogPublicSnapshotAuthor,
-  CatalogPublicSnapshotPackage,
-  CatalogPublicSnapshotPackageVersion,
-} from "../../types";
 
 export type CatalogImportContext = Readonly<{
-  author: CatalogPublicSnapshotAuthor;
-  catalogPackage: CatalogPublicSnapshotPackage;
-  packageVersion: CatalogPublicSnapshotPackageVersion;
+  packageVersionId: string;
+  title: string;
+  cardCount: number;
+  authorDisplayName: string;
 }>;
 
 export function getCatalogImportErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function isCatalogPublicVersionNotFoundError(error: unknown): boolean {
+  return error instanceof ApiError && error.code === "CATALOG_PUBLIC_PACKAGE_VERSION_NOT_FOUND";
 }
 
 export function isCatalogVersionUnavailableError(error: unknown): boolean {
@@ -31,19 +31,19 @@ export function CatalogImportContextCard(props: Readonly<{
 }>): ReactElement {
   const { catalogContext, accountEmail } = props;
   const { messages, t, formatCount } = useI18n();
-  const cardCount = formatCount(catalogContext.packageVersion.cardCount, messages.common.countLabels.card);
+  const cardCount = formatCount(catalogContext.cardCount, messages.common.countLabels.card);
 
   return (
     <section className="content-card invite-panel" data-testid="catalog-import-context">
       <h1 className="title">{t("catalogImport.title")}</h1>
       <p className="subtitle" data-testid="catalog-import-package-summary">
         {t("catalogImport.packageSummary", {
-          title: catalogContext.packageVersion.title,
+          title: catalogContext.title,
           count: cardCount,
         })}
       </p>
       <p className="subtitle" data-testid="catalog-import-author">
-        {t("catalogImport.author", { author: catalogContext.author.displayName })}
+        {t("catalogImport.author", { author: catalogContext.authorDisplayName })}
       </p>
       {accountEmail === null ? null : (
         <p className="subtitle catalog-import-account-email" data-testid="catalog-import-account-email">

--- a/apps/web/src/types/catalog.ts
+++ b/apps/web/src/types/catalog.ts
@@ -1,93 +1,20 @@
-export type CatalogPublicSnapshotAuthor = Readonly<{
+export type CatalogPublicPackageVersionAuthor = Readonly<{
   authorId: string;
   slug: string;
   displayName: string;
-  bio: string | null;
-  websiteUrl: string | null;
 }>;
 
-export type CatalogPublicSnapshotPackage = Readonly<{
-  packageId: string;
-  authorId: string;
-  slug: string;
-  status: "published";
-  latestPackageVersionId: string;
-  versionCount: number;
-  publishedAt: string;
-}>;
-
-export type CatalogPublicSnapshotPackageVersion = Readonly<{
+export type CatalogPublicPackageVersion = Readonly<{
   packageVersionId: string;
   packageId: string;
   versionNumber: number;
-  status: "published";
   slug: string;
   title: string;
   summary: string;
-  description: string;
   languageTags: ReadonlyArray<string>;
-  license: string;
-  contentWarning: string | null;
-  coverMediaAssetId: string | null;
   cardCount: number;
-  updatedAt: string;
   publishedAt: string;
-  installUrl: string;
-}>;
-
-export type CatalogPublicSnapshotCard = Readonly<{
-  packageCardId: string;
-  packageVersionId: string;
-  ordinal: number;
-  frontText: string;
-  backText: string;
-  cardType: string;
-  tags: ReadonlyArray<string>;
-  mediaAssetIds: ReadonlyArray<string>;
-}>;
-
-export type CatalogPublicSnapshotMediaAsset = Readonly<{
-  packageMediaAssetId: string;
-  packageVersionId: string;
-  packageMediaKey: string;
-  altText: string | null;
-  credit: string | null;
-  license: string | null;
-  mimeType: string;
-  sizeBytes: number;
-  downloadUrl: string;
-}>;
-
-export type CatalogPublicSnapshotCollection = Readonly<{
-  collectionId: string;
-  slug: string;
-  title: string;
-  summary: string;
-  description: string;
-  languageTags: ReadonlyArray<string>;
-  coverPackageId: string | null;
-  coverDownloadUrl?: string;
-  status: "published";
-  updatedAt: string;
-  publishedAt: string;
-}>;
-
-export type CatalogPublicSnapshotCollectionPackage = Readonly<{
-  collectionId: string;
-  packageId: string;
-  ordinal: number;
-}>;
-
-export type CatalogPublicSnapshot = Readonly<{
-  schemaVersion: 2;
-  generatedAt: string;
-  authors: ReadonlyArray<CatalogPublicSnapshotAuthor>;
-  packages: ReadonlyArray<CatalogPublicSnapshotPackage>;
-  packageVersions: ReadonlyArray<CatalogPublicSnapshotPackageVersion>;
-  cards: ReadonlyArray<CatalogPublicSnapshotCard>;
-  mediaAssets: ReadonlyArray<CatalogPublicSnapshotMediaAsset>;
-  collections: ReadonlyArray<CatalogPublicSnapshotCollection>;
-  collectionPackages: ReadonlyArray<CatalogPublicSnapshotCollectionPackage>;
+  author: CatalogPublicPackageVersionAuthor;
 }>;
 
 export type CatalogPackageInstallAuthor = Readonly<{


### PR DESCRIPTION
The deck-import screen downloaded the entire public catalog snapshot (~3.2 MB, 8k+ cards) just to read four fields of one package version, which is also the endpoint that has been producing API Gateway 504s.

## What changes

- New `GET /v1/catalog/package-versions/{packageVersionId}` returning only the version, its package ids and its author — no cards, no media, no `installUrl`.
- `apps/web` deck-import screen uses it instead of `loadPublicCatalog()`.
- Removes the now-unused snapshot client from `apps/web`: `loadPublicCatalog`, `parseCatalogPublicSnapshotResponse`, the seven private snapshot parsers, the `CatalogPublicSnapshot*` types and `resolveCatalogImportContext`. Backend snapshot code is untouched.

Net **+267 / −408**.

## Notes for review

- `infra/aws/lib/gateways/api-gateway.ts` is deliberately unchanged. `catalog.addResource("{proxy+}").addMethod("GET", integration)` already routes this path; an explicit `package-versions` resource would shadow the greedy proxy and break the existing `/cards` and `/media-assets/*` routes.
- The public route raises `CATALOG_PUBLIC_PACKAGE_VERSION_NOT_FOUND`, not the `CATALOG_PACKAGE_VERSION_NOT_FOUND` the authenticated flow matches. Handled with a separate predicate so the authenticated flow's behaviour is unchanged.
- The state machine is preserved: malformed-UUID short circuit still precedes any network call, and the lookup still resolves before `getOptionalSession()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)