### PR TITLE
Watch the public hosts from outside with a heartbeat probe

### DIFF
--- a/infra/aws/lambda/public-endpoint-heartbeat/index.ts
+++ b/infra/aws/lambda/public-endpoint-heartbeat/index.ts
@@ -1,0 +1,211 @@
+import { CloudWatchClient, MetricDatum, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+
+type HeartbeatTarget = Readonly<{
+  host: string;
+  probeUrl: string;
+}>;
+
+type HeartbeatConfig = Readonly<{
+  targets: ReadonlyArray<HeartbeatTarget>;
+  metricNamespace: string;
+  metricName: string;
+  metricHostDimensionName: string;
+  requestTimeoutMilliseconds: number;
+}>;
+
+type HeartbeatProbeResult = Readonly<{
+  host: string;
+  probeUrl: string;
+  reachable: boolean;
+  statusCode: number | undefined;
+  durationMilliseconds: number;
+  failureReason: string | undefined;
+}>;
+
+type PublicEndpointHeartbeatResult = Readonly<{
+  ok: true;
+  probes: ReadonlyArray<HeartbeatProbeResult>;
+}>;
+
+const expectedStatusCode = 200;
+const reachableMetricValue = 1;
+const unreachableMetricValue = 0;
+const millisecondsPerSecond = 1000;
+const cloudWatchClient = new CloudWatchClient({});
+
+function getRequiredEnv(envName: string): string {
+  const value = process.env[envName];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${envName} is required for the public endpoint heartbeat.`);
+  }
+
+  return value.trim();
+}
+
+function parseRequiredPositiveNumber(value: string, envName: string): number {
+  const parsedValue = Number(value);
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    throw new Error(`${envName} must be a positive number, received ${value}.`);
+  }
+
+  return parsedValue;
+}
+
+function parseRequiredString(value: unknown, fieldPath: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${fieldPath} must be a non-empty string, received ${JSON.stringify(value)}.`);
+  }
+
+  return value.trim();
+}
+
+function parseHeartbeatTargets(rawTargets: string, envName: string): ReadonlyArray<HeartbeatTarget> {
+  let parsedTargets: unknown;
+  try {
+    parsedTargets = JSON.parse(rawTargets);
+  } catch (error) {
+    throw new Error(`${envName} must be valid JSON, received ${rawTargets}: ${formatErrorSummary(error)}`);
+  }
+
+  if (!Array.isArray(parsedTargets) || parsedTargets.length === 0) {
+    throw new Error(`${envName} must be a non-empty JSON array, received ${rawTargets}.`);
+  }
+
+  return parsedTargets.map((entry: unknown, index: number): HeartbeatTarget => {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error(`${envName}[${index}] must be an object, received ${JSON.stringify(entry)}.`);
+    }
+
+    const target = entry as Record<string, unknown>;
+    const probeUrl = parseRequiredString(target.probeUrl, `${envName}[${index}].probeUrl`);
+    if (!probeUrl.startsWith("https://")) {
+      throw new Error(`${envName}[${index}].probeUrl must be an https URL, received ${probeUrl}.`);
+    }
+
+    return {
+      host: parseRequiredString(target.host, `${envName}[${index}].host`),
+      probeUrl,
+    };
+  });
+}
+
+function loadHeartbeatConfig(): HeartbeatConfig {
+  return {
+    targets: parseHeartbeatTargets(
+      getRequiredEnv("PUBLIC_ENDPOINT_HEARTBEAT_TARGETS"),
+      "PUBLIC_ENDPOINT_HEARTBEAT_TARGETS",
+    ),
+    metricNamespace: getRequiredEnv("PUBLIC_ENDPOINT_HEARTBEAT_METRIC_NAMESPACE"),
+    metricName: getRequiredEnv("PUBLIC_ENDPOINT_HEARTBEAT_METRIC_NAME"),
+    metricHostDimensionName: getRequiredEnv("PUBLIC_ENDPOINT_HEARTBEAT_METRIC_HOST_DIMENSION_NAME"),
+    requestTimeoutMilliseconds: parseRequiredPositiveNumber(
+      getRequiredEnv("PUBLIC_ENDPOINT_HEARTBEAT_REQUEST_TIMEOUT_SECONDS"),
+      "PUBLIC_ENDPOINT_HEARTBEAT_REQUEST_TIMEOUT_SECONDS",
+    ) * millisecondsPerSecond,
+  };
+}
+
+function formatErrorSummary(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+
+  return String(error);
+}
+
+// Every transport, TLS, DNS and timeout failure is the exact signal this heartbeat exists to
+// report, so it is turned into an unreachable result instead of an exception: an outage on one
+// host must still leave the other hosts with a published datapoint.
+// Redirects are not followed, matching the repository's own curl checks against these paths, so
+// anything other than the host itself answering HTTP 200 counts as unreachable.
+async function probeTarget(
+  target: HeartbeatTarget,
+  requestTimeoutMilliseconds: number,
+): Promise<HeartbeatProbeResult> {
+  const startedAtMilliseconds = Date.now();
+
+  try {
+    const response = await fetch(target.probeUrl, {
+      method: "GET",
+      redirect: "manual",
+      signal: AbortSignal.timeout(requestTimeoutMilliseconds),
+    });
+    await response.arrayBuffer();
+
+    return {
+      host: target.host,
+      probeUrl: target.probeUrl,
+      reachable: response.status === expectedStatusCode,
+      statusCode: response.status,
+      durationMilliseconds: Date.now() - startedAtMilliseconds,
+      failureReason: response.status === expectedStatusCode
+        ? undefined
+        : `Expected HTTP ${expectedStatusCode}, received HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      host: target.host,
+      probeUrl: target.probeUrl,
+      reachable: false,
+      statusCode: undefined,
+      durationMilliseconds: Date.now() - startedAtMilliseconds,
+      failureReason: formatErrorSummary(error),
+    };
+  }
+}
+
+function createMetricDatum(
+  config: HeartbeatConfig,
+  probe: HeartbeatProbeResult,
+  timestamp: Date,
+): MetricDatum {
+  return {
+    MetricName: config.metricName,
+    Dimensions: [{
+      Name: config.metricHostDimensionName,
+      Value: probe.host,
+    }],
+    Timestamp: timestamp,
+    Value: probe.reachable ? reachableMetricValue : unreachableMetricValue,
+  };
+}
+
+async function publishReachabilityMetrics(
+  config: HeartbeatConfig,
+  probes: ReadonlyArray<HeartbeatProbeResult>,
+): Promise<void> {
+  const timestamp = new Date();
+
+  try {
+    await cloudWatchClient.send(new PutMetricDataCommand({
+      Namespace: config.metricNamespace,
+      MetricData: probes.map((probe) => createMetricDatum(config, probe, timestamp)),
+    }));
+  } catch (error) {
+    throw new Error(
+      `Failed to publish CloudWatch metric ${config.metricNamespace}/${config.metricName} ` +
+      `for hosts ${probes.map((probe) => probe.host).join(", ")}: ${formatErrorSummary(error)}`,
+    );
+  }
+}
+
+export async function handler(): Promise<PublicEndpointHeartbeatResult> {
+  const config = loadHeartbeatConfig();
+  const probes = await Promise.all(
+    config.targets.map((target) => probeTarget(target, config.requestTimeoutMilliseconds)),
+  );
+
+  await publishReachabilityMetrics(config, probes);
+
+  console.log(JSON.stringify({
+    domain: "infra",
+    action: "public_endpoint_heartbeat_checked",
+    metricNamespace: config.metricNamespace,
+    metricName: config.metricName,
+    metricHostDimensionName: config.metricHostDimensionName,
+    requestTimeoutMilliseconds: config.requestTimeoutMilliseconds,
+    probes,
+  }));
+
+  return { ok: true, probes };
+}

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -16,11 +16,20 @@ import {
   globalMetricsSnapshotFreshnessMetricNamespace,
   globalMetricsSnapshotFreshnessMetricStackDimensionName,
 } from "./scheduled-jobs/global-metrics";
+import {
+  createPublicEndpointHeartbeatTargets,
+  publicEndpointHeartbeatIntervalMinutes,
+  publicEndpointHeartbeatMetricHostDimensionName,
+  publicEndpointHeartbeatMetricName,
+  publicEndpointHeartbeatMetricNamespace,
+} from "./scheduled-jobs/public-endpoint-heartbeat";
 import { communityLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfillScheduleHours } from "./scheduled-jobs/progress-active-days-backfill";
 
 const restApiNoTrafficEvaluationPeriods = 4;
+const publicEndpointHeartbeatEvaluationPeriods = 3;
+const publicEndpointHeartbeatDatapointsToAlarm = 2;
 const certificateExpiryAlarmThresholdDays = 45;
 const communityLeaderboardSnapshotStaleEvaluationPeriods = 2;
 const streakLeaderboardSnapshotStaleEvaluationPeriods = 2;
@@ -255,6 +264,34 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
       certificateArn: props.mcpCertificateArn,
       host: `mcp.${props.baseDomain}`,
     });
+  }
+
+  // The heartbeat publishes one datapoint per host every five minutes from outside AWS, so this
+  // is the only alarm that can see a host that stopped serving entirely: a broken Cloudflare
+  // CNAME, a detached API Gateway custom domain or a TLS failure produces no requests at all,
+  // which every request-driven alarm reads as silence. Two breaching datapoints out of three
+  // five-minute periods absorb a single transient blip or one skipped run while a genuine outage
+  // pages after two consecutive failures, inside fifteen minutes. Missing data breaches on
+  // purpose, unlike the certificate alarms above: a heartbeat that is not running leaves the
+  // hosts unwatched, and that silence is exactly what this alarm exists to report.
+  for (const target of createPublicEndpointHeartbeatTargets(props.baseDomain)) {
+    new cloudwatch.Alarm(scope, `${target.id}PublicEndpointHeartbeatAlarm`, {
+      metric: new cloudwatch.Metric({
+        namespace: publicEndpointHeartbeatMetricNamespace,
+        metricName: publicEndpointHeartbeatMetricName,
+        dimensionsMap: { [publicEndpointHeartbeatMetricHostDimensionName]: target.host },
+        period: cdk.Duration.minutes(publicEndpointHeartbeatIntervalMinutes),
+        statistic: "Minimum",
+      }),
+      threshold: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: publicEndpointHeartbeatEvaluationPeriods,
+      datapointsToAlarm: publicEndpointHeartbeatDatapointsToAlarm,
+      alarmDescription:
+        `Public host ${target.host} did not answer ${target.probeUrl} with HTTP 200 for two ` +
+        "external heartbeat probes, or the heartbeat itself stopped reporting",
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
   }
 
   const authApiAccessLog5xxMetricFilter = new logs.MetricFilter(scope, "AuthApiAccessLog5xxMetricFilter", {

--- a/infra/aws/lib/scheduled-jobs/public-endpoint-heartbeat.ts
+++ b/infra/aws/lib/scheduled-jobs/public-endpoint-heartbeat.ts
@@ -1,0 +1,112 @@
+import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as scheduler from "aws-cdk-lib/aws-scheduler";
+import { Construct } from "constructs";
+import * as path from "path";
+import { infraAwsNodejsProjectPaths } from "../nodejs-project-paths";
+
+export interface PublicEndpointHeartbeatProps {
+  baseDomain: string;
+}
+
+export interface PublicEndpointHeartbeatResult {
+  heartbeatFunction: lambdaNodejs.NodejsFunction;
+}
+
+export interface PublicEndpointHeartbeatTarget {
+  // Construct-id fragment shared by this host's schedule-side and alarm-side constructs.
+  readonly id: string;
+  readonly host: string;
+  readonly probeUrl: string;
+}
+
+export const publicEndpointHeartbeatMetricNamespace = "FlashcardsOpenSourceApp/PublicEndpointHeartbeat";
+export const publicEndpointHeartbeatMetricName = "PublicEndpointReachable";
+export const publicEndpointHeartbeatMetricHostDimensionName = "Host";
+export const publicEndpointHeartbeatIntervalMinutes = 5;
+// Sized for the slowest target rather than the fastest: `https://api.<domain>/v1/health` runs a
+// real query against RDS from a VPC-attached Lambda, so a cold start there loads a Secrets
+// Manager secret and opens a TLS Postgres connection before answering, which a tighter bound
+// would score as unreachable. The probes run concurrently, so the whole invocation still costs
+// about this timeout plus the CloudWatch publish, far inside the 30 second function timeout and
+// the five minute cadence.
+export const publicEndpointHeartbeatRequestTimeoutSeconds = 10;
+
+const publicEndpointHeartbeatScheduleExpression = `rate(${publicEndpointHeartbeatIntervalMinutes} minutes)`;
+
+const heartbeatBundling: lambdaNodejs.BundlingOptions = {
+  minify: true,
+  sourceMap: true,
+};
+
+// Each probe URL is the unauthenticated GET the post-deploy checks already treat as proof that
+// the host is serving: `scripts/checks/check-public-endpoints.sh` for the api and auth hosts,
+// and `scripts/checks/check-mcp-smoke.sh` for the mcp host. All three answer HTTP 200.
+export function createPublicEndpointHeartbeatTargets(
+  baseDomain: string,
+): ReadonlyArray<PublicEndpointHeartbeatTarget> {
+  return [
+    { id: "Api", host: `api.${baseDomain}`, probeUrl: `https://api.${baseDomain}/v1/health` },
+    { id: "Auth", host: `auth.${baseDomain}`, probeUrl: `https://auth.${baseDomain}/health` },
+    { id: "Mcp", host: `mcp.${baseDomain}`, probeUrl: `https://mcp.${baseDomain}/health` },
+  ];
+}
+
+// Deliberately outside the VPC: the probes have to leave through the public internet and reach
+// the same Cloudflare CNAME, TLS certificate and API Gateway custom domain a real client uses,
+// and the private subnets have no NAT path.
+export function publicEndpointHeartbeat(
+  scope: Construct,
+  props: PublicEndpointHeartbeatProps,
+): PublicEndpointHeartbeatResult {
+  const targets = createPublicEndpointHeartbeatTargets(props.baseDomain);
+
+  const heartbeatFunction = new lambdaNodejs.NodejsFunction(scope, "PublicEndpointHeartbeatHandler", {
+    entry: path.join(__dirname, "../../lambda/public-endpoint-heartbeat/index.ts"),
+    handler: "handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+    timeout: cdk.Duration.seconds(30),
+    memorySize: 256,
+    bundling: heartbeatBundling,
+    environment: {
+      PUBLIC_ENDPOINT_HEARTBEAT_TARGETS: JSON.stringify(
+        targets.map((target) => ({ host: target.host, probeUrl: target.probeUrl })),
+      ),
+      PUBLIC_ENDPOINT_HEARTBEAT_METRIC_NAMESPACE: publicEndpointHeartbeatMetricNamespace,
+      PUBLIC_ENDPOINT_HEARTBEAT_METRIC_NAME: publicEndpointHeartbeatMetricName,
+      PUBLIC_ENDPOINT_HEARTBEAT_METRIC_HOST_DIMENSION_NAME: publicEndpointHeartbeatMetricHostDimensionName,
+      PUBLIC_ENDPOINT_HEARTBEAT_REQUEST_TIMEOUT_SECONDS: publicEndpointHeartbeatRequestTimeoutSeconds.toString(),
+    },
+    ...infraAwsNodejsProjectPaths,
+  });
+
+  heartbeatFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["cloudwatch:PutMetricData"],
+    resources: ["*"],
+  }));
+
+  const heartbeatInvokeRole = new iam.Role(scope, "PublicEndpointHeartbeatSchedulerRole", {
+    assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
+  });
+  heartbeatInvokeRole.addToPolicy(new iam.PolicyStatement({
+    actions: ["lambda:InvokeFunction"],
+    resources: [heartbeatFunction.functionArn],
+  }));
+
+  new scheduler.CfnSchedule(scope, "PublicEndpointHeartbeatSchedule", {
+    description: `Probe the public api, auth and mcp hosts every ${publicEndpointHeartbeatIntervalMinutes} minutes`,
+    flexibleTimeWindow: { mode: "OFF" },
+    scheduleExpression: publicEndpointHeartbeatScheduleExpression,
+    scheduleExpressionTimezone: "UTC",
+    state: "ENABLED",
+    target: {
+      arn: heartbeatFunction.functionArn,
+      input: "{}",
+      roleArn: heartbeatInvokeRole.roleArn,
+    },
+  });
+
+  return { heartbeatFunction };
+}

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -23,6 +23,7 @@ import { globalMetrics } from "./scheduled-jobs/global-metrics";
 import { communityLeaderboard } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboard } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfill } from "./scheduled-jobs/progress-active-days-backfill";
+import { publicEndpointHeartbeat } from "./scheduled-jobs/public-endpoint-heartbeat";
 import {
   generatedMediaPromotion,
   type GeneratedMediaPromotionScheduleState,
@@ -244,6 +245,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       reportingDbSecret: dbResult.reportingDbSecret,
       ...sentryContext,
     });
+    publicEndpointHeartbeat(this, { baseDomain });
     const mediaAssetsResult = mediaAssets(this, {
       baseDomain,
     });


### PR DESCRIPTION
## Problem

Every alarm in the stack measures a failure rate, so it needs requests to arrive before it can observe anything. A broken Cloudflare CNAME, a detached API Gateway custom domain or a TLS fault leaves a host unreachable while its metrics simply go quiet. `ApiGatewayNoTrafficAlarm` covers that for `api.` only, and it works there because open clients keep a traffic floor — `auth.` and `mcp.` have no such floor, so no traffic-based alarm can cover them at all. The ACM alarms merged earlier catch an expiring certificate, not a broken path to it.

## Change

A small scheduled function probes all three hosts every 5 minutes and publishes `PublicEndpointReachable` (1 or 0) per host under `FlashcardsOpenSourceApp/PublicEndpointHeartbeat`, with one alarm per host on the existing alert topic.

- **Probe targets** are the health routes the post-deploy gates already assert as 200: `api.<domain>/v1/health` and `auth.<domain>/health` from `check-public-endpoints.sh`, `mcp.<domain>/health` from `check-mcp-smoke.sh`. `redirect: "manual"` matches those checks' redirect-less `curl`.
- **Isolation**: probes run concurrently and each catches its own DNS, TLS, connect and timeout failure, so one dead host cannot suppress the other two, and the invocation succeeds either way — the metric carries the signal, not the invocation outcome.
- **Alarms**: `Minimum < 1`, period 5 min, `evaluationPeriods` 3 with `datapointsToAlarm` 2, so a single blip or one skipped run stays quiet while a real outage pages within roughly ten minutes.
- **`treatMissingData: BREACHING`**, deliberately opposite to the certificate alarms: this heartbeat is the only external observer of these hosts, so its silence is itself the failure worth paging on.
- Not attached to the VPC (it needs public egress), IAM limited to `cloudwatch:PutMetricData`, and runtime, bundling, memory and timeout copied from the existing freshness-checker function.

## Expected on deploy

The release that creates these alarms will send three one-time ALARM notifications within ~5–10 minutes, self-clearing once two real datapoints land. That is the correct consequence of the missing-data treatment on a metric that has never been published, and matches the existing BREACHING alarms in this file.

Deferred follow-ups: a `metricErrors` alarm on the heartbeat function, and gating the heartbeat on the certificate ARNs so a deploy of this open-source stack without certificates does not get three permanently breaching alarms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)