### PR TITLE
Stop the progress refresh technical error on TLS transport failures

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift
@@ -19,7 +19,7 @@ extension FlashcardsStore {
             return false
         }
 
-        if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
+        if isSilentlyIgnorableNetworkTransportFailure(error: error) {
             return false
         }
 


### PR DESCRIPTION
## Change

One line in `shouldPresentProgressRefreshTechnicalError(error:)`: the transport check now uses `isSilentlyIgnorableNetworkTransportFailure` instead of `isNonCriticalProgressRefreshTransportFailure`.

## Behavior

For `secureConnectionFailed` and the four `serverCertificate*` codes on a progress refresh:

- no `captureSilentFailure` Sentry event;
- no technical-error modal, which is not actionable for a network-level failure;
- the inline "progress unavailable" / refresh error message still appears, because the early returns in the catch blocks keep using `isNonCriticalProgressRefreshTransportFailure`, which is unchanged.

Timeouts and connectivity failures are unaffected: the new helper is a strict superset of the retryable set, so every code that was suppressed before is still suppressed, at the same place.

Verified statically across all eleven call sites of the two predicates, including `FlashcardsStore+Progress.swift:953`, the one site that calls the gate without the early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)