### PR TITLE
Drop deprecated system-bar color attributes from the app theme

### DIFF
--- a/apps/android/app/src/main/res/values/themes.xml
+++ b/apps/android/app/src/main/res/values/themes.xml
@@ -7,8 +7,6 @@
 
     <style name="Theme.FlashcardsOpenSourceApp" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:windowBackground">@color/launch_background</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
     </style>


### PR DESCRIPTION
Clears the Google Play Console recommended action `Edge-to-edge may not display for all users` (Android vitals → Overview, category *User experience*), reported against release `main-draft-vc20348062-r32726019636a1-s6e265ed4`.

`android:statusBarColor` and `android:navigationBarColor` are no-ops from API 35 onward, and their presence is the usual trigger for that Play warning. The app already calls `enableEdgeToEdge()` in `MainActivity`.

Kept on purpose:

- `android:windowLightStatusBar` / `android:windowLightNavigationBar` — these still control system-bar icon contrast.
- `android:windowBackground`, the `Theme.FlashcardsOpenSourceApp.Starting` splash style, and the `@android:style/Theme.DeviceDefault.NoActionBar` parent.

## Accepted behavior change

`minSdk` is 34, so on Android 14 these two attributes are still honored today. After this change Android 14 falls back to the parent theme's system-bar colors instead of transparent. That was reviewed and accepted rather than maintaining a behavior split between Android 14 and 15+.

## Scope

Part of the Google Play app-optimization queue. R8 enablement, `testBuildType`, CI rewiring, and baseline/startup profiles are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)