### PR TITLE
Anonymize product analytics rows when an account is deleted

### DIFF
--- a/apps/backend/src/auth/accountDeletion.test.ts
+++ b/apps/backend/src/auth/accountDeletion.test.ts
@@ -96,6 +96,9 @@ test("deleteAccountForAuthenticatedUser locks shared workspace membership lifecy
         text === "DELETE FROM org.workspaces WHERE workspace_id = ANY($1::uuid[])"
         || text === "SELECT auth.delete_user_auth_artifacts($1, $2)"
         || text === "DELETE FROM org.user_settings WHERE user_id = $1"
+        || text.includes("FROM auth.guest_upgrade_history")
+        || text.includes("UPDATE analytics.product_events")
+        || text.includes("DELETE FROM analytics.identity_links")
       ) {
         return createQueryResult<Row>([]);
       }
@@ -178,6 +181,9 @@ test("deleteAccountForAuthenticatedUser rereads the mapping under the identity l
         || text === "SELECT auth.delete_user_auth_artifacts($1, $2)"
         || text === "DELETE FROM org.user_settings WHERE user_id = $1"
         || text.includes("INSERT INTO auth.deleted_subjects")
+        || text.includes("FROM auth.guest_upgrade_history")
+        || text.includes("UPDATE analytics.product_events")
+        || text.includes("DELETE FROM analytics.identity_links")
       ) {
         return createQueryResult<Row>([]);
       }

--- a/apps/backend/src/auth/accountDeletion.ts
+++ b/apps/backend/src/auth/accountDeletion.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { deleteCognitoUser } from "./cognitoUsers";
 import {
   applyUserDatabaseScopeInExecutor,
@@ -47,6 +48,10 @@ type UserSettingsEmailRow = Readonly<{
   email: string | null;
 }>;
 
+type AnalyticsPersonUserIdRow = Readonly<{
+  user_id: string;
+}>;
+
 const defaultAccountDeletionDependencies: AccountDeletionDependencies = {
   unsafeTransaction,
   deleteCognitoUser,
@@ -73,6 +78,126 @@ function assertCognitoUsername(cognitoUsername: string | null): string {
   }
 
   return cognitoUsername;
+}
+
+/**
+ * Resolves every user id this person's analytics rows were written under.
+ *
+ * A destructive guest upgrade binds the person onto an account id that is
+ * permanently different from the guest user id they browsed under, and the
+ * events from that guest phase keep the guest id in both identity columns
+ * forever. `auth.guest_upgrade_history` is the append-only record of those
+ * merges and account deletion cannot remove it, so a reporting reader could
+ * join those surviving rows straight back to the deleted account unless the
+ * guest ids are anonymized together with the account id.
+ *
+ * The walk is recursive because merges chain. A guest session survives the
+ * non-destructive upgrade that binds its guest id onto an account id, so that
+ * same id can later be merged into a different account as a source, and the
+ * history then reaches an older guest id only through the middle one. A
+ * single-level lookup would stop at the middle id and leave the older one
+ * carrying its real value, and anonymization runs once, so a missed ancestor
+ * stays identified forever. `visited_user_ids` keeps the walk from revisiting
+ * an id, so a cycle in the history terminates instead of looping.
+ *
+ * The history columns are `TEXT` while the analytics identity columns are
+ * `UUID`, so the lookup compares as text here and the result is cast back to
+ * `uuid` by the callers.
+ */
+async function loadAnalyticsUserIdsForPersonInExecutor(
+  executor: DatabaseExecutor,
+  appUserId: string,
+): Promise<Array<string>> {
+  const result = await executor.query<AnalyticsPersonUserIdRow>(
+    [
+      "WITH RECURSIVE person_user_ids AS (",
+      "SELECT $1::text AS user_id, ARRAY[$1::text] AS visited_user_ids",
+      "UNION ALL",
+      "SELECT history.source_guest_user_id,",
+      "person_user_ids.visited_user_ids || history.source_guest_user_id",
+      "FROM auth.guest_upgrade_history AS history",
+      "JOIN person_user_ids ON history.target_user_id = person_user_ids.user_id",
+      "WHERE NOT history.source_guest_user_id = ANY(person_user_ids.visited_user_ids)",
+      ")",
+      "SELECT DISTINCT user_id FROM person_user_ids",
+    ].join(" "),
+    [appUserId],
+  );
+  const userIds = new Set<string>([appUserId]);
+
+  for (const row of result.rows) {
+    userIds.add(row.user_id);
+  }
+
+  return [...userIds];
+}
+
+/**
+ * Anonymizes the analytics history of one account instead of erasing it.
+ *
+ * The replacement pseudonym is generated here and stored nowhere, the links that
+ * could resolve it back to the person are removed in the same transaction, and
+ * every remaining column that a table outliving account deletion could join on
+ * is cleared, the identity, session and workspace columns alike. So this is
+ * one-way: no mapping survives anywhere and it cannot be undone.
+ *
+ * One pseudonym covers every id the person ever produced events under, guest
+ * phase included, so their whole history collapses to a single unlinkable
+ * identity rather than to several that stay separable from each other.
+ */
+async function anonymizeProductAnalyticsInExecutor(
+  executor: DatabaseExecutor,
+  appUserId: string,
+): Promise<void> {
+  const anonymizedUserId = randomUUID();
+  const personUserIds = await loadAnalyticsUserIdsForPersonInExecutor(executor, appUserId);
+
+  // One shared pseudonym per person keeps retention and cohort arithmetic working, because the
+  // rows still describe one distinct person. country, event_properties and experiment_assignments
+  // stay: they name a place, and catalog-allowlisted enum, numeric and fixed-format values, never
+  // free text.
+  //
+  // workspace_id is cleared even though it names a resource rather than a person.
+  // auth.guest_upgrade_history survives account deletion, carries source_guest_workspace_id and
+  // target_workspace_id next to the user ids, and is readable by reporting_readonly, so a retained
+  // workspace_id joins right back to the deleted person's real user id through the very table the
+  // widened id set above exists to defeat. Clearing it for every anonymized row, rather than only
+  // for the workspaces that appear in that history, is deliberate: anonymization runs once and can
+  // never be reapplied, so a predicate narrowed to today's surviving tables would rot silently the
+  // first time another one joined a workspace to a user. The cost is the departed person's share of
+  // workspace-level aggregates.
+  //
+  // Matching user_id alone is enough, and it keeps the predicate to one column so a single-column
+  // index can serve it. Every producer in auth/index.ts writes subject_user_id either equal to
+  // user_id (the none, api_key and guest transports) or as the Cognito subject of an account whose
+  // app user id is already in this set (the bearer and session transports), so no row can name this
+  // person in subject_user_id without also naming them in user_id. subject_user_id is still
+  // rewritten below, because the Cognito subject it carries identifies the person just as directly.
+  await executor.query(
+    [
+      "UPDATE analytics.product_events SET",
+      "user_id = $1::uuid,",
+      "subject_user_id = $1::uuid,",
+      "anonymous_id = NULL,",
+      "session_id = NULL,",
+      "guest_session_id = NULL,",
+      "workspace_id = NULL,",
+      "request_id = NULL,",
+      "device_model = NULL,",
+      "os_version = NULL,",
+      "timezone = NULL,",
+      "device_locale = NULL,",
+      "identity_state = 'anonymized'",
+      "WHERE user_id = ANY($2::uuid[])",
+    ].join(" "),
+    [anonymizedUserId, personUserIds],
+  );
+  // Keyed by the real ids, which are still the parameter here: a surviving link resolves an
+  // anonymous_id back to this person and would make the rewrite above reversible.
+  await executor.query(
+    "DELETE FROM analytics.identity_links WHERE user_id = ANY($1::uuid[])",
+    [personUserIds],
+  );
 }
 
 async function deleteAccountDataInExecutor(
@@ -136,6 +261,7 @@ async function deleteAccountDataInExecutor(
     [appUserId, email],
   );
   await executor.query("DELETE FROM org.user_settings WHERE user_id = $1", [appUserId]);
+  await anonymizeProductAnalyticsInExecutor(executor, appUserId);
 }
 
 /**


### PR DESCRIPTION
Account deletion now replaces the person's identity in `analytics.product_events` instead of leaving those rows intact, and removes their `analytics.identity_links` rows so the anonymization cannot be reversed through them.

## Why the id set is wider than the account id

A person's events are not all written under their account id. Guest-transport requests write the guest user id into both identity columns, and a guest who upgrades through the merge path keeps a permanently different id. `auth.guest_upgrade_history` maps those ids to the account durably — `backend_app` holds no DELETE grant on it, so deletion cannot remove the mapping, and `reporting_readonly` can read both sides. Anonymizing only the account id would therefore leave the entire guest phase fully identified and joinable straight back to the deleted person.

The walk is recursive rather than single-level because a guest session survives the bound upgrade path, so a guest id can itself later be a merge source into a different account. A missed ancestor stays identified forever, since anonymization runs once.

One random UUID covers the whole id set, so the guest and account phases collapse to a single unlinkable identity rather than several. That keeps "these events came from one distinct person" true for retention and cohort maths while being unlinkable.

## Why `workspace_id` is cleared

It was originally kept, on the reasoning that a workspace names a resource rather than a person. That was wrong: the same surviving history table carries `source_guest_workspace_id` and `target_workspace_id` beside the user ids, so a retained workspace id is simply another join back to the deleted person. It is cleared unconditionally rather than only for workspaces present in that history — anonymization is one-shot, so a predicate tuned to today's surviving tables would rot silently the first time another table joined a workspace to a user.

`0114` documents this column as surviving anonymization. That file is immutable, so the corrected comment ships in the migration that accompanies this work.

## What survives, and why that is sound

`event_properties` and `experiment_assignments` are kept in full. That is only defensible because the event catalog binds every value to an enum member, a non-negative integer, or a fixed string format, so neither column can hold free text. `country` is kept because a country does not identify a person.

## Known residual

The predicate is `user_id = ANY(...)`, which an index on `analytics.product_events (user_id)` serves. That index does not exist in `0114` and arrives in the migration shipping alongside this change. Until then the statement scans, which is free while the table is empty — no producer has shipped yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)