### PR TITLE
Rebuild the catalog dump when published output changes

### DIFF
--- a/apps/backend/src/catalog/distribution/public/dumpRefresh.ts
+++ b/apps/backend/src/catalog/distribution/public/dumpRefresh.ts
@@ -12,13 +12,23 @@
  * Import this module by its narrow path only. Do not re-export it from the
  * `catalog` or public-catalog barrels: those barrels are imported by Lambdas
  * that must not pull in the sharp-dependent authoring graph.
+ *
+ * Report through `observability/runtime`, never through `observability/sentry`.
+ * The collection-cover trigger runs inside `DirectImageIngestionHandler`, whose
+ * bundle deliberately excludes the Sentry SDK — `entrypoints/directImageIngestion/lambda.test.ts`
+ * asserts that its import graph reaches no `observability/sentry/capture`,
+ * `config` or `tracing` module. The runtime indirection keeps that true without
+ * costing the heavy handler anything: `BackendHandler` calls
+ * `initializeBackendSentry`, which installs `captureBackendException` as the
+ * runtime sink, so triggers there still reach Sentry, while the lean handler
+ * falls back to the same structured CloudWatch exception record.
  */
 import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
 import {
-  captureBackendException,
+  captureBackendRuntimeException,
   createBackendObservationScope,
   normalizeCaughtError,
-} from "../../../observability/sentry";
+} from "../../../observability/runtime";
 
 export type CatalogDumpRefreshTrigger = Readonly<{
   route: string;
@@ -98,7 +108,7 @@ export async function refreshPublicCatalogDump(
     );
   } catch (error) {
     const refreshError = normalizeCaughtError(error);
-    captureBackendException({
+    captureBackendRuntimeException({
       action: "catalog_dump_refresh_failed",
       error: refreshError,
       scope: createBackendObservationScope(

--- a/apps/backend/src/catalog/distribution/public/dumpRefresh.ts
+++ b/apps/backend/src/catalog/distribution/public/dumpRefresh.ts
@@ -1,0 +1,124 @@
+/**
+ * Rebuild trigger for the public catalog dump artifact.
+ *
+ * Nothing rebuilds the artifact on a schedule, so every admin operation that
+ * changes published catalog output has to trigger the builder itself. The
+ * builder runs asynchronously: the admin request pays for one time-bounded
+ * invoke, never for the rebuild, and never fails because of it. The state
+ * change has already committed when the trigger runs, so failing would report
+ * a successful publish as failed — but a dropped trigger leaves the CDN stale
+ * until the next admin operation, so every failed trigger is captured.
+ *
+ * Import this module by its narrow path only. Do not re-export it from the
+ * `catalog` or public-catalog barrels: those barrels are imported by Lambdas
+ * that must not pull in the sharp-dependent authoring graph.
+ */
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import {
+  captureBackendException,
+  createBackendObservationScope,
+  normalizeCaughtError,
+} from "../../../observability/sentry";
+
+export type CatalogDumpRefreshTrigger = Readonly<{
+  route: string;
+  method: string;
+  requestId: string | null;
+}>;
+
+const catalogDumpFunctionNameEnvName = "CATALOG_DUMP_FUNCTION_NAME";
+
+/**
+ * Hard ceiling for one trigger's invoke, retry attempt included.
+ *
+ * The trigger spends the calling handler's remaining time, and the tightest
+ * caller is the direct image ingestion Lambda: it reserves
+ * `directImageIngestionResponseMarginMs` (2 s) of its 15 s timeout for producing
+ * the response, and an ingest that runs to its deadline leaves only that. A slow
+ * or throttled Lambda control-plane call must therefore fail fast and be
+ * captured, never run a committed admin operation out of time into a 502.
+ */
+const catalogDumpRefreshInvokeTimeoutMs = 1_000;
+
+/**
+ * Attempts allowed per trigger, first attempt included.
+ *
+ * Do not lower this back to one. The client below is a module-level singleton
+ * reused across invocations, so the first invoke after an idle container can hit
+ * a stale keep-alive socket and fail with `ECONNRESET` on a request the next
+ * attempt would have completed — silently costing artifact freshness on a
+ * surface too low-traffic for a later trigger to cover for it. Allowing the
+ * retry does not widen the latency bound above: `abortSignal` is applied to the
+ * whole `send` call, retries included, so both attempts share the single
+ * `catalogDumpRefreshInvokeTimeoutMs` budget instead of getting one each.
+ */
+const catalogDumpRefreshInvokeMaxAttempts = 2;
+
+let catalogDumpRefreshLambdaClient: LambdaClient | null = null;
+
+function getCatalogDumpRefreshLambdaClient(): LambdaClient {
+  if (catalogDumpRefreshLambdaClient === null) {
+    catalogDumpRefreshLambdaClient = new LambdaClient({
+      maxAttempts: catalogDumpRefreshInvokeMaxAttempts,
+    });
+  }
+
+  return catalogDumpRefreshLambdaClient;
+}
+
+function getCatalogDumpFunctionName(): string {
+  const functionName = process.env[catalogDumpFunctionNameEnvName];
+  if (functionName === undefined || functionName.trim() === "") {
+    throw new Error(`${catalogDumpFunctionNameEnvName} environment variable is not set`);
+  }
+
+  return functionName.trim();
+}
+
+/**
+ * Triggers one asynchronous public catalog dump rebuild and never throws.
+ *
+ * Callers must await this even though the rebuild itself is not awaited: the
+ * invoke call has to reach Lambda before the route handler returns, because the
+ * execution environment freezes right after the response.
+ */
+export async function refreshPublicCatalogDump(
+  trigger: CatalogDumpRefreshTrigger,
+): Promise<void> {
+  let functionName: string | null = null;
+  try {
+    functionName = getCatalogDumpFunctionName();
+    await getCatalogDumpRefreshLambdaClient().send(
+      new InvokeCommand({
+        FunctionName: functionName,
+        InvocationType: "Event",
+        Payload: new TextEncoder().encode(JSON.stringify({ triggerRoute: trigger.route })),
+      }),
+      { abortSignal: AbortSignal.timeout(catalogDumpRefreshInvokeTimeoutMs) },
+    );
+  } catch (error) {
+    const refreshError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "catalog_dump_refresh_failed",
+      error: refreshError,
+      scope: createBackendObservationScope(
+        "backend-api",
+        trigger.requestId,
+        trigger.route,
+        trigger.method,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: {
+        functionName,
+        route: trigger.route,
+        message: refreshError.message,
+      },
+    });
+  }
+}

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-catalog-dump.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-catalog-dump.ts
@@ -11,6 +11,8 @@ import {
 
 initializeBackendSentry("catalog-dump");
 
+const maximumTriggerRouteLength = 200;
+
 type CatalogDumpResponse = Readonly<{
   ok: true;
   bucketName: string;
@@ -50,14 +52,42 @@ function readOptionalTrimmedEnv(env: NodeJS.ProcessEnv, name: string): string | 
   return value.trim();
 }
 
-function createCatalogDumpFailureDetails(error: Error): CatalogDumpFailureDetails {
+function createCatalogDumpFailureDetails(
+  error: Error,
+  triggerRoute: string | null,
+): CatalogDumpFailureDetails {
   return {
     bucketName: readOptionalTrimmedEnv(process.env, "CATALOG_DUMP_S3_BUCKET_NAME"),
+    triggerRoute,
     message: error.message,
   };
 }
 
-const catalogDumpHandler: Handler<unknown, CatalogDumpResponse> = async (_event, context) => {
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+/**
+ * Reads the admin route that triggered this rebuild, so a stale artifact can be
+ * traced back to the operation that should have refreshed it. The deploy-time
+ * seed sends an empty payload, and a malformed payload must never fail a
+ * rebuild, so both degrade to no attribution.
+ */
+function readTriggerRoute(event: unknown): string | null {
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const triggerRoute = event.triggerRoute;
+  if (typeof triggerRoute !== "string" || triggerRoute.trim() === "") {
+    return null;
+  }
+
+  return triggerRoute.trim().slice(0, maximumTriggerRouteLength);
+}
+
+const catalogDumpHandler: Handler<unknown, CatalogDumpResponse> = async (event, context) => {
+  const triggerRoute = readTriggerRoute(event);
   const observationScope = createBackendObservationScope(
     "catalog-dump",
     context.awsRequestId ?? null,
@@ -84,6 +114,7 @@ const catalogDumpHandler: Handler<unknown, CatalogDumpResponse> = async (_event,
         sha256: result.sha256,
         generatedAt: result.generatedAt,
         byteLength: result.byteLength,
+        triggerRoute,
       },
     });
 
@@ -101,7 +132,7 @@ const catalogDumpHandler: Handler<unknown, CatalogDumpResponse> = async (_event,
       action: "catalog_dump_failed",
       error: normalizedError,
       scope: observationScope,
-      details: createCatalogDumpFailureDetails(normalizedError),
+      details: createCatalogDumpFailureDetails(normalizedError, triggerRoute),
     });
     throw error;
   }

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -93,6 +93,7 @@ export type {
   AgentSqlDetails,
   CatalogDumpFailureDetails,
   CatalogDumpGeneratedDetails,
+  CatalogDumpRefreshFailureDetails,
   CatalogDumpS3RetryDetails,
   CommunityLeaderboardSnapshotFailureDetails,
   CommunityLeaderboardSnapshotGeneratedDetails,

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -104,10 +104,19 @@ export type CatalogDumpGeneratedDetails = Readonly<{
   sha256: string;
   generatedAt: string;
   byteLength: number;
+  /** Admin route that triggered the rebuild, or `null` for a deploy-time seed. */
+  triggerRoute: string | null;
 }>;
 
 export type CatalogDumpFailureDetails = Readonly<{
   bucketName: string | null;
+  triggerRoute: string | null;
+  message: string;
+}>;
+
+export type CatalogDumpRefreshFailureDetails = Readonly<{
+  functionName: string | null;
+  route: string;
   message: string;
 }>;
 
@@ -399,6 +408,7 @@ export type OperationsWarningEvent =
 export type OperationsExceptionEvent =
   | (EventByAction<"global_metrics_snapshot_failed", GlobalMetricsSnapshotFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"catalog_dump_failed", CatalogDumpFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"catalog_dump_refresh_failed", CatalogDumpRefreshFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"community_leaderboard_snapshot_failed", CommunityLeaderboardSnapshotFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"streak_leaderboard_snapshot_failed", StreakLeaderboardSnapshotFailureDetails> & Readonly<{
     error: Error;

--- a/apps/backend/src/routes/catalog/admin.test.ts
+++ b/apps/backend/src/routes/catalog/admin.test.ts
@@ -309,6 +309,7 @@ function createCatalogImageTestApp(
       input.collectionId,
       input.imageBytes,
     ),
+    refreshPublicCatalogDumpFn: async () => {},
   }));
   return app;
 }

--- a/apps/backend/src/routes/catalog/admin.ts
+++ b/apps/backend/src/routes/catalog/admin.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import {
   requireCatalogAdminRequest,
   type CatalogAdminRequestContext,
@@ -18,6 +18,10 @@ import {
   updateCatalogPackageDraft,
   updateCatalogPackageVersionReviewStatus,
 } from "../../catalog";
+import {
+  refreshPublicCatalogDump,
+  type CatalogDumpRefreshTrigger,
+} from "../../catalog/distribution/public/dumpRefresh";
 import {
   catalogPackageStatuses,
   type AttachCatalogPackageMediaAssetInput,
@@ -90,6 +94,7 @@ type CatalogAdminRoutesOptions = Readonly<{
     adminEmail: string,
     note: string | null,
   ) => Promise<CatalogPackageVersion>;
+  refreshPublicCatalogDumpFn?: (trigger: CatalogDumpRefreshTrigger) => Promise<void>;
 }>;
 
 const catalogAdminMaximumBodyBytes = 2_000_000;
@@ -308,6 +313,14 @@ function parseNoteInput(record: Readonly<Record<string, unknown>>): string | nul
   return expectNullableNonEmptyString(record.note, "note");
 }
 
+function createCatalogDumpRefreshTrigger(context: Context<AppEnv>): CatalogDumpRefreshTrigger {
+  return {
+    route: context.req.path,
+    method: context.req.method,
+    requestId: context.get("requestId"),
+  };
+}
+
 export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const requireAdminRequestFn = options.requireAdminRequestFn ?? requireCatalogAdminRequest;
@@ -328,6 +341,7 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
     ?? updateCatalogPackageVersionReviewStatus;
   const publishCatalogPackageVersionFn = options.publishCatalogPackageVersionFn ?? publishCatalogPackageVersion;
   const delistCatalogPackageVersionFn = options.delistCatalogPackageVersionFn ?? delistCatalogPackageVersion;
+  const refreshPublicCatalogDumpFn = options.refreshPublicCatalogDumpFn ?? refreshPublicCatalogDump;
 
   app.post("/admin/catalog/authors", async (context) => {
     await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
@@ -342,6 +356,8 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
       authorId,
       await parseCatalogAdminJsonBody(context.req.raw),
     ));
+    // Author edits reach the snapshot of every already-published package.
+    await refreshPublicCatalogDumpFn(createCatalogDumpRefreshTrigger(context));
     return context.json({ author });
   });
 
@@ -367,6 +383,17 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
       packageId,
       await parseCatalogAdminJsonBody(context.req.raw),
     ));
+    if (catalogPackage.status === "published") {
+      // The package slug and author feed the snapshot, but every snapshot query
+      // requires `packages.status = 'published'`, so editing a package in any other
+      // status provably cannot change the artifact. Skipping those keeps a batch of
+      // draft saves from queuing no-op 15 s rebuilds ahead of the publish that
+      // matters on a builder limited to one concurrent run. The transitions in and
+      // out of published output are hooked by publish and delist instead, which
+      // stay unconditional.
+      await refreshPublicCatalogDumpFn(createCatalogDumpRefreshTrigger(context));
+    }
+
     return context.json({ catalogPackage });
   });
 
@@ -429,6 +456,7 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
       adminContext.email,
       parseNoteInput(await parseCatalogAdminJsonBody(context.req.raw)),
     );
+    await refreshPublicCatalogDumpFn(createCatalogDumpRefreshTrigger(context));
     return context.json({ packageVersion });
   });
 
@@ -440,6 +468,7 @@ export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Ho
       adminContext.email,
       parseNoteInput(await parseCatalogAdminJsonBody(context.req.raw)),
     );
+    await refreshPublicCatalogDumpFn(createCatalogDumpRefreshTrigger(context));
     return context.json({ packageVersion });
   });
 

--- a/apps/backend/src/routes/catalog/adminImageIngestion.ts
+++ b/apps/backend/src/routes/catalog/adminImageIngestion.ts
@@ -14,6 +14,10 @@ import {
   type CatalogPackageImageIngestionResult,
 } from "../../catalog/authoring/media/imageIngestion";
 import { normalizePackageMediaKey } from "../../catalog/common";
+import {
+  refreshPublicCatalogDump,
+  type CatalogDumpRefreshTrigger,
+} from "../../catalog/distribution/public/dumpRefresh";
 import type {
   CatalogCollectionCover,
   CatalogPackageMediaAsset,
@@ -53,6 +57,7 @@ export type CatalogAdminImageIngestionRoutesOptions = Readonly<{
   ingestCatalogPackageCardImageFn?: (input: CatalogPackageCardImageIngestionInput) => Promise<CatalogPackageImageIngestionResult>;
   replaceCatalogPackageCoverImageFn?: (input: CatalogPackageCoverImageIngestionInput) => Promise<CatalogPackageImageIngestionResult>;
   replaceCatalogCollectionCoverImageFn?: (input: CatalogCollectionCoverImageIngestionInput) => Promise<CatalogCollectionCoverImageIngestionResult>;
+  refreshPublicCatalogDumpFn?: (trigger: CatalogDumpRefreshTrigger) => Promise<void>;
 }>;
 
 function parsePackageId(value: string | undefined): string {
@@ -122,6 +127,14 @@ function createCatalogImageIngestionScope(context: Context<AppEnv>, userId: stri
     sessionId: null,
     clientAppVersion: context.get("clientAppVersion"),
     clientPlatform: context.get("clientPlatform"),
+  };
+}
+
+function createCatalogDumpRefreshTrigger(context: Context<AppEnv>): CatalogDumpRefreshTrigger {
+  return {
+    route: context.req.path,
+    method: context.req.method,
+    requestId: context.get("requestId"),
   };
 }
 
@@ -227,6 +240,7 @@ export function createCatalogAdminImageIngestionRoutes(options: CatalogAdminImag
     ?? replaceCatalogPackageCoverImage;
   const replaceCatalogCollectionCoverImageFn = options.replaceCatalogCollectionCoverImageFn
     ?? replaceCatalogCollectionCoverImage;
+  const refreshPublicCatalogDumpFn = options.refreshPublicCatalogDumpFn ?? refreshPublicCatalogDump;
 
   app.post("/admin/catalog/packages/:packageId/media-assets/images", async (context) => {
     const deadline = createRequestDeadline();
@@ -353,6 +367,10 @@ export function createCatalogAdminImageIngestionRoutes(options: CatalogAdminImag
         observationScope: scope,
       });
       addCatalogCollectionCoverIngestionSuccess(scope, result, 200);
+      if (result.applied) {
+        // Only a real cover swap changes `collections[].coverDownloadUrl`.
+        await refreshPublicCatalogDumpFn(createCatalogDumpRefreshTrigger(context));
+      }
       return context.json({
         collectionCover: toPublicCatalogCollectionCover(result.collectionCover),
       });

--- a/infra/aws/lib/catalog-dump.ts
+++ b/infra/aws/lib/catalog-dump.ts
@@ -115,6 +115,13 @@ export function catalogDump(scope: Construct, props: CatalogDumpProps): CatalogD
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),
     memorySize: 2048,
+    // Admin operations trigger rebuilds, so runs can now overlap. Two overlapping
+    // runs interleave the `latest.json` and `pointer.json` writes and can leave the
+    // pointer naming one build while `latest.json` holds another. One reserved
+    // execution serializes them without a lock: throttled asynchronous triggers stay
+    // queued and are retried by Lambda, and the run that wins is the one that read
+    // Postgres last.
+    reservedConcurrentExecutions: 1,
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     securityGroups: [props.lambdaSg],

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -37,6 +37,7 @@ export interface ApiGatewayProps {
   globalMetricsSnapshotBucket: s3.IBucket;
   globalMetricsSnapshotObjectKey: string;
   mediaAssetsBucket: s3.IBucket;
+  catalogDumpFunction: lambda.IFunction;
   userPoolId: string;
   userPoolArn: string;
   userPoolClientId: string;
@@ -79,6 +80,7 @@ interface BackendFunctionProps {
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsConfig: GlobalMetricsConfig | undefined;
   mediaAssetsBucket: s3.IBucket | undefined;
+  catalogDumpFunction: lambda.IFunction | undefined;
   memorySize: number;
   architecture: lambda.Architecture;
   bundling: lambdaNodejs.BundlingOptions;
@@ -98,6 +100,7 @@ interface DirectImageIngestionFunctionProps {
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   mediaAssetsBucket: s3.IBucket;
+  catalogDumpFunction: lambda.IFunction;
 }
 
 export const publicRestApiDefaultIntegrationTimeoutSeconds = 29;
@@ -471,6 +474,23 @@ function addGlobalMetricsEnvironment(
   }));
 }
 
+/**
+ * Lets one request-serving function trigger a public catalog dump rebuild after
+ * an admin operation changed published catalog output. Nothing rebuilds the
+ * artifact on a schedule, so only the functions serving those admin routes get
+ * the function name and the invoke permission, scoped to the builder alone.
+ */
+function addCatalogDumpRefreshEnvironment(
+  fn: lambdaNodejs.NodejsFunction,
+  catalogDumpFunction: lambda.IFunction,
+): void {
+  fn.addEnvironment("CATALOG_DUMP_FUNCTION_NAME", catalogDumpFunction.functionName);
+  fn.addToRolePolicy(new cdk.aws_iam.PolicyStatement({
+    actions: ["lambda:InvokeFunction"],
+    resources: [catalogDumpFunction.functionArn],
+  }));
+}
+
 export function createMediaAssetsObjectPolicyStatement(bucket: s3.IBucket): cdk.aws_iam.PolicyStatement {
   return new cdk.aws_iam.PolicyStatement({
     actions: [
@@ -651,6 +671,9 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
   if (props.mediaAssetsBucket !== undefined) {
     addMediaAssetsEnvironment(fn, props.mediaAssetsBucket);
   }
+  if (props.catalogDumpFunction !== undefined) {
+    addCatalogDumpRefreshEnvironment(fn, props.catalogDumpFunction);
+  }
 
   return fn;
 }
@@ -718,6 +741,10 @@ function createDirectImageIngestionFunction(
   fn.addToRolePolicy(
     createDirectImageIngestionObjectPolicyStatement(props.mediaAssetsBucket),
   );
+  // This function, not the shared backend handler, serves
+  // PUT /admin/catalog/collections/{collectionId}/cover, which changes the
+  // published collection cover.
+  addCatalogDumpRefreshEnvironment(fn, props.catalogDumpFunction);
   return fn;
 }
 
@@ -806,6 +833,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       snapshotObjectKey: props.globalMetricsSnapshotObjectKey,
     },
     mediaAssetsBucket: props.mediaAssetsBucket,
+    catalogDumpFunction: props.catalogDumpFunction,
     memorySize: 2048,
     architecture: lambda.Architecture.ARM_64,
     bundling: createLambdaBundling({
@@ -827,6 +855,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     mediaAssetsBucket: props.mediaAssetsBucket,
+    catalogDumpFunction: props.catalogDumpFunction,
   });
   const chatWorkerFn = createBackendFunction(scope, {
     constructId: "ChatRunWorkerHandler",
@@ -861,6 +890,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
     mediaAssetsBucket: props.mediaAssetsBucket,
+    catalogDumpFunction: undefined,
     memorySize: 1024,
     architecture: lambda.Architecture.ARM_64,
     bundling: createLambdaBundling({
@@ -901,6 +931,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
     mediaAssetsBucket: undefined,
+    catalogDumpFunction: undefined,
     memorySize: 256,
     architecture: lambda.Architecture.X86_64,
     bundling: createLambdaBundling({

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -373,6 +373,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       globalMetricsSnapshotBucket: globalMetricsResult.snapshotBucket,
       globalMetricsSnapshotObjectKey: globalMetricsResult.snapshotObjectKey,
       mediaAssetsBucket: mediaAssetsResult.bucket,
+      catalogDumpFunction: catalogDumpResult.dumpFunction,
       userPoolId: authResult.userPool.userPoolId,
       userPoolArn: authResult.userPool.userPoolArn,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,

--- a/scripts/generate/generate-catalog-dump.sh
+++ b/scripts/generate/generate-catalog-dump.sh
@@ -38,8 +38,11 @@ function invoke_lambda_and_print_payload() {
   local response_file
   response_file=$(mktemp)
 
+  # The builder holds one reserved execution so admin-triggered rebuilds cannot
+  # overlap, so this synchronous invoke is throttled while such a rebuild runs.
+  # Retry TooManyRequestsException long enough to outlast a queued rebuild.
   local invoke_metadata
-  invoke_metadata=$(aws lambda invoke \
+  invoke_metadata=$(AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=10 aws lambda invoke \
     --function-name "$function_name" \
     --cli-read-timeout 900 \
     --cli-binary-format raw-in-base64-out \


### PR DESCRIPTION
The CDN artifact was only refreshed by the post-deploy seed, so a deck published between deploys would never reach it. There is deliberately no safety cron, so this event set is the entire freshness mechanism.

## What changes

Hooks the five admin operations that can actually alter published catalog output — `publish`, `delist`, `PUT authors/{id}`, `PUT packages/{id}/draft`, and the collection cover `PUT`. Draft-only endpoints stay unhooked: every snapshot query requires `packages.status = 'published'`, so they provably cannot change the artifact.

- The invoke is asynchronous, **awaited** so it leaves before the handler returns (Lambda freezes the execution environment afterwards), bounded to 1 s with two attempts inside that one budget, and can never throw into an admin request that already committed its state change. A failure degrades to a `catalog_dump_refresh_failed` capture.
- The builder runs with `reservedConcurrentExecutions: 1`, so two overlapping runs cannot leave `latest.json` and `pointer.json` naming different snapshots.
- That makes the **synchronous** deploy seed throttlable, so its invoke now retries long enough to outlast a queued rebuild.
- The builder records which admin route triggered each rebuild, on both the success and failure paths. The deploy seed sends `{}` and records `null`, so seeded and admin-triggered rebuilds are distinguishable.

`PUT packages/{id}/draft` fires only when the package is already published — gating on `status`, not `publishedAt`, because publish sets `published_at = COALESCE(published_at, now())` and delist never clears it, so `publishedAt` stays non-null on delisted packages.

## Known, deliberately not addressed here

The collection-cover hook is gated on `result.applied`, which is not quite "the artifact changed": the snapshot's `coverDownloadUrl` is a stable id-only URL keyed only on whether a cover exists, so a blob swap changes nothing while the first-ever cover does. There are currently zero collections in the catalog, so the path is unreachable in production; queued as follow-up rather than another round here.

Also queued: an S3 lifecycle policy for accumulated artifact objects, and a `Throttles`/DLQ signal on the builder plus `initializeBackendSentry` on `DirectImageIngestionHandler`, whose only log-derived alarm matches handled 5xx records and so would not catch a failed refresh capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)