### PR TITLE
Stop reporting TLS transport failures from the AI chat passive refresh

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
@@ -853,7 +853,7 @@ extension AIChatStore {
         if isAIChatRequestCancellationError(error: error) {
             return true
         }
-        if isRetryableNetworkTransportFailure(error: error) {
+        if isSilentlyIgnorableNetworkTransportFailure(error: error) {
             return true
         }
         return self.isAIChatPassiveSnapshotRefreshBlockedGateFailure(error: error)

--- a/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
@@ -420,6 +420,27 @@ func isRetryableNetworkTransportFailure(code: URLError.Code) -> Bool {
     }
 }
 
+func isSilentlyIgnorableNetworkTransportFailure(error: Error) -> Bool {
+    if isRetryableNetworkTransportFailure(error: error) {
+        return true
+    }
+
+    guard let urlErrorCode: URLError.Code = flashcardsURLErrorCode(error: error, remainingDepth: 4) else {
+        return false
+    }
+
+    switch urlErrorCode {
+    case .secureConnectionFailed,
+         .serverCertificateHasBadDate,
+         .serverCertificateUntrusted,
+         .serverCertificateHasUnknownRoot,
+         .serverCertificateNotYetValid:
+        return true
+    default:
+        return false
+    }
+}
+
 func makeCloudAuthInlineErrorPresentation(
     error: Error,
     context: CloudAuthInlineErrorContext


### PR DESCRIPTION
## Problem

A Sentry `NSURLErrorDomain -1200` (`secureConnectionFailed`) arrives under action `ai_chat_passive_snapshot_refresh` from devices whose network intercepts or blocks TLS to the API. Nothing in the app is broken: the passive snapshot refresh is a background path the user never sees, and the same request fails identically for guest session creation on that network.

The capture guard `shouldIgnoreAIChatPassiveSnapshotRefreshFailure` suppresses `isRetryableNetworkTransportFailure`, whose code list covers timeouts and connectivity loss but no TLS or certificate code — so client-side transport interference is reported as an app error.

## Change

- `ErrorMessageSupport.swift`: add `isSilentlyIgnorableNetworkTransportFailure(error:)` next to the existing classifier. It is true for the whole retryable set plus `secureConnectionFailed`, `serverCertificateHasBadDate`, `serverCertificateUntrusted`, `serverCertificateHasUnknownRoot`, and `serverCertificateNotYetValid`, resolved through the same `flashcardsURLErrorCode(error:remainingDepth: 4)` walk.
- `AIChatStore+Surface.swift`: use it in that one capture guard.

`isRetryableNetworkTransportFailure` and all of its other call sites are untouched, so retry policy and every user-visible message keep their current classification. The visible AI chat bootstrap path still renders its network message for `-1200`.

## Scope

No user-visible behavior changes anywhere. Deliberately deferred to a separate decision: the same suppression for the progress refresh, cloud sync, media upload, and feedback automatic-prompt capture sites, which still report TLS failures. The progress-refresh predicate also gates the visible "progress unavailable" message, so it needs its own treatment rather than this one-line switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)