### PR TITLE
Render web review inline math inline

### DIFF
--- a/apps/web/src/screens/review/components/card/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewCardSide.tsx
@@ -16,7 +16,10 @@ import {
   type ManagedMediaReferenceState,
 } from "../../../../media/managedMediaMarkdown";
 import { classifyReviewContentPresentation } from "./reviewContentPresentation";
-import reviewMathBlocks, { normalizeReviewPlainTextEscapedDollars } from "./reviewMathBlocks";
+import reviewMathBlocks, {
+  escapeRejectedReviewMathDollars,
+  normalizeReviewPlainTextEscapedDollars,
+} from "./reviewMathBlocks";
 import { ReviewMathBlock } from "./ReviewMathBlock";
 
 const REVIEW_MARKDOWN_FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
@@ -155,13 +158,25 @@ const reviewMarkdownComponents: Components = {
     const formulaSource = node?.properties["data-formula-source"];
     const delimitedSource = node?.properties["data-delimited-source"];
     if (typeof formulaSource === "string" && typeof delimitedSource === "string") {
-      return <ReviewMathBlock formulaSource={formulaSource} delimitedSource={delimitedSource} />;
+      return <ReviewMathBlock formulaSource={formulaSource} delimitedSource={delimitedSource} inline={false} />;
     }
     if (formulaSource !== undefined || delimitedSource !== undefined) {
       throw new Error("Review formula block was missing its source properties");
     }
 
     return <div>{children}</div>;
+  },
+  span: function ReviewMarkdownSpan({ children, node }) {
+    const formulaSource = node?.properties["data-formula-source"];
+    const delimitedSource = node?.properties["data-delimited-source"];
+    if (typeof formulaSource === "string" && typeof delimitedSource === "string") {
+      return <ReviewMathBlock formulaSource={formulaSource} delimitedSource={delimitedSource} inline />;
+    }
+    if (formulaSource !== undefined || delimitedSource !== undefined) {
+      throw new Error("Review formula span was missing its source properties");
+    }
+
+    return <span>{children}</span>;
   },
   a: function ReviewMarkdownAnchor({ children, href, title }) {
     const { localReadVersion, workspaceId } = useReviewMarkdownRenderContext();
@@ -291,17 +306,22 @@ function ReviewCardMarkdown(props: Readonly<{
     workspaceId,
   } = props;
   const normalizedText = normalizeReviewMarkdownForWeb(text);
+  const containsDollarSign = normalizedText.includes("$");
+  // `remark-math` segments dollar-delimited source far more loosely than the
+  // review math contract does, so the rejected dollars are escaped before the
+  // parse and the transform only has to confirm the nodes it is handed.
+  const markdownText = containsDollarSign ? escapeRejectedReviewMathDollars(normalizedText) : normalizedText;
 
   return (
     <ReviewMarkdownRenderContext.Provider value={{ localReadVersion, workspaceId }}>
       <ReactMarkdown
         urlTransform={reviewMarkdownUrlTransform}
         components={reviewMarkdownComponents}
-        remarkPlugins={normalizedText.includes("$")
+        remarkPlugins={containsDollarSign
           ? [remarkGfm, remarkMath, reviewMathBlocks]
           : [remarkGfm]}
       >
-        {normalizedText}
+        {markdownText}
       </ReactMarkdown>
     </ReviewMarkdownRenderContext.Provider>
   );

--- a/apps/web/src/screens/review/components/card/ReviewMathBlock.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewMathBlock.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useRef, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import {
   initRatex,
-  renderLatexToCanvas,
+  renderLatexToDisplayList,
+  renderToCanvas,
 } from "ratex-wasm";
 import "ratex-wasm/fonts.css";
 import { useI18n } from "../../../../i18n";
 
 const REVIEW_MATH_FONT_SIZE_CSS_PIXELS = 18;
-const REVIEW_MATH_PADDING_CSS_PIXELS = 4;
+const REVIEW_MATH_BLOCK_PADDING_CSS_PIXELS = 4;
+// An inline formula sits in a line of prose, so it keeps only the single pixel
+// that stops a glyph overhanging the layout box from being clipped.
+const REVIEW_MATH_INLINE_PADDING_CSS_PIXELS = 1;
 const REVIEW_MATH_FONT_DESCRIPTORS: ReadonlyArray<string> = [
   `400 ${REVIEW_MATH_FONT_SIZE_CSS_PIXELS}px KaTeX_AMS`,
   `400 ${REVIEW_MATH_FONT_SIZE_CSS_PIXELS}px KaTeX_Caligraphic`,
@@ -34,6 +38,7 @@ const REVIEW_MATH_FONT_DESCRIPTORS: ReadonlyArray<string> = [
 type ReviewMathBlockProps = Readonly<{
   delimitedSource: string;
   formulaSource: string;
+  inline: boolean;
 }>;
 type ReviewMathRenderState = Readonly<{
   formulaSource: string;
@@ -63,13 +68,19 @@ async function loadReviewMathFonts(signal: AbortSignal): Promise<void> {
 }
 
 export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
-  const { delimitedSource, formulaSource } = props;
+  const { delimitedSource, formulaSource, inline } = props;
   const { t } = useI18n();
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [renderState, setRenderState] = useState<ReviewMathRenderState>(null);
   const renderErrorMessage = t("reviewScreen.errors.mathRenderFailed");
   const currentRenderStatus = renderState?.formulaSource === formulaSource ? renderState.status : null;
+
+  // The container is a `span` inline and a `div` as a block, so one callback ref
+  // keeps a single element reference across both shapes.
+  const setContainerElement = useCallback((element: HTMLElement | null): void => {
+    containerRef.current = element;
+  }, []);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -85,6 +96,7 @@ export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
     canvas.height = 0;
     canvas.style.width = "";
     canvas.style.height = "";
+    container.style.verticalAlign = "";
 
     async function renderFormula(): Promise<void> {
       try {
@@ -96,22 +108,39 @@ export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
           throw new Error("Review formula rendering could not resolve the theme text color");
         }
         const devicePixelRatio = window.devicePixelRatio;
-        renderLatexToCanvas(
-          formulaSource,
-          renderCanvas,
-          {
-            backgroundColor: "transparent",
-            fontSize: REVIEW_MATH_FONT_SIZE_CSS_PIXELS * devicePixelRatio,
-            padding: REVIEW_MATH_PADDING_CSS_PIXELS * devicePixelRatio,
-          },
-          {
-            color,
-            displayMode: true,
-          },
-        );
+        const paddingCssPixels = inline
+          ? REVIEW_MATH_INLINE_PADDING_CSS_PIXELS
+          : REVIEW_MATH_BLOCK_PADDING_CSS_PIXELS;
+        // The display list carries the layout box, so the canvas takes its final
+        // size in the same task that paints it and the line never reflows twice.
+        const displayList = renderLatexToDisplayList(formulaSource, {
+          color,
+          displayMode: inline === false,
+        });
+        renderToCanvas(displayList, renderCanvas, {
+          backgroundColor: "transparent",
+          fontSize: REVIEW_MATH_FONT_SIZE_CSS_PIXELS * devicePixelRatio,
+          padding: paddingCssPixels * devicePixelRatio,
+        });
         controller.signal.throwIfAborted();
         renderCanvas.style.width = `${renderCanvas.width / devicePixelRatio}px`;
         renderCanvas.style.height = `${renderCanvas.height / devicePixelRatio}px`;
+        if (inline) {
+          // `depth` is the descent below the formula baseline in em, and the
+          // padding sits below that, so together they are the distance from the
+          // surrounding text baseline to the bottom edge of the canvas box.
+          // Verified against `ratex-wasm@0.1.14`: `renderToCanvas` sizes the
+          // canvas as `ceil((height + depth) * fontSize + 2 * padding)` device
+          // pixels and translates by `padding` before drawing, so the full
+          // padding sits below the baseline. That `ceil` can leave up to one
+          // device pixel of unaccounted slack, which is below the visible
+          // threshold. A raised construction can report a negative depth, so the
+          // descent is clamped to keep the offset from becoming an invalid
+          // `--Npx` that the browser would drop.
+          const baselineDescentEm = Math.max(displayList.depth, 0);
+          const baselineOffsetCssPixels = baselineDescentEm * REVIEW_MATH_FONT_SIZE_CSS_PIXELS + paddingCssPixels;
+          renderContainer.style.verticalAlign = `-${baselineOffsetCssPixels}px`;
+        }
         setRenderState({
           formulaSource,
           status: "ready",
@@ -130,17 +159,47 @@ export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
 
     void renderFormula();
     return () => controller.abort();
-  }, [formulaSource]);
+  }, [formulaSource, inline]);
+
+  const formulaCanvas = (
+    <canvas
+      ref={canvasRef}
+      className={inline ? "review-math-inline-canvas" : "review-math-block-canvas"}
+      role="img"
+      aria-label={formulaSource}
+      hidden={currentRenderStatus !== "ready"}
+    />
+  );
+
+  if (inline) {
+    return (
+      <span
+        ref={setContainerElement}
+        className="review-math-inline"
+        data-render-status={currentRenderStatus ?? "loading"}
+      >
+        {formulaCanvas}
+        {currentRenderStatus === "failed" ? (
+          <span
+            className="review-math-inline-error"
+            role="alert"
+            aria-label={`${formulaSource}. ${renderErrorMessage}`}
+          >
+            <code className="review-math-block-source">{delimitedSource}</code>
+            <span className="review-math-inline-error-message">{renderErrorMessage}</span>
+          </span>
+        ) : null}
+      </span>
+    );
+  }
 
   return (
-    <div ref={containerRef} className="review-math-block" data-render-status={currentRenderStatus ?? "loading"}>
-      <canvas
-        ref={canvasRef}
-        className="review-math-block-canvas"
-        role="img"
-        aria-label={formulaSource}
-        hidden={currentRenderStatus !== "ready"}
-      />
+    <div
+      ref={setContainerElement}
+      className="review-math-block"
+      data-render-status={currentRenderStatus ?? "loading"}
+    >
+      {formulaCanvas}
       {currentRenderStatus === "failed" ? (
         <div
           className="review-math-block-error"

--- a/apps/web/src/screens/review/components/card/reviewMathBlocks.contract.test.ts
+++ b/apps/web/src/screens/review/components/card/reviewMathBlocks.contract.test.ts
@@ -1,0 +1,287 @@
+import type { Nodes, Root } from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import {
+  escapeRejectedReviewMathDollars,
+  hasEligibleReviewMath,
+  splitEligibleReviewMathForSpeech,
+  transformReviewMathBlocks,
+} from "./reviewMathBlocks";
+
+/**
+ * Pins the compact math parity fixture of docs/review-markdown-rendering.md for
+ * the web review screen. Item numbers below are that document's numbering.
+ */
+const reviewProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
+const nonBreakingSpace = "\u00A0";
+
+function transformCardSide(text: string): Root {
+  const escapedText = escapeRejectedReviewMathDollars(text);
+  return transformReviewMathBlocks(reviewProcessor.parse(escapedText), escapedText);
+}
+
+function describeChildren(children: ReadonlyArray<Nodes>): string {
+  return children.map(describeNode).join("");
+}
+
+function describeNode(node: Nodes): string {
+  if (node.type === "text") {
+    return node.value;
+  }
+  if (node.type === "inlineMath") {
+    return `[${node.value}]`;
+  }
+  if (node.type === "math") {
+    return `display(${node.value})`;
+  }
+  if (node.type === "paragraph") {
+    return `paragraph(${describeChildren(node.children)})`;
+  }
+  if ("children" in node) {
+    return `<${node.type}:${describeChildren(node.children)}>`;
+  }
+  if ("value" in node) {
+    return `<${node.type}:${node.value}>`;
+  }
+
+  return `<${node.type}>`;
+}
+
+function readReviewMathOutline(text: string): ReadonlyArray<string> {
+  return transformCardSide(text).children.map(describeNode);
+}
+
+function readAcceptedFormulas(text: string): ReadonlyArray<string> {
+  return splitEligibleReviewMathForSpeech(text)
+    .filter((segment) => segment.kind === "formula")
+    .map((segment) => segment.value);
+}
+
+function readOnlyParagraph(text: string): Extract<Nodes, { type: "paragraph" }> {
+  const child = transformCardSide(text).children[0];
+  if (child.type !== "paragraph") {
+    throw new Error(`Expected a paragraph, received ${child.type}`);
+  }
+
+  return child;
+}
+
+describe("review math delimiter rules", () => {
+  it("accepts a guarded inline span and a top-level display block", () => {
+    expect(readAcceptedFormulas("Before $x$ after")).toEqual(["x"]);
+    expect(readAcceptedFormulas("$$\n\\int_0^1 x^2\\,dx = \\frac{1}{3}\n$$"))
+      .toEqual(["\\int_0^1 x^2\\,dx = \\frac{1}{3}"]);
+    expect(readReviewMathOutline("$$\n\\int_0^1 x^2\\,dx = \\frac{1}{3}\n$$"))
+      .toEqual(["display(\\int_0^1 x^2\\,dx = \\frac{1}{3})"]);
+    expect(readAcceptedFormulas("$$E = mc^2$$")).toEqual(["E = mc^2"]);
+  });
+
+  it("keeps escaped, unbalanced, and code-covered dollars literal", () => {
+    expect(readAcceptedFormulas("Price: \\$5")).toEqual([]);
+    expect(readAcceptedFormulas("Unbalanced $x")).toEqual([]);
+    expect(readReviewMathOutline("Unbalanced $x")).toEqual(["paragraph(Unbalanced $x)"]);
+    expect(readAcceptedFormulas("`$inline_code$`")).toEqual([]);
+    expect(readAcceptedFormulas("```text\n$fenced_code$\n```")).toEqual([]);
+    expect(readReviewMathOutline("```text\n$fenced_code$\n```")).toEqual(["<code:$fenced_code$>"]);
+    expect(readAcceptedFormulas("    $indented_code$")).toEqual([]);
+    expect(readReviewMathOutline("    $indented_code$")).toEqual(["<code:$indented_code$>"]);
+  });
+
+  it("keeps a formula outside an inline code span ineligible in the same paragraph", () => {
+    expect(readAcceptedFormulas("Before $x$ after `code`")).toEqual([]);
+  });
+
+  it("keeps math inside links, emphasis, lists, images, and containers literal", () => {
+    expect(readAcceptedFormulas("[$link_label$](https://flashcards-open-source-app.com)")).toEqual([]);
+    expect(readAcceptedFormulas("**$strong$**")).toEqual([]);
+    expect(readAcceptedFormulas("- $list_item$")).toEqual([]);
+    expect(readReviewMathOutline("- $list_item$")).toEqual(["<list:<listItem:paragraph($list_item$)>>"]);
+    expect(readAcceptedFormulas("![Managed $label$](fcasset:media-asset-1)")).toEqual([]);
+    expect(readReviewMathOutline("![Managed $label$](fcasset:media-asset-1)")).toEqual(["paragraph(<image>)"]);
+    expect(readAcceptedFormulas("- Item:\n\n  $$\n  E = mc^2\n  $$")).toEqual([]);
+  });
+
+  it("performs no math segmentation on a side holding a reference definition", () => {
+    const referenceSide = "Reference side with $x$ and [documentation][docs].\n\n"
+      + "[docs]: https://flashcards-open-source-app.com";
+    expect(readAcceptedFormulas(referenceSide)).toEqual([]);
+    expect(readReviewMathOutline(referenceSide)).toEqual([
+      "paragraph(Reference side with $x$ and <linkReference:documentation>.)",
+      "<definition>",
+    ]);
+  });
+
+  it("recognizes an invalid formula so the engine error stays visible", () => {
+    expect(readAcceptedFormulas("Invalid $\\frac{1}{$")).toEqual(["\\frac{1}{"]);
+    expect(readReviewMathOutline("Invalid $\\frac{1}{$")).toEqual(["paragraph(Invalid [\\frac{1}{])"]);
+  });
+
+  it("applies the pandoc opening, closing, and digit guards", () => {
+    expect(readAcceptedFormulas("Earned value is $80,000 and actual cost is $100,000.")).toEqual([]);
+    expect(readReviewMathOutline("Earned value is $80,000 and actual cost is $100,000."))
+      .toEqual(["paragraph(Earned value is $80,000 and actual cost is $100,000.)"]);
+    expect(readAcceptedFormulas("A $100 bond with yield $r$ pays")).toEqual(["r"]);
+    expect(readAcceptedFormulas("Cost: $ x$")).toEqual([]);
+    expect(readReviewMathOutline("Cost: $ x$")).toEqual(["paragraph(Cost: $ x$)"]);
+    expect(readAcceptedFormulas("Prices are $20$30")).toEqual([]);
+    expect(readReviewMathOutline("Prices are $20$30")).toEqual(["paragraph(Prices are $20$30)"]);
+    expect(readAcceptedFormulas("where $m$ is mass and $c$ is the speed of light")).toEqual(["m", "c"]);
+  });
+
+  it("treats only the ASCII space and tab as space in the delimiter guards", () => {
+    const nonBreakingSide = `Total is $${nonBreakingSpace}x${nonBreakingSpace}$ today.`;
+    expect(readAcceptedFormulas(nonBreakingSide)).toEqual([`${nonBreakingSpace}x${nonBreakingSpace}`]);
+    expect(readReviewMathOutline(nonBreakingSide))
+      .toEqual([`paragraph(Total is [${nonBreakingSpace}x${nonBreakingSpace}] today.)`]);
+  });
+
+  it("never lets an inline span cross a line", () => {
+    expect(readAcceptedFormulas("Mass is $m\nand energy is$E today.")).toEqual([]);
+    expect(readReviewMathOutline("Mass is $m\nand energy is$E today."))
+      .toEqual(["paragraph(Mass is $m\nand energy is$E today.)"]);
+  });
+
+  it("reads a run of two or more dollars as a display fence sequence, never as inline delimiters", () => {
+    expect(readAcceptedFormulas("The formula $$E=mc^2$$ is famous.")).toEqual([]);
+    expect(readReviewMathOutline("The formula $$E=mc^2$$ is famous."))
+      .toEqual(["paragraph(The formula $$E=mc^2$$ is famous.)"]);
+    expect(readAcceptedFormulas("$$E=mc^2$$ where $m$ is mass.")).toEqual(["m"]);
+    expect(readAcceptedFormulas("Cost is $x and$$E$$ here$m$ ok.")).toEqual(["m"]);
+  });
+
+  it("requires the opening and closing display runs to hold the same number of dollars", () => {
+    expect(readAcceptedFormulas("$$$x$$$")).toEqual(["x"]);
+    expect(readReviewMathOutline("$$$x$$$")).toEqual(["display(x)"]);
+    expect(readAcceptedFormulas("$$$x$$")).toEqual([]);
+    expect(readReviewMathOutline("$$$x$$")).toEqual(["paragraph($$$x$$)"]);
+    expect(readAcceptedFormulas("$$x$$$")).toEqual([]);
+    expect(readReviewMathOutline("$$x$$$")).toEqual(["paragraph($$x$$$)"]);
+    expect(readAcceptedFormulas("$$\nX\n$$$")).toEqual([]);
+  });
+
+  it("keeps a construct the parser cannot reproduce literal on every path", () => {
+    // `remark-math` closes a text-math span on the escaped dollar, so the
+    // construct the source rules accept has no node to render into. Rendering,
+    // presentation selection, and speech all have to answer "no formula" here.
+    const escapedDollarInlineSide = "The price $p = \\$5$ today.";
+    expect(readAcceptedFormulas(escapedDollarInlineSide)).toEqual([]);
+    expect(hasEligibleReviewMath(escapedDollarInlineSide)).toBe(false);
+    expect(readReviewMathOutline(escapedDollarInlineSide))
+      .toEqual(["paragraph(The price $p = \\$5$ today.)"]);
+
+    const escapedDollarDisplaySide = "$$\\$x\\$$$";
+    expect(readAcceptedFormulas(escapedDollarDisplaySide)).toEqual([]);
+    expect(hasEligibleReviewMath(escapedDollarDisplaySide)).toBe(false);
+    expect(readReviewMathOutline(escapedDollarDisplaySide)).toEqual(["paragraph($$$x$$$)"]);
+  });
+
+  it("requires a display construct to begin and end its own top-level block", () => {
+    expect(readAcceptedFormulas("Answer:\n$$E = mc^2$$")).toEqual([]);
+    expect(readAcceptedFormulas("Answer:\n$$\nE = mc^2\n$$")).toEqual([]);
+    expect(readAcceptedFormulas("$$E = mc^2\n$$")).toEqual([]);
+    expect(readAcceptedFormulas("$$E = mc^2$$\nAnswer text.")).toEqual([]);
+    expect(readAcceptedFormulas("$$A$$\n$$B$$")).toEqual([]);
+    expect(readAcceptedFormulas("$$E=mc^2$$ $$F=ma$$")).toEqual([]);
+    expect(readAcceptedFormulas("$$\nA\n$$\n$$\nB\n$$")).toEqual(["A"]);
+  });
+
+  it("keeps an unterminated display fence literal", () => {
+    expect(readAcceptedFormulas("$$\nE = mc^2\n\nThe **rest** of the side.")).toEqual([]);
+  });
+
+  it("exposes the formula source without delimiters and keeps literal dollars in speech prose", () => {
+    expect(splitEligibleReviewMathForSpeech("A $100 bond with yield $r$ pays")).toEqual([
+      { kind: "prose", startsAtLineBoundary: true, value: "A $100 bond with yield " },
+      { kind: "formula", value: "r" },
+      { kind: "prose", startsAtLineBoundary: false, value: " pays" },
+    ]);
+  });
+});
+
+describe("review math rendering", () => {
+  it("keeps an accepted inline formula on the surrounding text baseline in its paragraph", () => {
+    expect(readReviewMathOutline("Before $x$ after")).toEqual(["paragraph(Before [x] after)"]);
+    expect(readReviewMathOutline("where $m$ is mass and $c$ is the speed of light"))
+      .toEqual(["paragraph(where [m] is mass and [c] is the speed of light)"]);
+  });
+
+  it("renders an accepted inline formula as a review math span carrying its sources", () => {
+    const paragraph = readOnlyParagraph("Before $x$ after");
+    expect(paragraph.children.map((child) => child.type)).toEqual(["text", "inlineMath", "text"]);
+    expect(paragraph.children[1].data).toEqual({
+      hName: "span",
+      hProperties: {
+        className: ["review-math-inline"],
+        "data-formula-source": "x",
+        "data-delimited-source": "$x$",
+      },
+      hChildren: [],
+    });
+  });
+
+  it("renders an accepted display formula as a standalone review math block", () => {
+    const child = transformCardSide("$$E = mc^2$$").children[0];
+    if (child.type !== "math") {
+      throw new Error(`Expected a display formula, received ${child.type}`);
+    }
+    expect(child.value).toBe("E = mc^2");
+    expect(child.data).toEqual({
+      hName: "div",
+      hProperties: {
+        className: ["review-math-block"],
+        "data-formula-source": "E = mc^2",
+        "data-delimited-source": "$$E = mc^2$$",
+      },
+      hChildren: [],
+    });
+  });
+
+  it("mixes literal dollars and an accepted formula inside one paragraph", () => {
+    expect(readReviewMathOutline("A $100 bond with yield $r$ pays"))
+      .toEqual(["paragraph(A $100 bond with yield [r] pays)"]);
+    expect(readReviewMathOutline("$$E=mc^2$$ where $m$ is mass."))
+      .toEqual(["paragraph($$E=mc^2$$ where [m] is mass.)"]);
+    expect(readReviewMathOutline("Cost is $x and$$E$$ here$m$ ok."))
+      .toEqual(["paragraph(Cost is $x and$$E$$ here[m] ok.)"]);
+  });
+
+  it("keeps a rejected display construct literal inside one paragraph", () => {
+    expect(readReviewMathOutline("Answer:\n$$E = mc^2$$")).toEqual(["paragraph(Answer:\n$$E = mc^2$$)"]);
+    expect(readReviewMathOutline("Answer:\n$$\nE = mc^2\n$$"))
+      .toEqual(["paragraph(Answer:\n$$\nE = mc^2\n$$)"]);
+    expect(readReviewMathOutline("$$E = mc^2\n$$")).toEqual(["paragraph($$E = mc^2\n$$)"]);
+    expect(readReviewMathOutline("$$E = mc^2$$\nAnswer text."))
+      .toEqual(["paragraph($$E = mc^2$$\nAnswer text.)"]);
+    expect(readReviewMathOutline("$$A$$\n$$B$$")).toEqual(["paragraph($$A$$\n$$B$$)"]);
+    expect(readReviewMathOutline("$$E=mc^2$$ $$F=ma$$")).toEqual(["paragraph($$E=mc^2$$ $$F=ma$$)"]);
+    expect(readReviewMathOutline("$$\nX\n$$$")).toEqual(["paragraph($$\nX\n$$$)"]);
+  });
+
+  it("needs a blank line between two multiple-line display constructs", () => {
+    expect(readReviewMathOutline("$$\nA\n$$\n$$\nB\n$$")).toEqual(["display(A)", "paragraph($$\nB\n$$)"]);
+  });
+
+  it("returns the remainder of an unterminated display fence to ordinary Markdown", () => {
+    expect(readReviewMathOutline("$$\nE = mc^2\n\nThe **rest** of the side."))
+      .toEqual(["paragraph($$\nE = mc^2)", "paragraph(The <strong:rest> of the side.)"]);
+  });
+
+  it("keeps dollar-delimited source literal wherever math is ineligible", () => {
+    expect(readReviewMathOutline("`$inline_code$`")).toEqual(["paragraph(<inlineCode:$inline_code$>)"]);
+    expect(readReviewMathOutline("Before $x$ after `code`"))
+      .toEqual(["paragraph(Before $x$ after <inlineCode:code>)"]);
+    expect(readReviewMathOutline("[$link_label$](https://flashcards-open-source-app.com)"))
+      .toEqual(["paragraph(<link:$link_label$>)"]);
+    expect(readReviewMathOutline("**$strong$**")).toEqual(["paragraph(<strong:$strong$>)"]);
+    expect(readReviewMathOutline("Price: \\$5")).toEqual(["paragraph(Price: $5)"]);
+  });
+
+  it("keeps display math inside a container block literal", () => {
+    const outline = readReviewMathOutline("- Item:\n\n  $$\n  E = mc^2\n  $$").join("");
+    expect(outline).toContain("$$\nE = mc^2\n$$");
+    expect(outline).not.toContain("display(");
+  });
+});

--- a/apps/web/src/screens/review/components/card/reviewMathBlocks.ts
+++ b/apps/web/src/screens/review/components/card/reviewMathBlocks.ts
@@ -1,4 +1,4 @@
-import type { Nodes, Parents, Paragraph, Root, RootContent } from "mdast";
+import type { Nodes, Parents, Root, RootContent } from "mdast";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkParse from "remark-parse";
@@ -6,15 +6,61 @@ import type { Plugin } from "unified";
 import { unified } from "unified";
 import { EXIT, SKIP, visit } from "unist-util-visit";
 
-const DISPLAY_MATH_OPEN_PATTERN = /^[ \t]*\$\$[ \t]*(?:\r\n|\r|\n)/;
-const DISPLAY_MATH_CLOSE_PATTERN = /(?:\r\n|\r|\n)[ \t]*\$\$[ \t]*$/;
+const REVIEW_MATH_DIGIT_PATTERN = /^[0-9]$/;
+const REVIEW_MATH_OPENING_RUN_INDENT_PATTERN = /^ {0,3}$/;
+const REVIEW_MATH_SPACE_ONLY_PATTERN = /^[ \t]*$/;
 
-type ReviewMathSource = Readonly<{
+type ReviewMathMode = "display" | "inline";
+
+type ReviewNodeSource = Readonly<{
   delimitedSource: string;
+  endIndex: number;
+  startIndex: number;
+}>;
+
+type ReviewMathSource = ReviewNodeSource & Readonly<{
+  formulaSource: string;
+  mathMode: ReviewMathMode;
+}>;
+
+/** One source line of the card side, without its line ending. */
+type ReviewMarkdownLine = Readonly<{
+  endIndex: number;
+  startIndex: number;
+  value: string;
+}>;
+
+/** A maximal run of unescaped dollar signs on one source line. */
+type ReviewDollarRun = Readonly<{
+  length: number;
+  startColumn: number;
+}>;
+
+/** A half-open source range the math scan must not read. */
+type ReviewSourceRange = Readonly<{
+  endIndex: number;
+  startIndex: number;
+}>;
+
+/** A formula the normative source rules recognize directly in the Markdown source. */
+type ReviewMathConstruct = Readonly<{
   endIndex: number;
   formulaSource: string;
   startIndex: number;
 }>;
+
+/**
+ * The formulas the source rules accept inside one top-level paragraph, plus the
+ * inline code spans that scan stepped over.
+ */
+type ReviewParagraphMathScan = Readonly<{
+  codeSpanRanges: ReadonlyArray<ReviewSourceRange>;
+  constructs: ReadonlyArray<ReviewMathConstruct>;
+  firstLineIndex: number;
+  lastLineIndex: number;
+  mathMode: ReviewMathMode;
+}>;
+
 export type ReviewMathSpeechSegment =
   | Readonly<{
     kind: "formula";
@@ -26,7 +72,346 @@ export type ReviewMathSpeechSegment =
     value: string;
   }>;
 
-function requireNodeSource(text: string, node: Nodes): ReviewMathSource {
+function splitReviewMarkdownLines(text: string): ReadonlyArray<ReviewMarkdownLine> {
+  const lines: Array<ReviewMarkdownLine> = [];
+  const lineEndingPattern = /\r\n|\r|\n/g;
+  let lineStartIndex = 0;
+
+  for (
+    let lineEnding = lineEndingPattern.exec(text);
+    lineEnding !== null;
+    lineEnding = lineEndingPattern.exec(text)
+  ) {
+    lines.push({
+      endIndex: lineEnding.index,
+      startIndex: lineStartIndex,
+      value: text.slice(lineStartIndex, lineEnding.index),
+    });
+    lineStartIndex = lineEnding.index + lineEnding[0].length;
+  }
+
+  lines.push({
+    endIndex: text.length,
+    startIndex: lineStartIndex,
+    value: text.slice(lineStartIndex),
+  });
+
+  return lines;
+}
+
+function findReviewLineIndex(lines: ReadonlyArray<ReviewMarkdownLine>, offset: number): number {
+  const lineIndex = lines.findIndex((line) => offset >= line.startIndex && offset <= line.endIndex);
+  if (lineIndex === -1) {
+    throw new Error(`Review math guard could not locate the source line at offset ${offset}`);
+  }
+
+  return lineIndex;
+}
+
+/** A blank line holds only spaces and tabs, as CommonMark defines it. */
+function isBlankReviewMarkdownLine(line: ReviewMarkdownLine): boolean {
+  return REVIEW_MATH_SPACE_ONLY_PATTERN.test(line.value);
+}
+
+/**
+ * The pandoc delimiter guards treat only the ASCII space, the ASCII tab, and the
+ * end of the line as space. Every other character, the non-breaking space
+ * included, is a non-space character, so this must never delegate to a general
+ * whitespace predicate.
+ */
+function isReviewMathSpaceCharacter(character: string | undefined): boolean {
+  return character === undefined || character === " " || character === "\t";
+}
+
+function isReviewMathDigitCharacter(character: string | undefined): boolean {
+  return character !== undefined && REVIEW_MATH_DIGIT_PATTERN.test(character);
+}
+
+function readDollarRuns(lineValue: string): ReadonlyArray<ReviewDollarRun> {
+  const runs: Array<ReviewDollarRun> = [];
+  let column = 0;
+
+  while (column < lineValue.length) {
+    if (lineValue[column] === "\\") {
+      column += 2;
+      continue;
+    }
+
+    if (lineValue[column] !== "$") {
+      column += 1;
+      continue;
+    }
+
+    let runLength = 1;
+    while (lineValue[column + runLength] === "$") {
+      runLength += 1;
+    }
+
+    runs.push({ length: runLength, startColumn: column });
+    column += runLength;
+  }
+
+  return runs;
+}
+
+function readBacktickRunLength(region: string, runStartOffset: number): number {
+  let runLength = 1;
+  while (region[runStartOffset + runLength] === "`") {
+    runLength += 1;
+  }
+
+  return runLength;
+}
+
+/**
+ * Joins the scanned lines back into one contiguous region, because CommonMark
+ * resolves an inline code span inside one block and a span may cross a line
+ * break of the paragraph. Each line ending contributes as many characters as it
+ * holds, so `lines[firstLineIndex].startIndex + offset` stays the source index.
+ */
+function readParagraphRegion(
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+  firstLineIndex: number,
+  lastLineIndex: number,
+): string {
+  let region = lines[firstLineIndex].value;
+
+  for (let lineIndex = firstLineIndex + 1; lineIndex <= lastLineIndex; lineIndex += 1) {
+    const line = lines[lineIndex];
+    region += "\n".repeat(line.startIndex - lines[lineIndex - 1].endIndex);
+    region += line.value;
+  }
+
+  return region;
+}
+
+/**
+ * Finds the run that closes a code span opened by a run of `openingRunLength`
+ * backticks. Backslash escapes do not work inside a code span, so this scan
+ * applies no escape handling at all: a backtick run directly after a backslash
+ * still closes the span, which is how CommonMark reads `` `foo\` ``.
+ */
+function findClosingBacktickRunOffset(
+  region: string,
+  searchStartOffset: number,
+  openingRunLength: number,
+): number | null {
+  let offset = searchStartOffset;
+
+  while (offset < region.length) {
+    if (region[offset] !== "`") {
+      offset += 1;
+      continue;
+    }
+
+    const runLength = readBacktickRunLength(region, offset);
+    if (runLength === openingRunLength) {
+      return offset;
+    }
+
+    offset += runLength;
+  }
+
+  return null;
+}
+
+/**
+ * Reads the source ranges the inline code spans of one paragraph cover. Code
+ * spans take precedence over math and are never scanned for math delimiters, so
+ * a dollar inside one of these ranges neither opens nor closes a formula and is
+ * never escaped.
+ *
+ * The scan carries the open and closed state through a single pass, because
+ * escape handling differs on the two sides of a span boundary: outside a span
+ * `` \` `` is an escaped backtick that opens nothing, while inside one the
+ * backslash is literal content that must never hide the closing run.
+ */
+function readParagraphCodeSpanRanges(
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+  firstLineIndex: number,
+  lastLineIndex: number,
+): ReadonlyArray<ReviewSourceRange> {
+  const region = readParagraphRegion(lines, firstLineIndex, lastLineIndex);
+  const regionStartIndex = lines[firstLineIndex].startIndex;
+  const ranges: Array<ReviewSourceRange> = [];
+  let offset = 0;
+
+  while (offset < region.length) {
+    if (region[offset] === "\\") {
+      offset += 2;
+      continue;
+    }
+
+    if (region[offset] !== "`") {
+      offset += 1;
+      continue;
+    }
+
+    const openingRunLength = readBacktickRunLength(region, offset);
+    const closingRunOffset = findClosingBacktickRunOffset(region, offset + openingRunLength, openingRunLength);
+    if (closingRunOffset === null) {
+      // The run opens no span, so it is literal text and the scan resumes right
+      // after it with escape handling active again.
+      offset += openingRunLength;
+      continue;
+    }
+
+    ranges.push({
+      endIndex: regionStartIndex + closingRunOffset + openingRunLength,
+      startIndex: regionStartIndex + offset,
+    });
+    offset = closingRunOffset + openingRunLength;
+  }
+
+  return ranges;
+}
+
+function isInsideCodeSpan(index: number, codeSpanRanges: ReadonlyArray<ReviewSourceRange>): boolean {
+  return codeSpanRanges.some((range) => index >= range.startIndex && index < range.endIndex);
+}
+
+/**
+ * Scans one source line for inline formulas using the pandoc `tex_math_dollars`
+ * delimiter guards. Only a run of exactly one dollar can delimit inline math,
+ * inline math never spans lines, and a dollar a code span covers is not part of
+ * the scan at all.
+ */
+function scanInlineMathSpans(
+  line: ReviewMarkdownLine,
+  codeSpanRanges: ReadonlyArray<ReviewSourceRange>,
+): ReadonlyArray<ReviewMathConstruct> {
+  const runs = readDollarRuns(line.value).filter((run) => (
+    isInsideCodeSpan(line.startIndex + run.startColumn, codeSpanRanges) === false
+  ));
+  const spans: Array<ReviewMathConstruct> = [];
+  let runIndex = 0;
+
+  while (runIndex < runs.length) {
+    const openingRun = runs[runIndex];
+    if (openingRun.length !== 1 || isReviewMathSpaceCharacter(line.value[openingRun.startColumn + 1])) {
+      runIndex += 1;
+      continue;
+    }
+
+    if (runIndex + 1 >= runs.length) {
+      // The line holds no later dollar, so nothing on it is left to scan.
+      break;
+    }
+
+    const closingRun = runs[runIndex + 1];
+    if (closingRun.length !== 1) {
+      // The attempt fails at the display fence sequence, and the scan continues
+      // after that whole run.
+      runIndex += 2;
+      continue;
+    }
+
+    if (
+      isReviewMathSpaceCharacter(line.value[closingRun.startColumn - 1])
+      || isReviewMathDigitCharacter(line.value[closingRun.startColumn + 1])
+    ) {
+      // The dollar that failed as a closer is the next candidate opener.
+      runIndex += 1;
+      continue;
+    }
+
+    spans.push({
+      endIndex: line.startIndex + closingRun.startColumn + 1,
+      formulaSource: line.value.slice(openingRun.startColumn + 1, closingRun.startColumn),
+      startIndex: line.startIndex + openingRun.startColumn,
+    });
+    runIndex += 2;
+  }
+
+  return spans;
+}
+
+/**
+ * Reads the display formula that opens on `lineIndex`, following the source-level
+ * rules of `docs/review-markdown-rendering.md`. The opening run must begin its
+ * own top-level block, and the closing run must hold exactly as many dollars as
+ * the opening run.
+ */
+function readDisplayMathConstruct(
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+  lineIndex: number,
+): ReviewMathConstruct | null {
+  const openingLine = lines[lineIndex];
+  const openingLineRuns = readDollarRuns(openingLine.value);
+  if (openingLineRuns.length === 0) {
+    return null;
+  }
+
+  const openingRun = openingLineRuns[0];
+  if (
+    openingRun.length < 2
+    || REVIEW_MATH_OPENING_RUN_INDENT_PATTERN.test(openingLine.value.slice(0, openingRun.startColumn)) === false
+    || (lineIndex > 0 && isBlankReviewMarkdownLine(lines[lineIndex - 1]) === false)
+  ) {
+    return null;
+  }
+
+  const startIndex = openingLine.startIndex + openingRun.startColumn;
+  const bodyStartColumn = openingRun.startColumn + openingRun.length;
+
+  if (openingLineRuns.length > 1) {
+    const closingRun = openingLineRuns[1];
+    if (
+      closingRun.length !== openingRun.length
+      || REVIEW_MATH_SPACE_ONLY_PATTERN.test(
+        openingLine.value.slice(closingRun.startColumn + closingRun.length),
+      ) === false
+      || (lineIndex + 1 < lines.length && isBlankReviewMarkdownLine(lines[lineIndex + 1]) === false)
+    ) {
+      return null;
+    }
+
+    return {
+      endIndex: openingLine.startIndex + closingRun.startColumn + closingRun.length,
+      formulaSource: openingLine.value.slice(bodyStartColumn, closingRun.startColumn),
+      startIndex,
+    };
+  }
+
+  if (REVIEW_MATH_SPACE_ONLY_PATTERN.test(openingLine.value.slice(bodyStartColumn)) === false) {
+    return null;
+  }
+
+  for (let closingLineIndex = lineIndex + 1; closingLineIndex < lines.length; closingLineIndex += 1) {
+    const closingLine = lines[closingLineIndex];
+    const closingLineRuns = readDollarRuns(closingLine.value);
+    if (closingLineRuns.length !== 1) {
+      continue;
+    }
+
+    const closingRun = closingLineRuns[0];
+    if (
+      REVIEW_MATH_OPENING_RUN_INDENT_PATTERN.test(closingLine.value.slice(0, closingRun.startColumn)) === false
+      || REVIEW_MATH_SPACE_ONLY_PATTERN.test(
+        closingLine.value.slice(closingRun.startColumn + closingRun.length),
+      ) === false
+    ) {
+      continue;
+    }
+
+    if (closingRun.length !== openingRun.length) {
+      return null;
+    }
+
+    return {
+      endIndex: closingLine.startIndex + closingRun.startColumn + closingRun.length,
+      formulaSource: lines
+        .slice(lineIndex + 1, closingLineIndex)
+        .map((bodyLine) => bodyLine.value)
+        .join("\n"),
+      startIndex,
+    };
+  }
+
+  return null;
+}
+
+function requireNodeSource(text: string, node: Nodes): ReviewNodeSource {
   const startIndex = node.position?.start.offset;
   const endIndex = node.position?.end.offset;
   if (startIndex === undefined || endIndex === undefined) {
@@ -36,63 +421,46 @@ function requireNodeSource(text: string, node: Nodes): ReviewMathSource {
   return {
     delimitedSource: text.slice(startIndex, endIndex),
     endIndex,
-    formulaSource: node.type === "math" || node.type === "inlineMath" ? node.value : "",
     startIndex,
   };
 }
 
-function readInlineMathSource(text: string, node: Nodes): ReviewMathSource | null {
+/**
+ * Accepts a display formula for a flow math node whose opening run begins an
+ * accepted display construct in the source. `remark-math` emits a flow math node
+ * only for the multiple-line shape; the single-line shape arrives as an inline
+ * math node and `scanParagraphMath` promotes it to display.
+ */
+function readDisplayMathNodeSource(
+  text: string,
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+  node: Nodes,
+): ReviewMathSource | null {
   const source = requireNodeSource(text, node);
-  const delimitedSource = source.delimitedSource;
-  if (
-    delimitedSource.length < 2
-    || delimitedSource.startsWith("$$")
-    || delimitedSource.endsWith("$$")
-    || /[\r\n]/.test(delimitedSource)
-  ) {
-    return null;
-  }
-
-  let precedingBackslashCount = 0;
-  for (let index = delimitedSource.length - 2; index >= 0 && delimitedSource[index] === "\\"; index -= 1) {
-    precedingBackslashCount += 1;
-  }
-  if (precedingBackslashCount % 2 !== 0) {
+  const construct = readDisplayMathConstruct(lines, findReviewLineIndex(lines, source.startIndex));
+  if (construct === null || construct.startIndex !== source.startIndex) {
     return null;
   }
 
   return {
     ...source,
-    formulaSource: delimitedSource.slice(1, -1),
+    formulaSource: construct.formulaSource,
+    mathMode: "display",
   };
 }
 
-function readDisplayMathSource(text: string, node: Nodes): ReviewMathSource | null {
-  const source = requireNodeSource(text, node);
-  const openMatch = DISPLAY_MATH_OPEN_PATTERN.exec(source.delimitedSource);
-  const closeMatch = DISPLAY_MATH_CLOSE_PATTERN.exec(source.delimitedSource);
-  if (openMatch === null || closeMatch === null || openMatch[0].length > closeMatch.index) {
-    return null;
-  }
-
-  return {
-    ...source,
-    formulaSource: source.delimitedSource.slice(openMatch[0].length, closeMatch.index),
-  };
-}
-
-function sourceKey(source: ReviewMathSource): string {
+function sourceKey(source: Readonly<{ endIndex: number; startIndex: number }>): string {
   return `${source.startIndex}:${source.endIndex}`;
 }
 
-function nodeSourceKey(node: Nodes): string {
+function readNodeSourceKey(node: Nodes): string | null {
   const startIndex = node.position?.start.offset;
   const endIndex = node.position?.end.offset;
   if (startIndex === undefined || endIndex === undefined) {
-    throw new Error(`Review math parser returned a ${node.type} node without source offsets`);
+    return null;
   }
 
-  return `${startIndex}:${endIndex}`;
+  return sourceKey({ endIndex, startIndex });
 }
 
 function containsReferenceDefinition(tree: Root): boolean {
@@ -104,38 +472,165 @@ function containsReferenceDefinition(tree: Root): boolean {
   return containsDefinition;
 }
 
+/**
+ * Reads every formula the source rules accept inside one top-level paragraph.
+ * The escape pass and the accept pass segment a paragraph with this one scan, so
+ * they can never disagree about the same card side.
+ */
+function scanParagraphMath(
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+  paragraph: ReviewNodeSource,
+): ReviewParagraphMathScan {
+  const firstLineIndex = findReviewLineIndex(lines, paragraph.startIndex);
+  const lastLineIndex = findReviewLineIndex(lines, paragraph.endIndex);
+  const displayConstruct = readDisplayMathConstruct(lines, firstLineIndex);
+
+  if (
+    displayConstruct !== null
+    && displayConstruct.startIndex === paragraph.startIndex
+    && displayConstruct.endIndex === paragraph.endIndex
+  ) {
+    // A display body is LaTeX source rather than Markdown, so it holds no code
+    // spans and every dollar in the paragraph belongs to the construct.
+    return {
+      codeSpanRanges: [],
+      constructs: [displayConstruct],
+      firstLineIndex,
+      lastLineIndex,
+      mathMode: "display",
+    };
+  }
+
+  const codeSpanRanges = readParagraphCodeSpanRanges(lines, firstLineIndex, lastLineIndex);
+  const constructs: Array<ReviewMathConstruct> = [];
+
+  for (let lineIndex = firstLineIndex; lineIndex <= lastLineIndex; lineIndex += 1) {
+    constructs.push(...scanInlineMathSpans(lines[lineIndex], codeSpanRanges));
+  }
+
+  return {
+    codeSpanRanges,
+    constructs,
+    firstLineIndex,
+    lastLineIndex,
+    mathMode: "inline",
+  };
+}
+
+/**
+ * Math is eligible only in a top-level paragraph whose children are ordinary text
+ * or formula spans. `remark-math` segments a paragraph more loosely than the
+ * source rules do, so a child the scan places inside an accepted formula is part
+ * of that formula source and does not make the paragraph ineligible. An inline
+ * code span is neither, so a paragraph that holds one outside every formula keeps
+ * its dollars literal.
+ */
+function isMathEligibleParagraph(
+  node: Extract<RootContent, { type: "paragraph" }>,
+  constructs: ReadonlyArray<ReviewMathConstruct>,
+): boolean {
+  return node.children.every((paragraphChild) => {
+    if (paragraphChild.type === "text" || paragraphChild.type === "inlineMath") {
+      return true;
+    }
+
+    const startIndex = paragraphChild.position?.start.offset;
+    const endIndex = paragraphChild.position?.end.offset;
+    if (startIndex === undefined || endIndex === undefined) {
+      return false;
+    }
+
+    return constructs.some((construct) => (
+      startIndex >= construct.startIndex && endIndex <= construct.endIndex
+    ));
+  });
+}
+
+/**
+ * Reads the source keys of the nodes an accepted construct of one paragraph can
+ * become. The transform renders a formula by replacing the node whose source
+ * range matches the construct exactly, so a construct the parser segments
+ * differently has no node to render into and has to stay literal on every path.
+ *
+ * `remark-math` consumes a text-math span raw and honours no backslash escape
+ * inside it, so `The price $p = \$5$ today.` is such a construct: the source
+ * rules close it on the last dollar, the parser closes it on the escaped one, and
+ * only the parser's boundaries can be rendered. Anchoring acceptance to the node
+ * keeps rendering, presentation selection, and speech on one literal answer
+ * instead of speaking a formula the card never shows.
+ *
+ * A single-line display construct is handed over as an `inlineMath` child rather
+ * than a flow math node, and `transformRootChildren` promotes it only when it is
+ * the paragraph's only child, so display acceptance tests exactly that shape.
+ */
+function readParagraphMathNodeKeys(
+  node: Extract<RootContent, { type: "paragraph" }>,
+  mathMode: ReviewMathMode,
+): ReadonlySet<string> {
+  if (mathMode === "display") {
+    if (node.children.length !== 1) {
+      return new Set<string>();
+    }
+
+    const onlyChild = node.children[0];
+    if (onlyChild.type !== "inlineMath") {
+      return new Set<string>();
+    }
+
+    const promotableKey = readNodeSourceKey(onlyChild);
+    return new Set<string>(promotableKey === null ? [] : [promotableKey]);
+  }
+
+  const nodeKeys = new Set<string>();
+  visit(node, "inlineMath", (inlineMathNode) => {
+    const nodeKey = readNodeSourceKey(inlineMathNode);
+    if (nodeKey !== null) {
+      nodeKeys.add(nodeKey);
+    }
+  });
+
+  return nodeKeys;
+}
+
 function collectAcceptedReviewMathSources(tree: Root, text: string): ReadonlyArray<ReviewMathSource> {
   if (containsReferenceDefinition(tree)) {
     return [];
   }
 
+  const lines = splitReviewMarkdownLines(text);
   const sources: Array<ReviewMathSource> = [];
+
   for (const child of tree.children) {
     if (child.type === "math") {
-      const source = readDisplayMathSource(text, child);
+      const source = readDisplayMathNodeSource(text, lines, child);
       if (source !== null) {
         sources.push(source);
       }
       continue;
     }
 
-    if (
-      child.type !== "paragraph"
-      || child.children.every((paragraphChild) => (
-        paragraphChild.type === "text" || paragraphChild.type === "inlineMath"
-      )) === false
-    ) {
+    if (child.type !== "paragraph") {
       continue;
     }
 
-    for (const paragraphChild of child.children) {
-      if (paragraphChild.type !== "inlineMath") {
+    const scan = scanParagraphMath(lines, requireNodeSource(text, child));
+    if (isMathEligibleParagraph(child, scan.constructs) === false) {
+      continue;
+    }
+
+    const nodeKeys = readParagraphMathNodeKeys(child, scan.mathMode);
+    for (const construct of scan.constructs) {
+      if (nodeKeys.has(sourceKey(construct)) === false) {
         continue;
       }
-      const source = readInlineMathSource(text, paragraphChild);
-      if (source !== null) {
-        sources.push(source);
-      }
+
+      sources.push({
+        delimitedSource: text.slice(construct.startIndex, construct.endIndex),
+        endIndex: construct.endIndex,
+        formulaSource: construct.formulaSource,
+        mathMode: scan.mathMode,
+        startIndex: construct.startIndex,
+      });
     }
   }
 
@@ -156,7 +651,7 @@ function createContainerMathLiteral(node: Extract<Nodes, { type: "math" }>): str
   return `${openingDelimiter}\n${node.value}\n$$`;
 }
 
-function markAcceptedMath(node: Extract<Nodes, { type: "math" }>, source: ReviewMathSource): void {
+function markAcceptedDisplayMath(node: Extract<Nodes, { type: "math" }>, source: ReviewMathSource): void {
   node.value = source.formulaSource;
   node.meta = null;
   node.data = {
@@ -170,7 +665,20 @@ function markAcceptedMath(node: Extract<Nodes, { type: "math" }>, source: Review
   };
 }
 
-function createAcceptedInlineMathBlock(
+function markAcceptedInlineMath(node: Extract<Nodes, { type: "inlineMath" }>, source: ReviewMathSource): void {
+  node.value = source.formulaSource;
+  node.data = {
+    hName: "span",
+    hProperties: {
+      className: ["review-math-inline"],
+      "data-formula-source": source.formulaSource,
+      "data-delimited-source": source.delimitedSource,
+    },
+    hChildren: [],
+  };
+}
+
+function createPromotedDisplayMath(
   node: Extract<Nodes, { type: "inlineMath" }>,
   source: ReviewMathSource,
 ): Extract<RootContent, { type: "math" }> {
@@ -180,44 +688,54 @@ function createAcceptedInlineMathBlock(
     meta: null,
     position: node.position,
   };
-  markAcceptedMath(mathNode, source);
+  markAcceptedDisplayMath(mathNode, source);
   return mathNode;
 }
 
-function splitAcceptedMathParagraph(
-  paragraph: Paragraph,
+function transformRootChildren(
+  children: ReadonlyArray<RootContent>,
+  text: string,
   acceptedSourcesByKey: ReadonlyMap<string, ReviewMathSource>,
-): ReadonlyArray<RootContent> {
-  const blocks: Array<RootContent> = [];
-  let textChildren: Paragraph["children"] = [];
+): Array<RootContent> {
+  const transformedChildren: Array<RootContent> = [];
 
-  function flushTextChildren(): void {
-    if (textChildren.length === 0) {
-      return;
-    }
-    blocks.push({
-      type: "paragraph",
-      children: textChildren,
-    });
-    textChildren = [];
-  }
-
-  for (const child of paragraph.children) {
-    if (child.type === "inlineMath") {
-      const source = acceptedSourcesByKey.get(nodeSourceKey(child));
-      if (source === undefined) {
-        throw new Error("Review math guard lost an accepted inline formula during paragraph splitting");
+  for (const child of children) {
+    if (child.type === "math") {
+      const source = requireNodeSource(text, child);
+      const acceptedSource = acceptedSourcesByKey.get(sourceKey(source));
+      if (acceptedSource !== undefined) {
+        markAcceptedDisplayMath(child, acceptedSource);
+        transformedChildren.push(child);
+        continue;
       }
-      flushTextChildren();
-      blocks.push(createAcceptedInlineMathBlock(child, source));
+
+      transformedChildren.push({
+        type: "paragraph",
+        children: [{
+          type: "text",
+          value: source.delimitedSource,
+          position: child.position,
+        }],
+        position: child.position,
+      });
       continue;
     }
 
-    textChildren.push(child);
-  }
-  flushTextChildren();
+    if (child.type === "paragraph" && child.children.length === 1) {
+      const onlyChild = child.children[0];
+      if (onlyChild.type === "inlineMath") {
+        const acceptedSource = acceptedSourcesByKey.get(sourceKey(requireNodeSource(text, onlyChild)));
+        if (acceptedSource !== undefined && acceptedSource.mathMode === "display") {
+          transformedChildren.push(createPromotedDisplayMath(onlyChild, acceptedSource));
+          continue;
+        }
+      }
+    }
 
-  return blocks;
+    transformedChildren.push(child);
+  }
+
+  return transformedChildren;
 }
 
 export function transformReviewMathBlocks(tree: Root, text: string): Root {
@@ -225,10 +743,14 @@ export function transformReviewMathBlocks(tree: Root, text: string): Root {
   const acceptedSources = collectAcceptedReviewMathSources(transformedTree, text);
   const acceptedSourcesByKey = new Map(acceptedSources.map((source) => [sourceKey(source), source]));
 
+  transformedTree.children = transformRootChildren(transformedTree.children, text, acceptedSourcesByKey);
+
   // This guard is the intentional V1 cross-client boundary for eligible formula topology.
   visit(transformedTree, "inlineMath", (node, index, parent) => {
     const source = requireNodeSource(text, node);
-    if (acceptedSourcesByKey.has(sourceKey(source))) {
+    const acceptedSource = acceptedSourcesByKey.get(sourceKey(source));
+    if (acceptedSource !== undefined && acceptedSource.mathMode === "inline") {
+      markAcceptedInlineMath(node, acceptedSource);
       return;
     }
     replaceParentChild(parent, index, {
@@ -240,17 +762,15 @@ export function transformReviewMathBlocks(tree: Root, text: string): Root {
   });
 
   visit(transformedTree, "math", (node, index, parent) => {
-    const source = requireNodeSource(text, node);
-    const acceptedSource = acceptedSourcesByKey.get(sourceKey(source));
-    if (acceptedSource !== undefined) {
-      markAcceptedMath(node, acceptedSource);
+    if (parent?.type === "root") {
+      // Top-level display math is already accepted or literalized above.
       return;
     }
     replaceParentChild(parent, index, {
       type: "paragraph",
       children: [{
         type: "text",
-        value: parent?.type === "root" ? source.delimitedSource : createContainerMathLiteral(node),
+        value: createContainerMathLiteral(node),
         position: node.position,
       }],
       position: node.position,
@@ -258,20 +778,165 @@ export function transformReviewMathBlocks(tree: Root, text: string): Root {
     return SKIP;
   });
 
-  transformedTree.children = transformedTree.children.flatMap((child) => {
-    if (child.type !== "paragraph" || child.children.some((paragraphChild) => paragraphChild.type === "inlineMath") === false) {
-      return [child];
-    }
-    return splitAcceptedMathParagraph(child, acceptedSourcesByKey);
-  });
-
   return transformedTree;
 }
 
 const reviewMathProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
 
+/**
+ * Collects every dollar sign inside a top-level block that the source rules leave
+ * literal. Dollars an inline code span covers are not math delimiters and are
+ * never escaped, because a backslash inside a code span is literal text rather
+ * than an escape. A rejected display fence contributes only its opening run: the
+ * re-parse then returns whatever that fence swallowed to ordinary Markdown.
+ */
+function collectRejectedDollarIndexes(
+  tree: Root,
+  text: string,
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+): ReadonlyArray<number> {
+  const rejectedIndexes: Array<number> = [];
+
+  for (const child of tree.children) {
+    if (child.type === "math") {
+      if (readDisplayMathNodeSource(text, lines, child) !== null) {
+        continue;
+      }
+      rejectedIndexes.push(...readRejectedDisplayFenceIndexes(text, lines, child));
+      continue;
+    }
+
+    if (child.type !== "paragraph") {
+      continue;
+    }
+
+    const scan = scanParagraphMath(lines, requireNodeSource(text, child));
+    if (isMathEligibleParagraph(child, scan.constructs) === false) {
+      continue;
+    }
+
+    for (let lineIndex = scan.firstLineIndex; lineIndex <= scan.lastLineIndex; lineIndex += 1) {
+      const line = lines[lineIndex];
+      for (const run of readDollarRuns(line.value)) {
+        const runStartIndex = line.startIndex + run.startColumn;
+        if (isInsideCodeSpan(runStartIndex, scan.codeSpanRanges)) {
+          continue;
+        }
+
+        const isAccepted = scan.constructs.some((construct) => (
+          runStartIndex >= construct.startIndex && runStartIndex < construct.endIndex
+        ));
+        if (isAccepted) {
+          continue;
+        }
+
+        for (let runOffset = 0; runOffset < run.length; runOffset += 1) {
+          rejectedIndexes.push(runStartIndex + runOffset);
+        }
+      }
+    }
+  }
+
+  return rejectedIndexes;
+}
+
+function readRejectedDisplayFenceIndexes(
+  text: string,
+  lines: ReadonlyArray<ReviewMarkdownLine>,
+  node: Extract<RootContent, { type: "math" }>,
+): ReadonlyArray<number> {
+  const source = requireNodeSource(text, node);
+  const line = lines[findReviewLineIndex(lines, source.startIndex)];
+  const openingRun = readDollarRuns(line.value).find((run) => (
+    line.startIndex + run.startColumn >= source.startIndex
+  ));
+  if (openingRun === undefined) {
+    throw new Error("Review math guard could not locate the opening run of a rejected display formula");
+  }
+
+  const openingRunStartIndex = line.startIndex + openingRun.startColumn;
+  const indexes: Array<number> = [];
+  for (let runOffset = 0; runOffset < openingRun.length; runOffset += 1) {
+    indexes.push(openingRunStartIndex + runOffset);
+  }
+
+  return indexes;
+}
+
+function escapeRejectedReviewMathDollarsOnce(text: string): string {
+  const tree = reviewMathProcessor.parse(text);
+  if (containsReferenceDefinition(tree)) {
+    return text;
+  }
+
+  // The rewrite below copies the source forward once, so the indexes have to be
+  // strictly ascending: a repeated or backwards index would duplicate source text
+  // instead of escaping a dollar.
+  const rejectedIndexes = [
+    ...new Set(collectRejectedDollarIndexes(tree, text, splitReviewMarkdownLines(text))),
+  ].sort((leftIndex, rightIndex) => leftIndex - rightIndex);
+  let escapedText = "";
+  let copiedIndex = 0;
+
+  for (const rejectedIndex of rejectedIndexes) {
+    escapedText += `${text.slice(copiedIndex, rejectedIndex)}\\`;
+    copiedIndex = rejectedIndex;
+  }
+
+  return escapedText + text.slice(copiedIndex);
+}
+
+/**
+ * Escapes every dollar sign the math contract leaves literal, so `remark-math`
+ * segments the card side exactly the way the source rules do before the transform
+ * confirms each node.
+ *
+ * `remark-math` closes a text-math span on the first later run of the same size
+ * and applies no delimiter guards, so it can swallow a span this contract
+ * accepts: `A $100 bond with yield $r$ pays` arrives as a single `inlineMath`
+ * node holding `100 bond with yield `, with no node left for `$r$`. An
+ * unterminated flow fence is worse still and swallows the whole remainder of the
+ * side, Markdown and all.
+ *
+ * Escaping only ever adds a backslash in front of a dollar the source rules
+ * already reject, so it can never change which formulas are accepted. Escaping a
+ * rejected fence changes which blocks the parser sees, so the pass repeats until
+ * the source stops changing; each pass escapes at least one previously unescaped
+ * dollar and never adds one, so the dollar count bounds the number of passes.
+ */
+export function escapeRejectedReviewMathDollars(text: string): string {
+  const passLimit = text.split("$").length;
+  let escapedText = text;
+
+  for (let pass = 0; pass < passLimit; pass += 1) {
+    const nextText = escapeRejectedReviewMathDollarsOnce(escapedText);
+    if (nextText === escapedText) {
+      return escapedText;
+    }
+    escapedText = nextText;
+  }
+
+  throw new Error("Review math escaping did not converge for the card side");
+}
+
+/**
+ * Reads the accepted formulas of a card side through the same escape pass the
+ * review screen renders with, so presentation selection, rendering, and speech
+ * can never disagree about which spans are formulas.
+ */
+function collectEscapedReviewMathSources(text: string): Readonly<{
+  escapedText: string;
+  sources: ReadonlyArray<ReviewMathSource>;
+}> {
+  const escapedText = escapeRejectedReviewMathDollars(text);
+  return {
+    escapedText,
+    sources: collectAcceptedReviewMathSources(reviewMathProcessor.parse(escapedText), escapedText),
+  };
+}
+
 export function hasEligibleReviewMath(text: string): boolean {
-  return collectAcceptedReviewMathSources(reviewMathProcessor.parse(text), text).length > 0;
+  return collectEscapedReviewMathSources(text).sources.length > 0;
 }
 
 export function normalizeReviewPlainTextEscapedDollars(text: string): string {
@@ -295,19 +960,31 @@ export function normalizeReviewPlainTextEscapedDollars(text: string): string {
   return normalizedCharacters.join("");
 }
 
+/**
+ * Prose is sliced out of the escaped source, so the dollars the escape pass added
+ * a backslash to are read back as the literal dollars the author wrote.
+ */
+function createReviewMathProseSegment(
+  escapedText: string,
+  startIndex: number,
+  endIndex: number,
+): ReviewMathSpeechSegment {
+  return {
+    kind: "prose",
+    startsAtLineBoundary: startIndex === 0 || /[\r\n]/.test(escapedText[startIndex - 1] ?? ""),
+    value: normalizeReviewPlainTextEscapedDollars(escapedText.slice(startIndex, endIndex)),
+  };
+}
+
 export function splitEligibleReviewMathForSpeech(text: string): ReadonlyArray<ReviewMathSpeechSegment> {
-  const sources = [...collectAcceptedReviewMathSources(reviewMathProcessor.parse(text), text)]
-    .sort((left, right) => left.startIndex - right.startIndex);
+  const { escapedText, sources } = collectEscapedReviewMathSources(text);
+  const orderedSources = [...sources].sort((left, right) => left.startIndex - right.startIndex);
   const segments: Array<ReviewMathSpeechSegment> = [];
   let sourceCursor = 0;
 
-  for (const source of sources) {
+  for (const source of orderedSources) {
     if (source.startIndex > sourceCursor) {
-      segments.push({
-        kind: "prose",
-        startsAtLineBoundary: sourceCursor === 0 || /[\r\n]/.test(text[sourceCursor - 1] ?? ""),
-        value: text.slice(sourceCursor, source.startIndex),
-      });
+      segments.push(createReviewMathProseSegment(escapedText, sourceCursor, source.startIndex));
     }
     segments.push({
       kind: "formula",
@@ -316,12 +993,8 @@ export function splitEligibleReviewMathForSpeech(text: string): ReadonlyArray<Re
     sourceCursor = source.endIndex;
   }
 
-  if (sourceCursor < text.length || segments.length === 0) {
-    segments.push({
-      kind: "prose",
-      startsAtLineBoundary: sourceCursor === 0 || /[\r\n]/.test(text[sourceCursor - 1] ?? ""),
-      value: text.slice(sourceCursor),
-    });
+  if (sourceCursor < escapedText.length || segments.length === 0) {
+    segments.push(createReviewMathProseSegment(escapedText, sourceCursor, escapedText.length));
   }
 
   return segments;

--- a/apps/web/src/styles/features/review/review-markdown.css
+++ b/apps/web/src/styles/features/review/review-markdown.css
@@ -47,14 +47,33 @@
   overflow-x: auto;
 }
 
-.review-math-block-canvas {
+.review-math-inline {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  color: var(--text);
+}
+
+.review-math-inline[data-render-status="failed"] {
+  display: inline;
+  overflow-x: visible;
+  color: var(--danger);
+}
+
+.review-math-inline-error-message {
+  margin-inline-start: 0.35em;
+}
+
+.review-math-block-canvas,
+.review-math-inline-canvas {
   display: block;
   width: auto;
   max-width: none;
   height: auto;
 }
 
-.review-math-block-canvas[hidden] {
+.review-math-block-canvas[hidden],
+.review-math-inline-canvas[hidden] {
   display: none;
 }
 


### PR DESCRIPTION
Implements the merged cross-client math contract (`docs/review-markdown-rendering.md`) on the web app review screen.

## What changes

- An accepted `$...$` span renders **on the text baseline inside its paragraph** instead of being hoisted into a standalone block.
- A `$$...$$` run that opens and closes on one line is display math.
- Currency amounts stay prose, per the pandoc delimiter guards.

## Why the parser is no longer trusted

`remark-math` closes text math on the first later `$` run of equal size and applies none of the pandoc guards. For a mixed currency-and-math side it hands over a node whose range is simply wrong, and the formula the contract requires has no node at all:

```
A $100 bond with yield $r$ pays
  -> paragraph[ text("A "), inlineMath("100 bond with yield "), text("r$ pays") ]
```

The contract's answer is the single formula `r`. So a source-level scanner decides, a pre-parse pass escapes every dollar the rules leave literal, and the re-parsed tree matches the contract. The escape pass **iterates to a fixed point**, because escaping a rejected `$$` fence opener changes which blocks the parser sees — that iteration is also what returns an unterminated fence's swallowed remainder to ordinary Markdown, which the sibling catalog website currently leaves literal.

Termination is bounded: escapes are only ever added, whole runs at a time, to previously-unescaped dollars, so the unescaped-dollar count strictly decreases and `passLimit = count + 1` covers every changing pass plus the terminating one. Two reviewers verified that argument independently.

## Acceptance is node-anchored

A construct is kept only when the escaped parse really contains a node at exactly those boundaries. Without this, a formula whose body contains `\$` — the contract's own recommended way to write a dollar — was announced by presentation selection and by speech while the render silently dropped it, showing the author's backslash raw. `HEAD` had been self-consistent there, so this was a regression the first draft introduced; the three paths now agree by construction.

## Inline baseline

`vertical-align: -(depth * fontSize + padding)`. Verified against `ratex-wasm@0.1.14` `dist/renderer.js`, which sizes the canvas as `ceil((height + depth) * em + 2 * pad)` and does `translate(pad, pad)` before drawing, so baseline-to-bottom is `depth * em + pad`. A negative depth is clamped so the style can never become an invalid `--Npx`.

## Tests

Adds a contract test pinning the 31-item parity fixture. Every case that asserts the speech path now also asserts the render path — the previous draft asserted speech only, which is exactly why the `\$` regression was invisible to the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)