### PR TITLE
Silence TLS transport failures in three background capture paths

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -1021,7 +1021,7 @@ extension FlashcardsStore {
     }
 
     private func captureMediaUploadTransferProcessingFailure(error: Error, linkedSession: CloudLinkedSession) {
-        if isRetryableNetworkTransportFailure(error: error) {
+        if isSilentlyIgnorableNetworkTransportFailure(error: error) {
             return
         }
 

--- a/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
@@ -452,7 +452,7 @@ func makeCloudAuthInlineErrorPresentation(
         )
     }
 
-    if isRetryableNetworkTransportFailure(error: error) {
+    if isSilentlyIgnorableNetworkTransportFailure(error: error) {
         return CloudAuthInlineErrorPresentation(
             message: makeCloudAuthTransportFailureMessage(context: context),
             technicalError: nil

--- a/apps/ios/Flashcards/Flashcards/Feedback/FlashcardsStore+Feedback.swift
+++ b/apps/ios/Flashcards/Flashcards/Feedback/FlashcardsStore+Feedback.swift
@@ -300,7 +300,7 @@ extension FlashcardsStore {
         if isRequestCancellationError(error: error) {
             return true
         }
-        if isRetryableNetworkTransportFailure(error: error) {
+        if isSilentlyIgnorableNetworkTransportFailure(error: error) {
             return true
         }
         if let statusCode = feedbackFailureDiagnostics(error: error).statusCode,


### PR DESCRIPTION
## Change

Three one-line guard swaps from `isRetryableNetworkTransportFailure` to the existing `isSilentlyIgnorableNetworkTransportFailure`, so client-side TLS interception stops reaching Sentry from paths where it is not an app defect:

- `makeCloudAuthInlineErrorPresentation` — cloud auth inline error;
- `captureMediaUploadTransferProcessingFailure` — media upload transfer processing;
- `shouldRetryAutomaticFeedbackPromptSilently` — automatic feedback prompt.

## Behavior

- Cloud auth: the message text is byte-identical — both the taken branch and the previous one return `makeCloudAuthTransportFailureMessage(context:)`. The optional "Technical details" affordance disappears for the five TLS/certificate codes, matching how timeouts and connectivity failures already behave there.
- Media upload: telemetry-only function, nothing user-facing.
- Feedback: a TLS failure now takes the normal 30-minute silent retry backoff instead of being captured, exactly as timeouts already do.

`shouldCaptureCloudSyncFailure` deliberately keeps the old classification: it captures only for the manual technical-error-modal retry trigger, where an event is legitimate. Neither predicate body changed, and no other call site is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)