### PR TITLE
Identify AI-chat error types by type instead of by class-name string

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/CloudJsonContract.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/CloudJsonContract.kt
@@ -4,7 +4,8 @@ import com.flashcardsopensourceapp.data.local.model.cloud.parseIsoTimestamp
 import org.json.JSONArray
 import org.json.JSONObject
 
-internal class CloudContractMismatchException(
+/** Public so consumer modules can identify this failure by type instead of by class name. */
+class CloudContractMismatchException(
     message: String,
     cause: Throwable? = null
 ) : IllegalStateException(message, cause)

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapFailureState.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapFailureState.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap
 
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatPersistedState
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiChatRuntimeState
@@ -73,6 +74,5 @@ internal fun freshSessionDraftToPreserveOnBootstrapFailure(
 }
 
 private fun isConversationPreservableBootstrapFailure(error: Exception): Boolean {
-    return error is AiChatBootstrapSessionMismatchException ||
-        error::class.java.name == "com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException"
+    return error is AiChatBootstrapSessionMismatchException || error is CloudContractMismatchException
 }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiViewModelDiagnosticsSupport.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiViewModelDiagnosticsSupport.kt
@@ -4,21 +4,18 @@ import com.flashcardsopensourceapp.core.observability.alreadyObservedAndroidThro
 import com.flashcardsopensourceapp.core.observability.shouldCaptureAndroidThrowable
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.ai.remote.isExpectedAiChatRemoteUserError
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
 import com.flashcardsopensourceapp.feature.ai.AiBootstrapErrorPresentation
 import com.flashcardsopensourceapp.feature.ai.runtime.errors.AiAlertState
 import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.AiChatBootstrapBlockedException
+import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.AiChatBootstrapSessionMismatchException
 import com.flashcardsopensourceapp.feature.ai.runtime.errors.AiErrorSurface
 import com.flashcardsopensourceapp.feature.ai.runtime.errors.AiUserFacingErrorPresentation
 import com.flashcardsopensourceapp.feature.ai.runtime.errors.aiChatAvailabilityMessage
 import com.flashcardsopensourceapp.feature.ai.runtime.errors.makeAiChatUserFacingErrorPresentation
 import com.flashcardsopensourceapp.feature.ai.strings.AiTextProvider
 import java.io.IOException
-
-private const val cloudContractMismatchExceptionName: String =
-    "com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException"
-private const val aiChatBootstrapSessionMismatchExceptionName: String =
-    "com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.AiChatBootstrapSessionMismatchException"
 
 internal fun makeAiUserFacingErrorPresentation(
     error: Exception,
@@ -166,12 +163,11 @@ private fun shouldIncludeLocalErrorMessage(error: Exception): Boolean {
     if (message.isNullOrBlank()) {
         return false
     }
-    if (error::class.java.name == cloudContractMismatchExceptionName) {
+    if (error is CloudContractMismatchException) {
         return false
     }
 
-    return error is IOException ||
-        error::class.java.name == aiChatBootstrapSessionMismatchExceptionName
+    return error is IOException || error is AiChatBootstrapSessionMismatchException
 }
 
 private fun formatTechnicalDetails(fields: List<Pair<String, String?>>): String {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiBootstrapErrorPresentationTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiBootstrapErrorPresentationTest.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.cloud.makeOfficialCloudServiceConfiguration
 import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.AiChatBootstrapBlockedException
 import com.flashcardsopensourceapp.feature.ai.runtime.errors.AiErrorSurface
@@ -201,7 +202,7 @@ class AiBootstrapErrorPresentationTest {
         assertEquals("AI chat could not be loaded. Try again.", presentation.message)
         assertTrue(
             presentation.technicalDetails.orEmpty().contains(
-                "type: com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException"
+                "type: ${CloudContractMismatchException::class.java.name}"
             )
         )
         assertFalse(presentation.technicalDetails.orEmpty().contains("message:"))
@@ -235,14 +236,5 @@ class AiBootstrapErrorPresentationTest {
             AiChatFailureIssueDisposition.NONE,
             aiChatFailureIssueDisposition(error = error)
         )
-    }
-
-    private fun makeCloudContractMismatchException(message: String): Exception {
-        val errorClass = Class.forName(
-            "com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException"
-        )
-        val constructor = errorClass.getDeclaredConstructor(String::class.java, Throwable::class.java)
-        constructor.isAccessible = true
-        return constructor.newInstance(message, null) as Exception
     }
 }

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapTestSupport.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapTestSupport.kt
@@ -1,14 +1,10 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 
-internal fun makeCloudContractMismatchException(message: String): Exception {
-    val errorClass = Class.forName(
-        "com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException"
-    )
-    val constructor = errorClass.getDeclaredConstructor(String::class.java, Throwable::class.java)
-    constructor.isAccessible = true
-    return constructor.newInstance(message, null) as Exception
+internal fun makeCloudContractMismatchException(message: String): CloudContractMismatchException {
+    return CloudContractMismatchException(message = message, cause = null)
 }
 
 internal fun makeCloudRemoteException(statusCode: Int): CloudRemoteException {


### PR DESCRIPTION
Prerequisite for enabling R8 on the Android release build.

Three sites compared `error::class.java.name` against a hardcoded fully qualified class name:

- `AiChatBootstrapFailureState.isConversationPreservableBootstrapFailure`
- both checks in `AiViewModelDiagnosticsSupport.shouldIncludeLocalErrorMessage`

A real local `:app:bundleRelease` with R8 enabled confirmed the problem is not hypothetical: R8 renames `CloudContractMismatchException` to `gh0` and `AiChatBootstrapSessionMismatchException` to `j7`, while the FQN string literals remain unchanged in the DEX. Every one of these comparisons would therefore become permanently `false` once obfuscation is on — no crash, just silently wrong AI-chat error handling (lost conversation preservation on contract mismatch, and wrong error-message filtering).

## Cross-module visibility

`CloudContractMismatchException` was `internal` to `data:local`, which is exactly why the string comparison existed. It is now public, matching `AiChatRemoteException`, `CloudRemoteException`, `CloudHealthValidationException`, and `SyncBlockedException`, which already cross that boundary. The rest of the `cloud.wire` package (`strictRemoteJson`, `buildRemoteContractMismatch`, the `requireCloud*` helpers) stays `internal`.

An R8 `-keep` rule pinning the class name was rejected: it would re-create the name coupling this change removes.

## Tests

No new tests. Two existing test files were adapted: the shared helper now constructs the exception directly instead of via `Class.forName`, and the FQN assertion became `CloudContractMismatchException::class.java.name`.

## Scope

Part of the Google Play app-optimization queue. R8 enablement, `testBuildType`, CI rewiring, and baseline/startup profiles are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)