### PR TITLE
Render Android review inline math inline

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
@@ -29,9 +29,22 @@ sealed interface ReviewRenderedContent {
     ) : ReviewRenderedContent
 }
 
+/**
+ * An accepted `$…$` span that renders on the surrounding text baseline.
+ *
+ * The span stands in its block Markdown as one marker character, and formulas are ordered by the
+ * marker they replace. [tag] is the Compose inline-content tag the rendered formula is resolved by.
+ */
+data class ReviewInlineMathFormula(
+    val tag: String,
+    val source: String,
+    val delimitedSource: String
+)
+
 sealed interface ReviewManagedMarkdownBlock {
     data class Markdown(
-        val markdown: String
+        val markdown: String,
+        val inlineFormulas: List<ReviewInlineMathFormula>
     ) : ReviewManagedMarkdownBlock
 
     data class ManagedMedia(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
@@ -65,9 +65,15 @@ internal fun prepareReviewContent(
     text: String,
     mediaAssetsById: Map<String, MediaAsset>
 ): PreparedReviewContent {
-    val mathExtraction: ReviewMathBlockExtraction = extractReviewMathBlocks(markdown = text)
+    // An accepted inline formula stands in as one marker character, so a marker the card text
+    // already holds would consume a formula slot. Removing it once, before segmentation, keeps
+    // every offset that segmentation, rendering and speech derive from this text consistent.
+    val sanitizedText: String = removeReviewInlineMathMarkers(text = text)
+    val mathExtraction: ReviewMathBlockExtraction = extractReviewMathBlocks(
+        markdown = sanitizedText
+    )
     val renderedContent: ReviewRenderedContent = makeReviewRenderedContent(
-        text = text,
+        text = sanitizedText,
         mediaAssetsById = mediaAssetsById,
         mathBlocks = mathExtraction.blocks,
         requiresMarkdownRendering = mathExtraction.requiresMarkdownRendering
@@ -93,6 +99,7 @@ private fun makeReviewRenderedContent(
 
     val managedMarkdown: ReviewRenderedContent.ManagedMarkdown? = makeReviewManagedMarkdownContent(
         text = text,
+        inlineFormulas = emptyList(),
         mediaAssetsById = mediaAssetsById
     )
     if (managedMarkdown != null) {
@@ -117,18 +124,43 @@ private fun makeReviewMathMarkdownContent(
     mathBlocks: List<ReviewMathBlock>,
     mediaAssetsById: Map<String, MediaAsset>
 ): ReviewRenderedContent.ManagedMarkdown {
-    val renderedBlocks: List<ReviewManagedMarkdownBlock> = buildList {
-        mathBlocks.forEach { block ->
-            when (block) {
-                is ReviewMathBlock.Markdown -> addAll(
-                    reviewManagedMarkdownBlocks(
-                        text = block.markdown,
-                        mediaAssetsById = mediaAssetsById
+    val renderedBlocks: MutableList<ReviewManagedMarkdownBlock> = mutableListOf()
+    val pendingMarkdown: StringBuilder = StringBuilder()
+    val pendingFormulas: MutableList<ReviewInlineMathFormula> = mutableListOf()
+    var inlineFormulaIndex: Int = 0
+
+    fun flushPendingMarkdown() {
+        renderedBlocks.addAll(
+            elements = reviewManagedMarkdownBlocks(
+                text = pendingMarkdown.toString(),
+                inlineFormulas = pendingFormulas.toList(),
+                mediaAssetsById = mediaAssetsById
+            )
+        )
+        pendingMarkdown.clear()
+        pendingFormulas.clear()
+    }
+
+    mathBlocks.forEach { block ->
+        when (block) {
+            is ReviewMathBlock.Markdown -> pendingMarkdown.append(block.markdown)
+
+            // An accepted inline span stays inside its paragraph, standing in as one marker
+            // character; only display math is its own top-level block.
+            is ReviewMathBlock.Formula -> if (block.continuesParagraph) {
+                pendingFormulas.add(
+                    element = ReviewInlineMathFormula(
+                        tag = reviewInlineMathTag(index = inlineFormulaIndex),
+                        source = block.source,
+                        delimitedSource = block.delimitedSource
                     )
                 )
-
-                is ReviewMathBlock.Formula -> add(
-                    ReviewManagedMarkdownBlock.Formula(
+                inlineFormulaIndex += 1
+                pendingMarkdown.append(reviewInlineMathMarker)
+            } else {
+                flushPendingMarkdown()
+                renderedBlocks.add(
+                    element = ReviewManagedMarkdownBlock.Formula(
                         source = block.source,
                         delimitedSource = block.delimitedSource
                     )
@@ -136,15 +168,19 @@ private fun makeReviewMathMarkdownContent(
             }
         }
     }
-    return ReviewRenderedContent.ManagedMarkdown(blocks = renderedBlocks)
+    flushPendingMarkdown()
+
+    return ReviewRenderedContent.ManagedMarkdown(blocks = renderedBlocks.toList())
 }
 
 private fun reviewManagedMarkdownBlocks(
     text: String,
+    inlineFormulas: List<ReviewInlineMathFormula>,
     mediaAssetsById: Map<String, MediaAsset>
 ): List<ReviewManagedMarkdownBlock> {
     val managedContent: ReviewRenderedContent.ManagedMarkdown? = makeReviewManagedMarkdownContent(
         text = text,
+        inlineFormulas = inlineFormulas,
         mediaAssetsById = mediaAssetsById
     )
     if (managedContent != null) {
@@ -153,7 +189,12 @@ private fun reviewManagedMarkdownBlocks(
     return if (text.isBlank()) {
         emptyList()
     } else {
-        listOf(ReviewManagedMarkdownBlock.Markdown(markdown = text))
+        listOf(
+            ReviewManagedMarkdownBlock.Markdown(
+                markdown = text,
+                inlineFormulas = inlineFormulas
+            )
+        )
     }
 }
 
@@ -203,6 +244,7 @@ internal fun parseReviewManagedMediaAssetId(reference: String): String? {
 
 private fun makeReviewManagedMarkdownContent(
     text: String,
+    inlineFormulas: List<ReviewInlineMathFormula>,
     mediaAssetsById: Map<String, MediaAsset>
 ): ReviewRenderedContent.ManagedMarkdown? {
     val matches: List<ReviewManagedMediaMatch> = findReviewManagedMediaMatches(
@@ -214,22 +256,41 @@ private fun makeReviewManagedMarkdownContent(
     }
 
     var currentIndex: Int = 0
+    var formulaIndex: Int = 0
     val blocks: List<ReviewManagedMarkdownBlock> = buildList {
         matches.forEach { match ->
             val precedingMarkdown: String = text.substring(
                 startIndex = currentIndex,
                 endIndex = match.range.first
             )
+            val precedingFormulaCount: Int = countReviewInlineMathMarkers(text = precedingMarkdown)
             if (precedingMarkdown.isNotBlank()) {
-                add(ReviewManagedMarkdownBlock.Markdown(markdown = precedingMarkdown))
+                add(
+                    ReviewManagedMarkdownBlock.Markdown(
+                        markdown = precedingMarkdown,
+                        inlineFormulas = inlineFormulas.subList(
+                            fromIndex = formulaIndex,
+                            toIndex = formulaIndex + precedingFormulaCount
+                        )
+                    )
+                )
             }
+            formulaIndex += precedingFormulaCount
             add(ReviewManagedMarkdownBlock.ManagedMedia(reference = match.reference))
             currentIndex = match.range.last + 1
         }
 
         val trailingMarkdown: String = text.substring(startIndex = currentIndex)
         if (trailingMarkdown.isNotBlank()) {
-            add(ReviewManagedMarkdownBlock.Markdown(markdown = trailingMarkdown))
+            add(
+                ReviewManagedMarkdownBlock.Markdown(
+                    markdown = trailingMarkdown,
+                    inlineFormulas = inlineFormulas.subList(
+                        fromIndex = formulaIndex,
+                        toIndex = inlineFormulas.size
+                    )
+                )
+            )
         }
     }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewInlineMathContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewInlineMathContent.kt
@@ -1,0 +1,252 @@
+package com.flashcardsopensourceapp.feature.review
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.util.Log
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
+import io.ratex.DisplayList
+import io.ratex.RaTeXEngine
+import io.ratex.RaTeXException
+import io.ratex.RaTeXFontLoader
+import io.ratex.RaTeXRenderer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.ceil
+
+/**
+ * One accepted inline formula stands in the block Markdown as this single character, so the
+ * Markdown parser never reinterprets LaTeX and no block syntax can appear at a paragraph start.
+ */
+internal const val reviewInlineMathMarker: Char = '\uFFFC'
+
+private const val reviewInlineMathLogTag: String = "ReviewInlineMath"
+
+internal sealed interface ReviewInlineMathRenderState {
+    data class Rendered(
+        val bitmap: ImageBitmap,
+        val widthPx: Float,
+        val ascentPx: Float,
+        val depthPx: Float
+    ) : ReviewInlineMathRenderState
+
+    data object Failed : ReviewInlineMathRenderState
+}
+
+internal data class ReviewInlineMathContent(
+    val renderStates: Map<String, ReviewInlineMathRenderState>,
+    val inlineContent: Map<String, InlineTextContent>
+)
+
+/**
+ * Rendered formulas together with the exact list they were rendered from.
+ *
+ * Tags are positional, so a map only ever describes its own [formulas]; pairing them lets a map
+ * left over from the previous card be recognized instead of drawing that card's bitmaps.
+ */
+private data class ReviewInlineMathRenderResult(
+    val formulas: List<ReviewInlineMathFormula>,
+    val renderStates: Map<String, ReviewInlineMathRenderState>
+)
+
+internal fun reviewInlineMathTag(index: Int): String {
+    return "review-inline-math-$index"
+}
+
+internal fun countReviewInlineMathMarkers(text: String): Int {
+    return text.count { character -> character == reviewInlineMathMarker }
+}
+
+/**
+ * Drops every [reviewInlineMathMarker] a card already carries, so the markers this pipeline injects
+ * for accepted inline formulas are the only ones the marker counters can ever see.
+ */
+internal fun removeReviewInlineMathMarkers(text: String): String {
+    if (text.indexOf(char = reviewInlineMathMarker) < 0) {
+        return text
+    }
+    return text.filter { character -> character != reviewInlineMathMarker }
+}
+
+@Composable
+internal fun rememberReviewInlineMathContent(
+    formulas: List<ReviewInlineMathFormula>
+): ReviewInlineMathContent {
+    val context: Context = LocalContext.current
+    val density: Density = LocalDensity.current
+    val formulaColor: Int = MaterialTheme.colorScheme.onSurface.toArgb()
+    val formulaFontSize: TextUnit = MaterialTheme.typography.bodyLarge.fontSize
+    val formulaFontSizePx: Float = with(density) { formulaFontSize.toPx() }
+
+    val renderResult: ReviewInlineMathRenderResult by produceState(
+        initialValue = ReviewInlineMathRenderResult(
+            formulas = emptyList(),
+            renderStates = emptyMap()
+        ),
+        key1 = formulas,
+        key2 = formulaColor,
+        key3 = formulaFontSizePx
+    ) {
+        value = ReviewInlineMathRenderResult(
+            formulas = formulas,
+            renderStates = renderReviewInlineMathFormulas(
+                context = context,
+                formulas = formulas,
+                colorArgb = formulaColor,
+                fontSizePx = formulaFontSizePx
+            )
+        )
+    }
+    // The producer coroutine runs after this composition, so the previous card's result can still
+    // be held here; a result that does not describe these formulas reads as "not yet rendered".
+    val renderStates: Map<String, ReviewInlineMathRenderState> = if (
+        renderResult.formulas == formulas
+    ) {
+        renderResult.renderStates
+    } else {
+        emptyMap()
+    }
+
+    val inlineContent: Map<String, InlineTextContent> = remember(
+        formulas,
+        renderStates,
+        density,
+        formulaFontSize
+    ) {
+        formulas.associate { formula ->
+            val renderState: ReviewInlineMathRenderState? = renderStates[formula.tag]
+            formula.tag to InlineTextContent(
+                placeholder = reviewInlineMathPlaceholder(
+                    renderState = renderState,
+                    density = density,
+                    pendingSize = formulaFontSize
+                )
+            ) {
+                if (renderState is ReviewInlineMathRenderState.Rendered) {
+                    ReviewInlineMathFormulaImage(renderState = renderState)
+                }
+            }
+        }
+    }
+
+    return ReviewInlineMathContent(
+        renderStates = renderStates,
+        inlineContent = inlineContent
+    )
+}
+
+/**
+ * The slot sits entirely above the text baseline, so the bitmap moves down by its own depth to put
+ * the formula baseline on the text baseline and hang the descender into the descender band.
+ */
+@Composable
+private fun ReviewInlineMathFormulaImage(renderState: ReviewInlineMathRenderState.Rendered) {
+    Spacer(
+        modifier = Modifier
+            .fillMaxSize()
+            .drawBehind {
+                drawImage(
+                    image = renderState.bitmap,
+                    topLeft = Offset(x = 0f, y = renderState.depthPx)
+                )
+            }
+    )
+}
+
+private fun reviewInlineMathPlaceholder(
+    renderState: ReviewInlineMathRenderState?,
+    density: Density,
+    pendingSize: TextUnit
+): Placeholder {
+    if (renderState !is ReviewInlineMathRenderState.Rendered) {
+        return Placeholder(
+            width = pendingSize,
+            height = pendingSize,
+            placeholderVerticalAlign = PlaceholderVerticalAlign.AboveBaseline
+        )
+    }
+    return Placeholder(
+        width = with(density) { renderState.widthPx.coerceAtLeast(1f).toSp() },
+        height = with(density) {
+            (renderState.ascentPx + renderState.depthPx).coerceAtLeast(1f).toSp()
+        },
+        placeholderVerticalAlign = PlaceholderVerticalAlign.AboveBaseline
+    )
+}
+
+private suspend fun renderReviewInlineMathFormulas(
+    context: Context,
+    formulas: List<ReviewInlineMathFormula>,
+    colorArgb: Int,
+    fontSizePx: Float
+): Map<String, ReviewInlineMathRenderState> {
+    if (formulas.isEmpty()) {
+        return emptyMap()
+    }
+    return withContext(Dispatchers.IO) {
+        RaTeXFontLoader.ensureLoaded(context)
+        formulas.associate { formula ->
+            formula.tag to renderReviewInlineMathFormula(
+                formula = formula,
+                colorArgb = colorArgb,
+                fontSizePx = fontSizePx
+            )
+        }
+    }
+}
+
+private fun renderReviewInlineMathFormula(
+    formula: ReviewInlineMathFormula,
+    colorArgb: Int,
+    fontSizePx: Float
+): ReviewInlineMathRenderState {
+    return try {
+        val displayList: DisplayList = RaTeXEngine.parseBlocking(
+            latex = formula.source,
+            displayMode = false,
+            color = colorArgb
+        )
+        val renderer = RaTeXRenderer(
+            displayList = displayList,
+            fontSize = fontSizePx,
+            typefaceLoader = { fontId -> RaTeXFontLoader.getTypeface(fontId) }
+        )
+        val bitmapWidth: Int = ceil(renderer.widthPx).toInt().coerceAtLeast(minimumValue = 1)
+        val bitmapHeight: Int = ceil(renderer.totalHeightPx).toInt().coerceAtLeast(minimumValue = 1)
+        val bitmap: Bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+        renderer.draw(canvas = Canvas(bitmap))
+        ReviewInlineMathRenderState.Rendered(
+            bitmap = bitmap.asImageBitmap(),
+            widthPx = bitmapWidth.toFloat(),
+            ascentPx = renderer.heightPx,
+            depthPx = renderer.depthPx
+        )
+    } catch (error: RaTeXException) {
+        Log.e(reviewInlineMathLogTag, "RaTeX inline formula rendering failed.", error)
+        ReviewInlineMathRenderState.Failed
+    } catch (error: Throwable) {
+        // The library's own display path reports any other throwable as a render error too, and a
+        // rejected formula has to stay visible with a localized error instead of taking the screen.
+        Log.e(reviewInlineMathLogTag, "Inline formula rendering failed unexpectedly.", error)
+        ReviewInlineMathRenderState.Failed
+    }
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMarkdownText.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMarkdownText.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -15,13 +16,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
@@ -30,11 +36,18 @@ import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.ImageData
 import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.MarkdownAnnotator
+import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownInlineContent
 import com.mikepenz.markdown.model.markdownPadding
+import com.mikepenz.markdown.utils.EntityConverter
+import org.intellij.markdown.flavours.gfm.GFMElementTypes
+import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 
 private val reviewMarkdownLoadingIndicatorSize = 24.dp
 private val reviewMarkdownLoadingMinimumHeight = 48.dp
+private val reviewMathSoftBreakRegex: Regex = Regex(pattern = """[ \t]*(?:\r\n|\r|\n)[ \t]*""")
 
 private object ReviewNetworkImageTransformer : ImageTransformer {
     @Composable
@@ -55,11 +68,30 @@ private object ReviewNetworkImageTransformer : ImageTransformer {
 @Composable
 internal fun ReviewMarkdownText(
     markdown: String,
+    inlineFormulas: List<ReviewInlineMathFormula>,
     modifier: Modifier
 ) {
     val platformUriHandler: UriHandler = LocalUriHandler.current
     val reviewUriHandler: UriHandler = remember(platformUriHandler) {
         makeReviewMarkdownUriHandler(platformUriHandler = platformUriHandler)
+    }
+    val inlineMathContent: ReviewInlineMathContent = rememberReviewInlineMathContent(
+        formulas = inlineFormulas
+    )
+    val mathErrorMessage: String = stringResource(id = R.string.review_math_render_failed)
+    val mathErrorColor: Color = MaterialTheme.colorScheme.error
+    val inlineMathAnnotator: MarkdownAnnotator = remember(
+        inlineFormulas,
+        inlineMathContent.renderStates,
+        mathErrorMessage,
+        mathErrorColor
+    ) {
+        makeReviewInlineMathAnnotator(
+            formulas = inlineFormulas,
+            renderStates = inlineMathContent.renderStates,
+            errorMessage = mathErrorMessage,
+            errorColor = mathErrorColor
+        )
     }
 
     CompositionLocalProvider(LocalUriHandler provides reviewUriHandler) {
@@ -128,6 +160,8 @@ internal fun ReviewMarkdownText(
                     tableCornerSize = 12.dp
                 ),
                 imageTransformer = ReviewNetworkImageTransformer,
+                annotator = inlineMathAnnotator,
+                inlineContent = markdownInlineContent(content = inlineMathContent.inlineContent),
                 loading = { loadingModifier ->
                     Box(
                         contentAlignment = Alignment.Center,
@@ -142,6 +176,111 @@ internal fun ReviewMarkdownText(
                 }
             )
         }
+    }
+}
+
+/**
+ * Replaces every [reviewInlineMathMarker] with its formula, so an accepted `$…$` span stays on the
+ * surrounding text baseline inside its paragraph instead of becoming a block of its own, and writes
+ * every dollar the contract keeps literal back from the source.
+ */
+private fun makeReviewInlineMathAnnotator(
+    formulas: List<ReviewInlineMathFormula>,
+    renderStates: Map<String, ReviewInlineMathRenderState>,
+    errorMessage: String,
+    errorColor: Color
+): MarkdownAnnotator {
+    return markdownAnnotator { content, child ->
+        val startOffset: Int = child.startOffset
+        val endOffset: Int = child.endOffset
+        if (startOffset < 0 || startOffset >= endOffset || endOffset > content.length) {
+            return@markdownAnnotator false
+        }
+        val isDollarNode: Boolean = child.type == GFMTokenTypes.DOLLAR ||
+            child.type == GFMElementTypes.INLINE_MATH ||
+            child.type == GFMElementTypes.BLOCK_MATH
+        if (isDollarNode.not() && child.children.isNotEmpty()) {
+            return@markdownAnnotator false
+        }
+        val nodeText: String = content.substring(startIndex = startOffset, endIndex = endOffset)
+        if (isDollarNode.not() && nodeText.contains(char = reviewInlineMathMarker).not()) {
+            return@markdownAnnotator false
+        }
+        appendReviewMathNodeText(
+            nodeText = nodeText,
+            formulas = formulas,
+            firstFormulaIndex = countReviewInlineMathMarkers(
+                text = content.substring(startIndex = 0, endIndex = startOffset)
+            ),
+            renderStates = renderStates,
+            errorMessage = errorMessage,
+            errorColor = errorColor
+        )
+        true
+    }
+}
+
+/**
+ * Appends one node the renderer cannot handle itself.
+ *
+ * The pinned renderer emits nothing for a `$`-math node and only one `$` for a longer `$` run, so
+ * every dollar the contract keeps literal has to be written back from the source here.
+ */
+private fun AnnotatedString.Builder.appendReviewMathNodeText(
+    nodeText: String,
+    formulas: List<ReviewInlineMathFormula>,
+    firstFormulaIndex: Int,
+    renderStates: Map<String, ReviewInlineMathRenderState>,
+    errorMessage: String,
+    errorColor: Color
+) {
+    var formulaIndex: Int = firstFormulaIndex
+    // A line break inside a paragraph is a soft break, which Markdown renders as a single space.
+    val softBreakText: String = reviewMathSoftBreakRegex.replace(
+        input = nodeText,
+        replacement = " "
+    )
+    // A consumed node skips the renderer's own unescaping, so the same pass runs here; the marker
+    // is outside its escape character class and survives untouched.
+    val literalText: String = EntityConverter.replaceEntities(
+        text = softBreakText,
+        processEntities = false,
+        processEscapes = true
+    )
+    literalText.forEach { character ->
+        if (character == reviewInlineMathMarker) {
+            formulas.getOrNull(index = formulaIndex)?.let { formula ->
+                appendReviewInlineMathFormula(
+                    formula = formula,
+                    renderState = renderStates[formula.tag],
+                    errorMessage = errorMessage,
+                    errorColor = errorColor
+                )
+            }
+            formulaIndex += 1
+        } else {
+            append(character)
+        }
+    }
+}
+
+private fun AnnotatedString.Builder.appendReviewInlineMathFormula(
+    formula: ReviewInlineMathFormula,
+    renderState: ReviewInlineMathRenderState?,
+    errorMessage: String,
+    errorColor: Color
+) {
+    if (renderState is ReviewInlineMathRenderState.Failed) {
+        // A rejected formula stays visible as its original delimited source next to a localized error.
+        withStyle(style = SpanStyle(color = errorColor, fontFamily = FontFamily.Monospace)) {
+            append(formula.delimitedSource)
+        }
+        withStyle(style = SpanStyle(color = errorColor)) {
+            append(" $errorMessage")
+        }
+    } else {
+        // The alternate text carries the LaTeX source, which speech and accessibility read.
+        appendInlineContent(id = formula.tag, alternateText = formula.source)
     }
 }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
@@ -43,10 +43,14 @@ private data class ReviewMathExtraction(
     val escapedDollarOffsets: List<Int>
 )
 
-private data class ReviewInlineMathExtraction(
-    val candidates: List<ReviewMathCandidate>,
-    val escapedDollarOffsets: List<Int>,
-    val hasUnmatchedOpener: Boolean
+private data class ReviewMathDollarRun(
+    val startIndex: Int,
+    val length: Int
+)
+
+private data class ReviewLineDollars(
+    val runs: List<ReviewMathDollarRun>,
+    val escapingBackslashIndices: List<Int>
 )
 
 private const val reviewProtectedProseCharacters: String = "[]`|<>*_~"
@@ -110,6 +114,7 @@ private fun hasReviewReferenceDefinitionOutsideProtectedContexts(
                 line.contentEndOffset <= candidate.endOffset
         }
         val fenceMarker: String? = reviewFenceMarker(line = line.content)
+        val displayFenceRunLength: Int? = reviewDisplayFenceRunLength(line = line.content)
         when {
             isInsideDisplayMath -> lineIndex += 1
             isReviewIndentedCodeLine(line = line.content) -> lineIndex += 1
@@ -120,10 +125,12 @@ private fun hasReviewReferenceDefinitionOutsideProtectedContexts(
                     marker = fenceMarker
                 )
             }
-            isReviewDisplayDelimiterLine(line = line.content) -> {
+            displayFenceRunLength != null &&
+                isReviewTopLevelBlockStart(lines = lines, lineIndex = lineIndex) -> {
                 val closingLineIndex: Int? = findReviewDisplayClosingLine(
                     lines = lines,
-                    openingLineIndex = lineIndex
+                    openingLineIndex = lineIndex,
+                    openingRunLength = displayFenceRunLength
                 )
                 if (closingLineIndex == null) {
                     // The unmatched display tail is literal, including reference-looking lines.
@@ -151,8 +158,13 @@ private fun extractReviewMathCandidates(
     while (lineIndex < lines.size) {
         val line: ReviewMathLine = lines[lineIndex]
         val fenceMarker: String? = reviewFenceMarker(line = line.content)
+        val displayFenceRunLength: Int? = reviewDisplayFenceRunLength(line = line.content)
+        val singleLineDisplayCandidate: ReviewMathCandidate? = makeReviewSingleLineDisplayCandidate(
+            lines = lines,
+            lineIndex = lineIndex
+        )
         when {
-            line.content.isBlank() -> lineIndex += 1
+            isReviewBlankLine(line = line.content) -> lineIndex += 1
 
             isReviewIndentedCodeLine(line = line.content) -> lineIndex += 1
 
@@ -171,10 +183,12 @@ private fun extractReviewMathCandidates(
                 )
             }
 
-            isReviewDisplayDelimiterLine(line = line.content) -> {
+            displayFenceRunLength != null &&
+                isReviewTopLevelBlockStart(lines = lines, lineIndex = lineIndex) -> {
                 val closingLineIndex: Int? = findReviewDisplayClosingLine(
                     lines = lines,
-                    openingLineIndex = lineIndex
+                    openingLineIndex = lineIndex,
+                    openingRunLength = displayFenceRunLength
                 )
                 if (closingLineIndex == null) {
                     // V1 avoids tail Markdown reconstruction; the unmatched tail stays byte-for-byte literal.
@@ -187,6 +201,11 @@ private fun extractReviewMathCandidates(
                     )?.let(candidates::add)
                     lineIndex = closingLineIndex + 1
                 }
+            }
+
+            singleLineDisplayCandidate != null -> {
+                candidates.add(element = singleLineDisplayCandidate)
+                lineIndex += 1
             }
 
             isReviewContainerLine(line = line.content) || isReviewRawHtmlLine(line = line.content) -> {
@@ -209,8 +228,7 @@ private fun extractReviewMathCandidates(
                         reviewTableDelimiterRegex.matches(nextLine.content)
                     )
                 if (isSetextOrTable.not()) {
-                    val paragraphExtraction: ReviewInlineMathExtraction? = extractReviewInlineParagraph(
-                        markdown = markdown,
+                    val paragraphExtraction: ReviewMathExtraction? = extractReviewInlineParagraph(
                         lines = lines.subList(
                             fromIndex = lineIndex,
                             toIndex = paragraphEndIndex
@@ -286,7 +304,7 @@ private fun reviewLineIndexAfterLiteralBlock(
     startLineIndex: Int
 ): Int {
     var lineIndex: Int = startLineIndex + 1
-    while (lineIndex < lines.size && lines[lineIndex].content.isNotBlank()) {
+    while (lineIndex < lines.size && isReviewBlankLine(line = lines[lineIndex].content).not()) {
         lineIndex += 1
     }
     return lineIndex
@@ -294,12 +312,15 @@ private fun reviewLineIndexAfterLiteralBlock(
 
 private fun findReviewDisplayClosingLine(
     lines: List<ReviewMathLine>,
-    openingLineIndex: Int
+    openingLineIndex: Int,
+    openingRunLength: Int
 ): Int? {
     var lineIndex: Int = openingLineIndex + 1
     while (lineIndex < lines.size) {
-        if (isReviewDisplayDelimiterLine(line = lines[lineIndex].content)) {
-            return lineIndex
+        val closingRunLength: Int? = reviewDisplayFenceRunLength(line = lines[lineIndex].content)
+        if (closingRunLength != null) {
+            // Only the first later delimiter-only line can close, and it has to hold the same run length.
+            return if (closingRunLength == openingRunLength) lineIndex else null
         }
         lineIndex += 1
     }
@@ -332,6 +353,87 @@ private fun makeReviewDisplayCandidate(
     )
 }
 
+private fun makeReviewSingleLineDisplayCandidate(
+    lines: List<ReviewMathLine>,
+    lineIndex: Int
+): ReviewMathCandidate? {
+    if (isReviewTopLevelBlockStart(lines = lines, lineIndex = lineIndex).not()) {
+        return null
+    }
+    if (isReviewTopLevelBlockEnd(lines = lines, lineIndex = lineIndex).not()) {
+        return null
+    }
+    val line: ReviewMathLine = lines[lineIndex]
+    val bodyRange: IntRange = reviewSingleLineDisplayBodyRange(line = line.content) ?: return null
+    val source: String = line.content.substring(
+        startIndex = bodyRange.first,
+        endIndex = bodyRange.last + 1
+    )
+    if (source.isBlank()) {
+        return null
+    }
+    return ReviewMathCandidate(
+        startOffset = line.startOffset,
+        endOffset = line.contentEndOffset,
+        source = source,
+        delimitedSource = line.content,
+        kind = ReviewMathCandidateKind.DISPLAY
+    )
+}
+
+/**
+ * Body of `$$X$$` written on one line, where the closing run is the first later run on that line,
+ * holds as many `$` as the opening run, and is followed only by spaces or tabs.
+ */
+private fun reviewSingleLineDisplayBodyRange(line: String): IntRange? {
+    val runs: List<ReviewMathDollarRun> = reviewLineDollars(line = line).runs
+    val openingRun: ReviewMathDollarRun = runs.getOrNull(index = 0) ?: return null
+    val closingRun: ReviewMathDollarRun = runs.getOrNull(index = 1) ?: return null
+    if (openingRun.startIndex != 0 || openingRun.length < 2) {
+        return null
+    }
+    if (closingRun.length != openingRun.length) {
+        return null
+    }
+    val trailing: String = line.substring(startIndex = closingRun.startIndex + closingRun.length)
+    if (trailing.all { character -> isReviewMathSpace(character = character) }.not()) {
+        return null
+    }
+    return openingRun.length..(closingRun.startIndex - 1)
+}
+
+/**
+ * Length of the `$` run on a line that holds nothing but that run.
+ *
+ * V1 requires an unindented run: it approximates the contract's "direct top-level block" test
+ * without reconstructing container blocks, so an indented `$$` inside a list item stays literal.
+ */
+private fun reviewDisplayFenceRunLength(line: String): Int? {
+    val run: ReviewMathDollarRun = reviewLineDollars(line = line).runs.singleOrNull() ?: return null
+    if (run.startIndex != 0 || run.length < 2) {
+        return null
+    }
+    val trailing: String = line.substring(startIndex = run.length)
+    if (trailing.all { character -> isReviewMathSpace(character = character) }.not()) {
+        return null
+    }
+    return run.length
+}
+
+private fun isReviewTopLevelBlockStart(
+    lines: List<ReviewMathLine>,
+    lineIndex: Int
+): Boolean {
+    return lineIndex == 0 || isReviewBlankLine(line = lines[lineIndex - 1].content)
+}
+
+private fun isReviewTopLevelBlockEnd(
+    lines: List<ReviewMathLine>,
+    lineIndex: Int
+): Boolean {
+    return lineIndex == lines.size - 1 || isReviewBlankLine(line = lines[lineIndex + 1].content)
+}
+
 private fun findReviewParagraphEndIndex(
     lines: List<ReviewMathLine>,
     startLineIndex: Int
@@ -344,121 +446,172 @@ private fun findReviewParagraphEndIndex(
 }
 
 private fun extractReviewInlineParagraph(
-    markdown: String,
     lines: List<ReviewMathLine>
-): ReviewInlineMathExtraction? {
+): ReviewMathExtraction? {
     if (lines.dropLast(n = 1).any { line -> hasReviewMarkdownHardBreak(line = line.content) }) {
         return null
     }
     val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
     val escapedDollarOffsets: MutableList<Int> = mutableListOf()
-    var hasUnmatchedOpener: Boolean = false
     lines.forEach { line ->
-        val lineExtraction: ReviewInlineMathExtraction = extractReviewInlineLine(
-            markdown = markdown,
+        val lineExtraction: ReviewMathExtraction = extractReviewInlineLine(
             line = line
         ) ?: return null
         candidates.addAll(lineExtraction.candidates)
         escapedDollarOffsets.addAll(lineExtraction.escapedDollarOffsets)
-        hasUnmatchedOpener = hasUnmatchedOpener || lineExtraction.hasUnmatchedOpener
     }
-    return ReviewInlineMathExtraction(
-        candidates = if (hasUnmatchedOpener) emptyList() else candidates,
-        escapedDollarOffsets = escapedDollarOffsets,
-        hasUnmatchedOpener = hasUnmatchedOpener
+    return ReviewMathExtraction(
+        candidates = candidates,
+        escapedDollarOffsets = escapedDollarOffsets
     )
 }
 
-private fun extractReviewInlineLine(
-    markdown: String,
-    line: ReviewMathLine
-): ReviewInlineMathExtraction? {
-    val leadingWhitespace: String = line.content.takeWhile { character -> character.isWhitespace() }
-    if (leadingWhitespace.any { character -> character != ' ' } || leadingWhitespace.length > 3) {
+private fun extractReviewInlineLine(line: ReviewMathLine): ReviewMathExtraction? {
+    val leadingSpaces: String = line.content.takeWhile { character ->
+        isReviewMathSpace(character = character)
+    }
+    if (leadingSpaces.contains(char = '\t') || leadingSpaces.length > 3) {
         return null
     }
-    val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
-    val escapedDollarOffsets: MutableList<Int> = mutableListOf()
-    val prose: StringBuilder = StringBuilder()
-    var openingDollarOffset: Int? = null
-    var literalDoubleDollarSecondOffset: Int? = null
+    val dollars: ReviewLineDollars = reviewLineDollars(line = line.content)
+    val spans: List<IntRange> = reviewAcceptedInlineMathSpans(
+        line = line.content,
+        runs = dollars.runs
+    )
+    val prose: String = reviewInlineMathProse(line = line.content, spans = spans)
+    if (containsReviewProtectedProse(source = prose)) {
+        return null
+    }
+    return ReviewMathExtraction(
+        candidates = spans.map { span ->
+            ReviewMathCandidate(
+                startOffset = line.startOffset + span.first,
+                endOffset = line.startOffset + span.last + 1,
+                source = line.content.substring(
+                    startIndex = span.first + 1,
+                    endIndex = span.last
+                ),
+                delimitedSource = line.content.substring(
+                    startIndex = span.first,
+                    endIndex = span.last + 1
+                ),
+                kind = ReviewMathCandidateKind.INLINE
+            )
+        },
+        escapedDollarOffsets = dollars.escapingBackslashIndices.map { index ->
+            line.startOffset + index
+        }
+    )
+}
+
+/**
+ * Ranges from an accepted opening `$` to its closing `$`, both inclusive.
+ *
+ * Follows the pandoc `tex_math_dollars` guards: the opener needs a non-space character to its
+ * right, the closer needs a non-space character to its left and no digit to its right, and a `$`
+ * that fails as a closer is re-tested from scratch as the next opener.
+ */
+private fun reviewAcceptedInlineMathSpans(
+    line: String,
+    runs: List<ReviewMathDollarRun>
+): List<IntRange> {
+    val spans: MutableList<IntRange> = mutableListOf()
+    var openingIndex: Int = -1
+    runs.forEach { run ->
+        val index: Int = run.startIndex
+        openingIndex = when {
+            // A run of two or more `$` is a display fence sequence and never an inline delimiter.
+            run.length > 1 -> -1
+
+            openingIndex < 0 -> if (hasReviewInlineOpeningGuard(line = line, index = index)) {
+                index
+            } else {
+                -1
+            }
+
+            hasReviewInlineClosingGuard(line = line, index = index) -> {
+                spans.add(element = openingIndex..index)
+                -1
+            }
+
+            hasReviewInlineOpeningGuard(line = line, index = index) -> index
+
+            else -> -1
+        }
+    }
+    return spans
+}
+
+private fun hasReviewInlineOpeningGuard(line: String, index: Int): Boolean {
+    val rightCharacter: Char = line.getOrNull(index = index + 1) ?: return false
+    return isReviewMathSpace(character = rightCharacter).not()
+}
+
+private fun hasReviewInlineClosingGuard(line: String, index: Int): Boolean {
+    val leftCharacter: Char = line.getOrNull(index = index - 1) ?: return false
+    if (isReviewMathSpace(character = leftCharacter)) {
+        return false
+    }
+    val rightCharacter: Char = line.getOrNull(index = index + 1) ?: return true
+    return rightCharacter !in '0'..'9'
+}
+
+private fun reviewInlineMathProse(line: String, spans: List<IntRange>): String {
+    if (spans.isEmpty()) {
+        return line
+    }
+    return buildString(capacity = line.length) {
+        var currentIndex: Int = 0
+        spans.forEach { span ->
+            append(line.substring(startIndex = currentIndex, endIndex = span.first))
+            currentIndex = span.last + 1
+        }
+        append(line.substring(startIndex = currentIndex))
+    }
+}
+
+private fun reviewLineDollars(line: String): ReviewLineDollars {
+    val runs: MutableList<ReviewMathDollarRun> = mutableListOf()
+    val escapingBackslashIndices: MutableList<Int> = mutableListOf()
+    var index: Int = 0
     var precedingBackslashCount: Int = 0
-
-    line.content.forEachIndexed { index, character ->
-        if (character == '\\') {
-            precedingBackslashCount += 1
-            if (openingDollarOffset == null) {
-                prose.append(character)
+    while (index < line.length) {
+        val character: Char = line[index]
+        when {
+            character == '\\' -> {
+                precedingBackslashCount += 1
+                index += 1
             }
-            return@forEachIndexed
-        }
 
-        val isEscaped: Boolean = precedingBackslashCount % 2 == 1
-        precedingBackslashCount = 0
-        if (character != '$') {
-            if (openingDollarOffset == null) {
-                prose.append(character)
+            character != '$' -> {
+                precedingBackslashCount = 0
+                index += 1
             }
-            return@forEachIndexed
-        }
 
-        if (literalDoubleDollarSecondOffset == index) {
-            literalDoubleDollarSecondOffset = null
-            return@forEachIndexed
-        }
-
-        if (isEscaped) {
-            escapedDollarOffsets.add(line.startOffset + index - 1)
-            if (openingDollarOffset == null) {
-                prose.append(character)
+            precedingBackslashCount % 2 == 1 -> {
+                precedingBackslashCount = 0
+                escapingBackslashIndices.add(element = index - 1)
+                index += 1
             }
-            return@forEachIndexed
-        }
 
-        if (line.content.getOrNull(index = index + 1) == '$') {
-            if (openingDollarOffset != null) {
-                return null
-            }
-            prose.append("$$")
-            literalDoubleDollarSecondOffset = index + 1
-            return@forEachIndexed
-        }
-
-        val openingOffset: Int? = openingDollarOffset
-        if (openingOffset == null) {
-            openingDollarOffset = index
-        } else {
-            val source: String = line.content.substring(
-                startIndex = openingOffset + 1,
-                endIndex = index
-            )
-            if (source.isBlank()) {
-                return null
-            }
-            candidates.add(
-                ReviewMathCandidate(
-                    startOffset = line.startOffset + openingOffset,
-                    endOffset = line.startOffset + index + 1,
-                    source = source,
-                    delimitedSource = markdown.substring(
-                        startIndex = line.startOffset + openingOffset,
-                        endIndex = line.startOffset + index + 1
-                    ),
-                    kind = ReviewMathCandidateKind.INLINE
+            else -> {
+                var runEndIndex: Int = index
+                while (runEndIndex < line.length && line[runEndIndex] == '$') {
+                    runEndIndex += 1
+                }
+                runs.add(
+                    ReviewMathDollarRun(
+                        startIndex = index,
+                        length = runEndIndex - index
+                    )
                 )
-            )
-            openingDollarOffset = null
+                index = runEndIndex
+            }
         }
     }
-
-    if (containsReviewProtectedProse(source = prose.toString())) {
-        return null
-    }
-    val hasUnmatchedOpener: Boolean = openingDollarOffset != null
-    return ReviewInlineMathExtraction(
-        candidates = if (hasUnmatchedOpener) emptyList() else candidates,
-        escapedDollarOffsets = escapedDollarOffsets,
-        hasUnmatchedOpener = hasUnmatchedOpener
+    return ReviewLineDollars(
+        runs = runs,
+        escapingBackslashIndices = escapingBackslashIndices
     )
 }
 
@@ -489,10 +642,9 @@ private fun hasReviewMarkdownHardBreak(line: String): Boolean {
 }
 
 private fun isReviewParagraphBoundary(line: String): Boolean {
-    return line.isBlank() ||
+    return isReviewBlankLine(line = line) ||
         reviewFenceMarker(line = line) != null ||
         isReviewIndentedCodeLine(line = line) ||
-        isReviewDisplayDelimiterLine(line = line) ||
         isReviewContainerLine(line = line) ||
         isReviewRawHtmlLine(line = line) ||
         isReviewSingleLineBoundary(line = line)
@@ -528,8 +680,17 @@ private fun isReviewIndentedCodeLine(line: String): Boolean {
     return false
 }
 
-private fun isReviewDisplayDelimiterLine(line: String): Boolean {
-    return line.trimEnd(chars = charArrayOf(' ', '\t')) == "$$"
+/**
+ * The contract defines a space as exactly U+0020, U+0009, and the line break. A general whitespace
+ * predicate also accepts U+00A0, which the delimiter guards and the blank-line test must reject.
+ */
+private fun isReviewMathSpace(character: Char): Boolean {
+    return character == ' ' || character == '\t'
+}
+
+/** CommonMark blank line: a line holding only spaces and tabs, not only a zero-length line. */
+private fun isReviewBlankLine(line: String): Boolean {
+    return line.all { character -> isReviewMathSpace(character = character) }
 }
 
 private fun makeReviewMathBlocks(
@@ -543,14 +704,12 @@ private fun makeReviewMathBlocks(
                 markdown = markdown,
                 startOffset = 0,
                 endOffset = markdown.length,
-                escapedDollarOffsets = escapedDollarOffsets,
-                continuesInlineParagraph = false
+                escapedDollarOffsets = escapedDollarOffsets
             )
         )
     }
 
     var currentOffset: Int = 0
-    var continuesInlineParagraph: Boolean = false
     return buildList {
         candidates.forEach { candidate ->
             if (currentOffset < candidate.startOffset) {
@@ -559,8 +718,7 @@ private fun makeReviewMathBlocks(
                         markdown = markdown,
                         startOffset = currentOffset,
                         endOffset = candidate.startOffset,
-                        escapedDollarOffsets = escapedDollarOffsets,
-                        continuesInlineParagraph = continuesInlineParagraph
+                        escapedDollarOffsets = escapedDollarOffsets
                     )
                 )
             }
@@ -572,7 +730,6 @@ private fun makeReviewMathBlocks(
                 )
             )
             currentOffset = candidate.endOffset
-            continuesInlineParagraph = candidate.kind == ReviewMathCandidateKind.INLINE
         }
         if (currentOffset < markdown.length) {
             add(
@@ -580,8 +737,7 @@ private fun makeReviewMathBlocks(
                     markdown = markdown,
                     startOffset = currentOffset,
                     endOffset = markdown.length,
-                    escapedDollarOffsets = escapedDollarOffsets,
-                    continuesInlineParagraph = continuesInlineParagraph
+                    escapedDollarOffsets = escapedDollarOffsets
                 )
             )
         }
@@ -592,8 +748,7 @@ private fun makeReviewMarkdownBlock(
     markdown: String,
     startOffset: Int,
     endOffset: Int,
-    escapedDollarOffsets: List<Int>,
-    continuesInlineParagraph: Boolean
+    escapedDollarOffsets: List<Int>
 ): ReviewMathBlock.Markdown {
     val rawMarkdown: String = markdown.substring(startIndex = startOffset, endIndex = endOffset)
     val removedOffsets: Set<Int> = escapedDollarOffsets.filter { offset ->
@@ -607,33 +762,7 @@ private fun makeReviewMarkdownBlock(
         }
     }
     return ReviewMathBlock.Markdown(
-        markdown = if (continuesInlineParagraph) {
-            normalizeReviewInlineMathParagraphContinuation(markdown = rawMarkdown)
-        } else {
-            rawMarkdown
-        },
+        markdown = rawMarkdown,
         normalizedMarkdown = normalizedMarkdown
     )
-}
-
-private fun normalizeReviewInlineMathParagraphContinuation(markdown: String): String {
-    if (markdown.isEmpty() || markdown.first() == '\r' || markdown.first() == '\n') {
-        return markdown
-    }
-    // A mid-paragraph fragment must not acquire document-level block syntax after splitting.
-    val leadingWhitespaceLength: Int = markdown.takeWhile { character ->
-        character == ' ' || character == '\t'
-    }.length
-    val content: String = markdown.drop(n = leadingWhitespaceLength)
-    val normalizedPrefix: String = if (leadingWhitespaceLength == 0) "" else " "
-    val escapedContent: String = when {
-        Regex(pattern = """^#{1,6}(?:[ \t]+|$)""").containsMatchIn(content) -> "\\$content"
-        Regex(pattern = """^[-+*](?:[ \t]+|$)""").containsMatchIn(content) -> "\\$content"
-        Regex(pattern = """^(?:-[ \t]*){3,}(?:\r?\n|$)""").containsMatchIn(content) -> "\\$content"
-        else -> Regex(pattern = """^(\d{1,9})([.)])(?=[ \t]+|\r\n|\r|\n|$)""").replaceFirst(
-            input = content,
-            replacement = "$1\\\\$2"
-        )
-    }
-    return normalizedPrefix + escapedContent
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
@@ -39,6 +39,7 @@ fun ReviewRenderedContentView(
         is ReviewRenderedContent.Markdown -> {
             ReviewMarkdownText(
                 markdown = content.markdown,
+                inlineFormulas = emptyList(),
                 modifier = modifier.fillMaxWidth()
             )
         }
@@ -53,6 +54,7 @@ fun ReviewRenderedContentView(
                         when (block) {
                             is ReviewManagedMarkdownBlock.Markdown -> ReviewMarkdownText(
                                 markdown = block.markdown,
+                                inlineFormulas = block.inlineFormulas,
                                 modifier = Modifier.fillMaxWidth()
                             )
 


### PR DESCRIPTION
Implements the merged cross-client math contract (`docs/review-markdown-rendering.md`) on the Android review screen.

## What changes

- An accepted `$...$` span renders **on the text baseline inside its paragraph** instead of becoming a separate block in the block `Column`.
- A `$$...$$` run that opens and closes on one line is display math.
- The scanner follows the contract's source-level rules directly: maximal dollar runs, the pandoc delimiter guards including the digit clause, the failed-closer-becomes-next-opener rule, equal-length closing runs, block start/end tests, and the CommonMark blank line. *space* is defined as exactly U+0020 and U+0009, so `Char.isWhitespace` — which accepts U+00A0 — cannot make this client disagree with the other three.

Inline formulas reach Compose through the markdown renderer's own `markdownAnnotator` and `markdownInlineContent` hooks, rasterized off the main thread and seated on the text baseline by an `AboveBaseline` placeholder offset down by the formula's depth.

## It also fixes a pre-existing bug: the renderer was dropping literal dollars

`org.intellij.markdown`'s GFM flavour always runs its `MathParser`, producing `INLINE_MATH`/`BLOCK_MATH` nodes. The pinned `multiplatform-markdown-renderer` **has no branch for either type**, and its `GFMTokenTypes.DOLLAR` branch emits a single `$` for a run of any length. So today `The formula $$E=mc^2$$ is famous.` renders as `The formula  is famous.` and `Prices are $20$30` renders as `Prices are 30`.

The annotator now consumes those node types and writes the source back verbatim. Exposure in published catalog decks is zero — no published side both routes to the markdown renderer and contains a dollar — but it is reachable for user-authored cards.

## Reviewed twice

Round 1 found a crash: a literal U+FFFC in card text was indistinguishable from the injected marker, and `emptyList().subList(0, 1)` threw inside the synchronous presentation mapping, escaping to the review screen. U+FFFC arrives routinely in text pasted from PDFs and Word. Fixed at the funnel by sanitizing once before any offset is computed. Round 1 also broadened the inline render's `catch` to `Throwable` to match RaTeX's own display path, so an OOM or a native-library failure shows the localized error rather than taking the screen down.

Round 2 found no issues.

## Needs a device check before the visual result is trusted

Three items could not be verified statically, and Gradle/emulator runs were not authorized for this task:

- a tall inline formula (`$\frac{1}{2}$`, `$\int_0^1 x^2\,dx$`) may be clipped, because M3 `bodyLarge` carries an explicit `lineHeight = 24.sp` and Compose applies that through a `LineHeightSpan` that can stop the line box growing to the placeholder's metrics;
- a very wide inline formula has no scroll container by contract, so confirm it clips rather than breaking the layout;
- the restored literal dollars should be spot-checked byte-for-byte on a plain currency card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)