### PR TITLE
Build the public catalog dump as a CDN artifact

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -18,6 +18,7 @@ on:
       - 'scripts/checks/check-public-endpoints.sh'
       - 'scripts/deploy/deploy-admin.sh'
       - 'scripts/deploy/deploy-web.sh'
+      - 'scripts/generate/generate-catalog-dump.sh'
       - 'scripts/generate/generate-global-metrics-snapshot.sh'
       - 'scripts/deploy/migrate-aws.sh'
       - 'scripts/generate/write-ci-cdk-context.py'
@@ -63,7 +64,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          aws_release_script_pattern='^scripts/(checks/(check-agent-api-smoke|check-api-health|check-demo-cognito-users|check-mcp-smoke|check-multipart-completion-reconciliation-schedule|check-public-endpoints)\.sh|deploy/(deploy-admin|deploy-web|migrate-aws)\.sh|generate/(generate-global-metrics-snapshot\.sh|write-ci-cdk-context\.py))$'
+          aws_release_script_pattern='^scripts/(checks/(check-agent-api-smoke|check-api-health|check-demo-cognito-users|check-mcp-smoke|check-multipart-completion-reconciliation-schedule|check-public-endpoints)\.sh|deploy/(deploy-admin|deploy-web|migrate-aws)\.sh|generate/(generate-catalog-dump\.sh|generate-global-metrics-snapshot\.sh|write-ci-cdk-context\.py))$'
 
           changed_files_path="${RUNNER_TEMP}/changed-files.txt"
           before_sha="${PUSH_BEFORE_SHA:-}"
@@ -410,6 +411,9 @@ jobs:
 
       - name: Seed global metrics snapshot
         run: bash scripts/generate/generate-global-metrics-snapshot.sh --stack-name ${{ env.STACK_NAME }}
+
+      - name: Seed public catalog dump
+        run: bash scripts/generate/generate-catalog-dump.sh --stack-name ${{ env.STACK_NAME }}
 
       - name: Deploy web assets
         run: bash scripts/deploy/deploy-web.sh --stack-name ${{ env.STACK_NAME }}

--- a/apps/backend/src/catalog/cardMedia.ts
+++ b/apps/backend/src/catalog/cardMedia.ts
@@ -1,4 +1,6 @@
-import { extractMarkdownFcAssetIds } from "../workspacePackages";
+// Not the `../workspacePackages` barrel: it pulls the image ingestion graph, which
+// resolves `sharp` at load time, into every bundle reaching the public catalog snapshot.
+import { extractMarkdownFcAssetIds } from "../workspacePackages/markdownMedia";
 
 export type CatalogCardMediaReferenceInput = Readonly<{
   frontText: string;

--- a/apps/backend/src/catalog/distribution/public/dumpGeneration.ts
+++ b/apps/backend/src/catalog/distribution/public/dumpGeneration.ts
@@ -1,0 +1,33 @@
+import { parsePublicOrigin } from "../../../shared/publicUrls";
+import type { BackendObservationScope } from "../../../observability/sentry";
+import { loadPublicCatalogSnapshot } from "./snapshot";
+import { writeCatalogDumpToS3, type CatalogDumpWriteResult } from "./dumpStorage";
+
+function getRequiredCatalogDumpEnv(envName: string): string {
+  const value = process.env[envName];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${envName} is required for the public catalog dump.`);
+  }
+
+  return value.trim();
+}
+
+/**
+ * Builds the snapshot the public catalog dump publishes. The builder runs without
+ * an HTTP request, so both public base URLs come from the environment instead of
+ * the request URL the `GET /v1/catalog` route resolves them from.
+ */
+export async function generateAndWriteCatalogDump(
+  observationScope: BackendObservationScope,
+): Promise<CatalogDumpWriteResult> {
+  const configuredApiBaseUrl = getRequiredCatalogDumpEnv("PUBLIC_API_BASE_URL");
+  const publicApiBaseUrl = configuredApiBaseUrl.endsWith("/")
+    ? configuredApiBaseUrl.slice(0, -1)
+    : configuredApiBaseUrl;
+  const publicAppBaseUrl = parsePublicOrigin(
+    getRequiredCatalogDumpEnv("PUBLIC_APP_BASE_URL"),
+    "PUBLIC_APP_BASE_URL",
+  );
+  const snapshot = await loadPublicCatalogSnapshot(publicApiBaseUrl, publicAppBaseUrl);
+  return writeCatalogDumpToS3(observationScope, snapshot);
+}

--- a/apps/backend/src/catalog/distribution/public/dumpStorage.ts
+++ b/apps/backend/src/catalog/distribution/public/dumpStorage.ts
@@ -1,0 +1,181 @@
+import { createHash } from "node:crypto";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  addBackendBreadcrumb,
+  type BackendObservationScope,
+} from "../../../observability/sentry";
+import type { CatalogPublicSnapshot } from "../../types";
+
+type CatalogDumpStorageConfig = Readonly<{
+  bucketName: string;
+  cdnBaseUrl: string;
+}>;
+
+export type CatalogDumpWriteResult = Readonly<{
+  bucketName: string;
+  objectKey: string;
+  sha256: string;
+  generatedAt: string;
+  byteLength: number;
+}>;
+
+const maxS3AttemptCount = 3;
+const catalogDumpObjectKeyPrefix = "catalog";
+const latestCatalogDumpObjectKey = `${catalogDumpObjectKeyPrefix}/latest.json`;
+const pointerCatalogDumpObjectKey = `${catalogDumpObjectKeyPrefix}/pointer.json`;
+const catalogDumpContentType = "application/json; charset=utf-8";
+const immutableCatalogDumpCacheControl = "public, max-age=31536000, immutable";
+const revalidatedCatalogDumpCacheControl = "public, max-age=60";
+
+let catalogDumpS3Client: S3Client | undefined;
+
+function getCatalogDumpS3Client(): S3Client {
+  if (catalogDumpS3Client !== undefined) {
+    return catalogDumpS3Client;
+  }
+
+  catalogDumpS3Client = new S3Client({});
+  return catalogDumpS3Client;
+}
+
+function getRequiredCatalogDumpEnv(envName: string): string {
+  const value = process.env[envName];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${envName} is required for public catalog dump storage.`);
+  }
+
+  return value.trim();
+}
+
+function getCatalogDumpStorageConfig(): CatalogDumpStorageConfig {
+  const cdnBaseUrl = getRequiredCatalogDumpEnv("CATALOG_DUMP_CDN_BASE_URL");
+  return {
+    bucketName: getRequiredCatalogDumpEnv("CATALOG_DUMP_S3_BUCKET_NAME"),
+    cdnBaseUrl: cdnBaseUrl.endsWith("/") ? cdnBaseUrl.slice(0, -1) : cdnBaseUrl,
+  };
+}
+
+function getS3ErrorStatusCode(error: unknown): number | null {
+  if (typeof error !== "object" || error === null || !("$metadata" in error)) {
+    return null;
+  }
+
+  const metadata = (error as Readonly<{
+    $metadata?: Readonly<{
+      httpStatusCode?: unknown;
+    }>;
+  }>).$metadata;
+
+  return typeof metadata?.httpStatusCode === "number" ? metadata.httpStatusCode : null;
+}
+
+function getS3ErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : "UnknownError";
+}
+
+function getS3ErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatS3ErrorSummary(error: unknown): string {
+  const errorName = getS3ErrorName(error);
+  const errorMessage = getS3ErrorMessage(error);
+  const statusCode = getS3ErrorStatusCode(error);
+  const statusSuffix = statusCode === null ? "" : ` status=${statusCode}`;
+  return `${errorName}${statusSuffix}: ${errorMessage}`;
+}
+
+async function putCatalogDumpObjectWithRetries(params: Readonly<{
+  observationScope: BackendObservationScope;
+  bucketName: string;
+  objectKey: string;
+  body: string;
+  cacheControl: string;
+}>): Promise<void> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= maxS3AttemptCount; attempt += 1) {
+    try {
+      await getCatalogDumpS3Client().send(new PutObjectCommand({
+        Bucket: params.bucketName,
+        Key: params.objectKey,
+        Body: params.body,
+        ContentType: catalogDumpContentType,
+        CacheControl: params.cacheControl,
+      }));
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxS3AttemptCount) {
+        break;
+      }
+
+      addBackendBreadcrumb({
+        action: "catalog_dump_s3_retry",
+        scope: params.observationScope,
+        details: {
+          attempt,
+          maxAttempts: maxS3AttemptCount,
+          bucketName: params.bucketName,
+          objectKey: params.objectKey,
+          statusCode: getS3ErrorStatusCode(error),
+          errorClass: getS3ErrorName(error),
+          errorMessage: getS3ErrorMessage(error),
+        },
+      });
+    }
+  }
+
+  throw new Error(
+    `Failed to write the public catalog dump to s3://${params.bucketName}/${params.objectKey}: ${formatS3ErrorSummary(lastError)}`,
+  );
+}
+
+/**
+ * Publishes one snapshot as an immutable content-addressed object plus the
+ * `latest.json` and `pointer.json` aliases. The immutable object is written
+ * first so a pointer never names an object that does not exist yet.
+ */
+export async function writeCatalogDumpToS3(
+  observationScope: BackendObservationScope,
+  snapshot: CatalogPublicSnapshot,
+): Promise<CatalogDumpWriteResult> {
+  const config = getCatalogDumpStorageConfig();
+  const body = JSON.stringify(snapshot);
+  const sha256 = createHash("sha256").update(body).digest("hex");
+  const objectKey = `${catalogDumpObjectKeyPrefix}/${sha256}.json`;
+
+  await putCatalogDumpObjectWithRetries({
+    observationScope,
+    bucketName: config.bucketName,
+    objectKey,
+    body,
+    cacheControl: immutableCatalogDumpCacheControl,
+  });
+  await putCatalogDumpObjectWithRetries({
+    observationScope,
+    bucketName: config.bucketName,
+    objectKey: latestCatalogDumpObjectKey,
+    body,
+    cacheControl: revalidatedCatalogDumpCacheControl,
+  });
+  await putCatalogDumpObjectWithRetries({
+    observationScope,
+    bucketName: config.bucketName,
+    objectKey: pointerCatalogDumpObjectKey,
+    body: JSON.stringify({
+      objectKey,
+      url: `${config.cdnBaseUrl}/${objectKey}`,
+      generatedAt: snapshot.generatedAt,
+    }),
+    cacheControl: revalidatedCatalogDumpCacheControl,
+  });
+
+  return {
+    bucketName: config.bucketName,
+    objectKey,
+    sha256,
+    generatedAt: snapshot.generatedAt,
+    byteLength: Buffer.byteLength(body, "utf8"),
+  };
+}

--- a/apps/backend/src/catalog/publicSafety.ts
+++ b/apps/backend/src/catalog/publicSafety.ts
@@ -1,8 +1,10 @@
+// Not the `../workspacePackages` barrel: it pulls the image ingestion graph, which
+// resolves `sharp` at load time, into every bundle reaching the public catalog snapshot.
 import {
   extractMarkdownLinkDestinationUrls,
   extractMarkdownNonCodeTextSegments,
-} from "../workspacePackages";
-import { isMarkdownComplexityLimitError } from "../workspacePackages/markdownMedia";
+  isMarkdownComplexityLimitError,
+} from "../workspacePackages/markdownMedia";
 import {
   containsUnsafePublicPackageMediaReference,
   isUnsafePublicPackageMediaKey,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-catalog-dump.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-catalog-dump.ts
@@ -1,0 +1,110 @@
+import type { Handler } from "aws-lambda";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  type CatalogDumpFailureDetails,
+  wrapBackendHandler,
+} from "../../observability/sentry";
+
+initializeBackendSentry("catalog-dump");
+
+type CatalogDumpResponse = Readonly<{
+  ok: true;
+  bucketName: string;
+  objectKey: string;
+  sha256: string;
+  generatedAt: string;
+  byteLength: number;
+}>;
+
+type CatalogDumpRuntime = Readonly<{
+  generateAndWriteCatalogDump: typeof import("../../catalog/distribution/public/dumpGeneration").generateAndWriteCatalogDump;
+}>;
+
+let catalogDumpRuntimePromise: Promise<CatalogDumpRuntime> | null = null;
+
+async function createCatalogDumpRuntime(): Promise<CatalogDumpRuntime> {
+  const { generateAndWriteCatalogDump } = await import("../../catalog/distribution/public/dumpGeneration");
+  return {
+    generateAndWriteCatalogDump,
+  };
+}
+
+function getCatalogDumpRuntime(): Promise<CatalogDumpRuntime> {
+  if (catalogDumpRuntimePromise === null) {
+    catalogDumpRuntimePromise = createCatalogDumpRuntime();
+  }
+
+  return catalogDumpRuntimePromise;
+}
+
+function readOptionalTrimmedEnv(env: NodeJS.ProcessEnv, name: string): string | null {
+  const value = env[name];
+  if (value === undefined || value.trim() === "") {
+    return null;
+  }
+
+  return value.trim();
+}
+
+function createCatalogDumpFailureDetails(error: Error): CatalogDumpFailureDetails {
+  return {
+    bucketName: readOptionalTrimmedEnv(process.env, "CATALOG_DUMP_S3_BUCKET_NAME"),
+    message: error.message,
+  };
+}
+
+const catalogDumpHandler: Handler<unknown, CatalogDumpResponse> = async (_event, context) => {
+  const observationScope = createBackendObservationScope(
+    "catalog-dump",
+    context.awsRequestId ?? null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  try {
+    const runtime = await getCatalogDumpRuntime();
+    const result = await runtime.generateAndWriteCatalogDump(observationScope);
+
+    addBackendBreadcrumb({
+      action: "catalog_dump_generated",
+      scope: observationScope,
+      details: {
+        bucketName: result.bucketName,
+        objectKey: result.objectKey,
+        sha256: result.sha256,
+        generatedAt: result.generatedAt,
+        byteLength: result.byteLength,
+      },
+    });
+
+    return {
+      ok: true,
+      bucketName: result.bucketName,
+      objectKey: result.objectKey,
+      sha256: result.sha256,
+      generatedAt: result.generatedAt,
+      byteLength: result.byteLength,
+    };
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "catalog_dump_failed",
+      error: normalizedError,
+      scope: observationScope,
+      details: createCatalogDumpFailureDetails(normalizedError),
+    });
+    throw error;
+  }
+};
+
+export const handler = wrapBackendHandler(catalogDumpHandler);

--- a/apps/backend/src/observability/sentry/events/common.ts
+++ b/apps/backend/src/observability/sentry/events/common.ts
@@ -5,6 +5,7 @@ export type BackendService =
   | "chat-worker"
   | "chat-live"
   | "global-metrics-snapshot"
+  | "catalog-dump"
   | "community-leaderboard-snapshot"
   | "streak-leaderboard-snapshot"
   | "progress-active-days-backfill"

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -91,6 +91,9 @@ export type {
 export type {
   AdminQueryDetails,
   AgentSqlDetails,
+  CatalogDumpFailureDetails,
+  CatalogDumpGeneratedDetails,
+  CatalogDumpS3RetryDetails,
   CommunityLeaderboardSnapshotFailureDetails,
   CommunityLeaderboardSnapshotGeneratedDetails,
   DatabasePoolErrorDetails,

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -98,6 +98,19 @@ export type GlobalMetricsSnapshotFailureDetails = Readonly<{
   message: string;
 }>;
 
+export type CatalogDumpGeneratedDetails = Readonly<{
+  bucketName: string;
+  objectKey: string;
+  sha256: string;
+  generatedAt: string;
+  byteLength: number;
+}>;
+
+export type CatalogDumpFailureDetails = Readonly<{
+  bucketName: string | null;
+  message: string;
+}>;
+
 export type CommunityLeaderboardSnapshotGeneratedDetails = Readonly<{
   metricVersion: string;
   generatedAtUtc: string;
@@ -282,6 +295,16 @@ export type GlobalMetricsS3RetryDetails = Readonly<{
   errorMessage: string;
 }>;
 
+export type CatalogDumpS3RetryDetails = Readonly<{
+  attempt: number;
+  maxAttempts: number;
+  bucketName: string;
+  objectKey: string;
+  statusCode: number | null;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
 export type MediaAssetStorageRetryDetails = Readonly<{
   operation:
     | "create_presigned_upload"
@@ -341,6 +364,7 @@ export type OperationsBreadcrumbEvent =
   | EventByAction<"agent_sql", AgentSqlDetails>
   | EventByAction<"mcp_request", McpRequestDetails>
   | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
+  | EventByAction<"catalog_dump_generated", CatalogDumpGeneratedDetails>
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
@@ -352,6 +376,7 @@ export type OperationsBreadcrumbEvent =
   | EventByAction<"multipart_completion_reconciliation_job_terminally_failed", MultipartCompletionReconciliationTerminalFailureDetails>
   | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
   | EventByAction<"global_metrics_s3_retry", GlobalMetricsS3RetryDetails>
+  | EventByAction<"catalog_dump_s3_retry", CatalogDumpS3RetryDetails>
   | EventByAction<"media_asset_storage_retry", MediaAssetStorageRetryDetails>
   | EventByAction<"media_asset_storage_terminal", MediaAssetStorageTerminalDetails>;
 
@@ -373,6 +398,7 @@ export type OperationsWarningEvent =
 
 export type OperationsExceptionEvent =
   | (EventByAction<"global_metrics_snapshot_failed", GlobalMetricsSnapshotFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"catalog_dump_failed", CatalogDumpFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"community_leaderboard_snapshot_failed", CommunityLeaderboardSnapshotFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"streak_leaderboard_snapshot_failed", StreakLeaderboardSnapshotFailureDetails> & Readonly<{
     error: Error;

--- a/infra/aws/lib/catalog-dump.ts
+++ b/infra/aws/lib/catalog-dump.ts
@@ -1,0 +1,147 @@
+import * as cdk from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
+import { parsePublicOrigin } from "./public-origin";
+import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
+
+export interface CatalogDumpProps {
+  vpc: ec2.Vpc;
+  lambdaSg: ec2.SecurityGroup;
+  db: rds.DatabaseInstance;
+  backendDbSecret: cdk.aws_secretsmanager.Secret;
+  baseDomain: string;
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
+}
+
+export interface CatalogDumpResult {
+  bucket: s3.Bucket;
+  distribution: cloudfront.Distribution;
+  dumpFunction: lambdaNodejs.NodejsFunction;
+}
+
+// Must stay in sync with the object key prefix written by the backend dump storage.
+const catalogDumpObjectKeyPrefix = "catalog";
+
+const lambdaBundling: lambdaNodejs.BundlingOptions = {
+  minify: true,
+  sourceMap: true,
+  commandHooks: {
+    beforeBundling: () => [],
+    beforeInstall: () => [],
+    afterBundling: (_inputDir: string, outputDir: string) => [
+      `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+      createSentrySourceMapUploadCommand(outputDir),
+    ],
+  },
+};
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function addOptionalSentryEnvironment(
+  scope: Construct,
+  fn: lambdaNodejs.NodejsFunction,
+  props: CatalogDumpProps,
+): void {
+  if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
+    return;
+  }
+  if (
+    !hasConfiguredValue(props.sentryEnvironment) ||
+    !hasConfiguredValue(props.sentryRelease) ||
+    !hasConfiguredValue(props.sentryTracesSampleRate)
+  ) {
+    throw new Error("sentryEnvironment, sentryRelease, and sentryTracesSampleRate are required when sentryDsnSecretArn is configured");
+  }
+
+  const tracesSampleRate = Number(props.sentryTracesSampleRate);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+
+  const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope,
+    "CatalogDumpSentryDsnSecret",
+    props.sentryDsnSecretArn,
+  );
+  secret.grantRead(fn);
+  fn.addEnvironment("SENTRY_DSN", secret.secretValue.unsafeUnwrap());
+  fn.addEnvironment("SENTRY_ENVIRONMENT", props.sentryEnvironment);
+  fn.addEnvironment("SENTRY_RELEASE", props.sentryRelease);
+  fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
+}
+
+/**
+ * Public catalog dump artifact pipeline. The builder Lambda reads Postgres as the
+ * backend_app runtime role, exactly like the API handler behind `GET /v1/catalog`,
+ * and publishes the snapshot to a private bucket served through CloudFront.
+ * Freshness is controlled per object by `Cache-Control`, so the distribution keeps
+ * one cache-optimized behavior and no custom domain.
+ */
+export function catalogDump(scope: Construct, props: CatalogDumpProps): CatalogDumpResult {
+  const bucket = new s3.Bucket(scope, "CatalogDumpBucket", {
+    encryption: s3.BucketEncryption.S3_MANAGED,
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    enforceSSL: true,
+    removalPolicy: cdk.RemovalPolicy.RETAIN,
+    autoDeleteObjects: false,
+  });
+
+  const distribution = new cloudfront.Distribution(scope, "CatalogDumpDistribution", {
+    comment: "flashcards-open-source-app public catalog dump",
+    defaultBehavior: {
+      origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
+      viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+      compress: true,
+    },
+  });
+
+  const dumpFunction = new lambdaNodejs.NodejsFunction(scope, "CatalogDumpHandler", {
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-catalog-dump.ts"),
+    handler: "handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+    timeout: cdk.Duration.minutes(5),
+    memorySize: 2048,
+    vpc: props.vpc,
+    vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+    securityGroups: [props.lambdaSg],
+    ...backendNodejsProjectPaths,
+    bundling: lambdaBundling,
+    environment: {
+      NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
+      DB_SECRET_ARN: props.backendDbSecret.secretArn,
+      DB_HOST: props.db.dbInstanceEndpointAddress,
+      DB_NAME: "flashcards",
+      PUBLIC_API_BASE_URL: `https://api.${props.baseDomain}/v1`,
+      PUBLIC_APP_BASE_URL: parsePublicOrigin(`https://app.${props.baseDomain}`, "appBaseUrl"),
+      CATALOG_DUMP_S3_BUCKET_NAME: bucket.bucketName,
+      CATALOG_DUMP_CDN_BASE_URL: `https://${distribution.distributionDomainName}`,
+    },
+  });
+
+  props.backendDbSecret.grantRead(dumpFunction);
+  addOptionalSentryEnvironment(scope, dumpFunction, props);
+  dumpFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:PutObject"],
+    resources: [bucket.arnForObjects(`${catalogDumpObjectKeyPrefix}/*`)],
+  }));
+
+  return {
+    bucket,
+    distribution,
+    dumpFunction,
+  };
+}

--- a/infra/aws/lib/ci-cd.ts
+++ b/infra/aws/lib/ci-cd.ts
@@ -16,6 +16,7 @@ export interface CiCdProps {
   communityLeaderboardSnapshotFn: lambda.IFunction;
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
+  catalogDumpFn: lambda.IFunction;
   migrationFn: lambda.IFunction;
   generatedMediaPromotionScheduleArn: string;
   multipartCompletionReconciliationScheduleArn: string;
@@ -175,6 +176,12 @@ export function ciCd(scope: Construct, props: CiCdProps): void {
     sid: "InvokeProgressActiveDaysBackfillLambda",
     actions: ["lambda:InvokeFunction"],
     resources: [props.progressActiveDaysBackfillFn.functionArn],
+  }));
+
+  cdkDeployStatements.push(new iam.PolicyStatement({
+    sid: "InvokeCatalogDumpLambda",
+    actions: ["lambda:InvokeFunction"],
+    resources: [props.catalogDumpFn.functionArn],
   }));
 
   const deployRole = new iam.Role(scope, "GithubActionsRole", {

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -44,6 +44,7 @@ export interface MonitoringProps {
   progressActiveDaysBackfillFn: lambda.IFunction;
   generatedMediaPromotionFn: lambda.IFunction;
   multipartCompletionReconciliationFn: lambda.Function;
+  catalogDumpFn: lambda.IFunction;
 }
 
 export interface MonitoringResult {
@@ -294,6 +295,18 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     threshold: 1,
     evaluationPeriods: 1,
     alarmDescription: "Global metrics snapshot Lambda had errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  // The catalog dump has no schedule, so only failures of an actual run can alarm here.
+  new cloudwatch.Alarm(scope, "CatalogDumpLambdaErrorAlarm", {
+    metric: props.catalogDumpFn.metricErrors({
+      period: cdk.Duration.minutes(15),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "Public catalog dump Lambda had errors",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
 

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -32,6 +32,9 @@ export interface OutputsProps {
   communityLeaderboardSnapshotFunction: lambda.IFunction;
   streakLeaderboardSnapshotFunction: lambda.IFunction;
   progressActiveDaysBackfillFunction: lambda.IFunction;
+  catalogDumpBucket: s3.IBucket;
+  catalogDumpDistribution: cloudfront.Distribution;
+  catalogDumpFunction: lambda.IFunction;
   globalMetricsVisible: boolean;
   userPoolId: string;
   userPoolClientId: string;
@@ -189,6 +192,26 @@ export function outputs(scope: Construct, props: OutputsProps): void {
   new cdk.CfnOutput(scope, "ProgressActiveDaysBackfillFunctionName", {
     value: props.progressActiveDaysBackfillFunction.functionName,
     description: "Lambda function name for Progress active review days backfill",
+  });
+
+  new cdk.CfnOutput(scope, "CatalogDumpBucketName", {
+    value: props.catalogDumpBucket.bucketName,
+    description: "Private S3 bucket for public catalog dump artifacts",
+  });
+
+  new cdk.CfnOutput(scope, "CatalogDumpDistributionId", {
+    value: props.catalogDumpDistribution.distributionId,
+    description: "CloudFront distribution ID for the public catalog dump",
+  });
+
+  new cdk.CfnOutput(scope, "CatalogDumpDistributionDomainName", {
+    value: props.catalogDumpDistribution.domainName,
+    description: "CloudFront distribution domain name for the public catalog dump",
+  });
+
+  new cdk.CfnOutput(scope, "CatalogDumpFunctionName", {
+    value: props.catalogDumpFunction.functionName,
+    description: "Lambda function name for public catalog dump generation",
   });
 
   new cdk.CfnOutput(scope, "GlobalMetricsVisible", {

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -32,6 +32,7 @@ import {
   type MultipartCompletionReconciliationScheduleState,
 } from "./scheduled-jobs/multipart-completion-reconciliation";
 import { mediaAssets } from "./media-assets";
+import { catalogDump } from "./catalog-dump";
 import { parsePublicOrigin } from "./public-origin";
 
 function getOptionalContextValue(stack: cdk.Stack, key: string): string | undefined {
@@ -266,6 +267,14 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
         scheduleState: multipartCompletionReconciliationScheduleState,
         ...sentryContext,
       });
+    const catalogDumpResult = catalogDump(this, {
+      vpc: net.vpc,
+      lambdaSg: net.lambdaSg,
+      db: dbResult.db,
+      backendDbSecret: dbResult.backendDbSecret,
+      baseDomain,
+      ...sentryContext,
+    });
     let analyticsAccessResult: AnalyticsAccessResult | undefined;
     if (analyticsAccessRequested) {
       if (analyticsSshPublicKeysValue === undefined) {
@@ -401,6 +410,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       generatedMediaPromotionFn: generatedMediaPromotionResult.promotionFunction,
       multipartCompletionReconciliationFn:
         multipartCompletionReconciliationResult.reconciliationFunction,
+      catalogDumpFn: catalogDumpResult.dumpFunction,
     });
 
     ciCd(this, {
@@ -414,6 +424,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       communityLeaderboardSnapshotFn: communityLeaderboardResult.snapshotFunction,
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
+      catalogDumpFn: catalogDumpResult.dumpFunction,
       migrationFn,
       generatedMediaPromotionScheduleArn:
         generatedMediaPromotionResult.promotionScheduleArn,
@@ -450,6 +461,9 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       communityLeaderboardSnapshotFunction: communityLeaderboardResult.snapshotFunction,
       streakLeaderboardSnapshotFunction: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFunction: progressActiveDaysBackfillResult.backfillFunction,
+      catalogDumpBucket: catalogDumpResult.bucket,
+      catalogDumpDistribution: catalogDumpResult.distribution,
+      catalogDumpFunction: catalogDumpResult.dumpFunction,
       globalMetricsVisible,
       userPoolId: authResult.userPool.userPoolId,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,

--- a/scripts/generate/generate-catalog-dump.sh
+++ b/scripts/generate/generate-catalog-dump.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Rebuild the public catalog dump artifact served through CloudFront.
+
+set -euo pipefail
+
+STACK_NAME="FlashcardsOpenSourceApp"
+CATALOG_DUMP_FUNCTION_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack-name) STACK_NAME="$2"; shift 2 ;;
+    --function-name) CATALOG_DUMP_FUNCTION_NAME="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+function resolve_stack_output() {
+  local output_key="$1"
+
+  local output_value
+  output_value=$(aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --query "Stacks[0].Outputs[?OutputKey=='${output_key}'].OutputValue" \
+    --output text)
+
+  if [[ -z "$output_value" || "$output_value" == "None" ]]; then
+    echo "ERROR: ${output_key} is not present on ${STACK_NAME}." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$output_value"
+}
+
+function invoke_lambda_and_print_payload() {
+  local function_name="$1"
+  local success_message="$2"
+
+  local response_file
+  response_file=$(mktemp)
+
+  local invoke_metadata
+  invoke_metadata=$(aws lambda invoke \
+    --function-name "$function_name" \
+    --cli-read-timeout 900 \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{}' \
+    "$response_file")
+
+  python3 - "$response_file" "$invoke_metadata" "$success_message" "$function_name" <<'PY'
+import json
+import pathlib
+import sys
+
+response_path = pathlib.Path(sys.argv[1])
+metadata = json.loads(sys.argv[2])
+success_message = sys.argv[3]
+function_name = sys.argv[4]
+payload = json.loads(response_path.read_text())
+
+function_error = metadata.get("FunctionError")
+if function_error:
+    raise SystemExit(
+        f"ERROR: Lambda {function_name} failed ({function_error}): {json.dumps(payload)}"
+    )
+
+if not isinstance(payload, dict):
+    raise SystemExit(f"ERROR: Unexpected Lambda payload from {function_name}: {payload!r}")
+
+print(success_message)
+print(json.dumps(payload, indent=2, sort_keys=True))
+PY
+
+  rm -f "$response_file"
+}
+
+if [[ -z "$CATALOG_DUMP_FUNCTION_NAME" ]]; then
+  CATALOG_DUMP_FUNCTION_NAME=$(resolve_stack_output "CatalogDumpFunctionName")
+fi
+
+invoke_lambda_and_print_payload "$CATALOG_DUMP_FUNCTION_NAME" "Public catalog dump generated."


### PR DESCRIPTION
`GET /v1/catalog` recomputes the entire public catalog on every request — five full-table scans, per-card markdown re-validation, ~3.2 MB of JSON. It crossed API Gateway's 29s integration ceiling and produced 504s for roughly half of all requests.

This adds the pipeline that produces the snapshot **once** instead. Nothing consumes it yet.

## What changes

- New `infra/aws/lib/catalog-dump.ts`: S3 bucket + CloudFront distribution (OAC, default `*.cloudfront.net` domain, so no ACM certificate and no DNS record) + the `CatalogDumpHandler` builder Lambda.
- Builder writes three objects: immutable `catalog/<sha256>.json` (1 y cache), plus `catalog/latest.json` and `catalog/pointer.json` (60 s). The immutable object is written **first**, so a pointer can never name an object that does not exist yet.
- CI seeds the artifact after every deploy: new script plus all three required `aws-web-release.yml` edits (step, `paths:` filter, and the `aws_release_script_pattern` regex).
- Error alarm on the builder. Deliberately **no** staleness alarm and **no** cron — freshness is event-driven and lands in the next PR.

## The one subtle thing

The builder is a plain-bundled Lambda, unlike the three handlers that carry `sharp` via `nodeModules` + Docker bundling. Its module graph reached `mediaAssets/ingestion/imageNormalization.ts`, whose module-scope `require.resolve("sharp")` would have thrown `MODULE_NOT_FOUND` on every invocation — failing the seed step, and with it every release, after the backend deploy but before web/admin assets ship.

Fixed by redirecting two catalog barrel imports to `workspacePackages/markdownMedia` directly. The graph from the entrypoint goes from 126 modules to 35, with zero edges into that barrel. Every plain-bundled Lambda stays graph-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)