### PR TITLE
Alarm when the public API stops receiving traffic entirely

### DIFF
--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -20,6 +20,7 @@ import { communityLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/comm
 import { streakLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfillScheduleHours } from "./scheduled-jobs/progress-active-days-backfill";
 
+const restApiNoTrafficEvaluationPeriods = 4;
 const communityLeaderboardSnapshotStaleEvaluationPeriods = 2;
 const streakLeaderboardSnapshotStaleEvaluationPeriods = 2;
 const progressActiveDaysBackfillStaleEvaluationPeriods = 2;
@@ -138,6 +139,28 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     evaluationPeriods: 1,
     alarmDescription: "API Gateway returned 5+ server errors in 5 minutes",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  // Every other API alarm needs traffic to observe a failure, so a dead edge (expired TLS
+  // certificate, broken DNS, detached custom domain) stays silent because API Gateway then
+  // publishes no datapoints at all. Missing data is treated as breaching here on purpose,
+  // and a full hour of zero requests keeps quiet organic traffic hours below the threshold.
+  new cloudwatch.Alarm(scope, "ApiGatewayNoTrafficAlarm", {
+    metric: new cloudwatch.Metric({
+      namespace: "AWS/ApiGateway",
+      metricName: "Count",
+      dimensionsMap: { ApiName: props.restApi.restApiName },
+      period: cdk.Duration.minutes(15),
+      statistic: "Sum",
+    }),
+    threshold: 0,
+    comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+    evaluationPeriods: restApiNoTrafficEvaluationPeriods,
+    datapointsToAlarm: restApiNoTrafficEvaluationPeriods,
+    alarmDescription:
+      "API Gateway received no requests for one hour, so the public API edge is unreachable " +
+      "(expired TLS certificate, broken DNS, or detached custom domain)",
+    treatMissingData: cloudwatch.TreatMissingData.BREACHING,
   }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
 
   new cloudwatch.Alarm(scope, "AuthApiGateway5xxAlarm", {


### PR DESCRIPTION
## Problem

Every alarm in `monitoring.ts` measures a failure rate — 5xx counts, Lambda errors, RDS saturation. All of them need requests to arrive in order to observe anything. If the edge itself dies (expired TLS certificate, broken DNS, detached custom domain), API Gateway publishes no datapoints at all, and `treatMissingData: NOT_BREACHING` makes those alarms read a total outage as silence. Nothing else watches production between deploys: the health and endpoint checks run only inside `AWS/Web Release`, and the only scheduled workflow is the live-e2e cleanup.

## Change

One additive alarm, `ApiGatewayNoTrafficAlarm`, on the backend REST API `Count` metric, wired to the existing `flashcards-open-source-app-alerts` topic:

- `Sum` over 15 minutes, `<= 0`, `evaluationPeriods` = `datapointsToAlarm` = 4 → a full hour of consecutive silence;
- `treatMissingData: BREACHING` — deliberately the opposite of the neighbouring 5xx alarms, because a dead edge produces missing data rather than bad data. This is the same construction the four staleness alarms in this file already use.

## Trade-off

The threshold is literally zero, not "low", so a single request from any client in any 15-minute window resets the streak. There is no synthetic traffic floor behind it: no scheduled backend job goes through API Gateway, and the daily live-e2e cleanup is the only recurring caller. If production turns out to have genuinely empty overnight hours, `restApiNoTrafficEvaluationPeriods` is the one-line lever (4 → 8 for two hours); the `alarmDescription` names the window, so it must be updated in the same edit.

Purely additive: no existing construct is touched, so no logical ID changes and the deploy adds exactly one `AWS::CloudWatch::Alarm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)