### PR TITLE
Render iOS review inline math inline

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewCardSideView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewCardSideView.swift
@@ -116,13 +116,16 @@ struct ReviewCardSideView: View {
             VStack(alignment: .leading, spacing: 12) {
                 ForEach(managedMarkdownContent.blocks.indices, id: \.self) { index in
                     switch managedMarkdownContent.blocks[index] {
-                    case .markdown(let markdownContent):
+                    case .markdown(let markdownContent, let inlineMath):
                         ReviewMarkdownText(
                             markdownContent: markdownContent,
-                            surfaceStyle: surfaceStyle
+                            surfaceStyle: surfaceStyle,
+                            inlineMath: inlineMath
                         )
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                     case .formula(let formula):
+                        // Only display formulas remain standalone blocks; inline formulas stay
+                        // inside their paragraph.
                         ReviewMathFormulaView(
                             formula: formula,
                             surfaceStyle: surfaceStyle

--- a/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewContentPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewContentPresentation.swift
@@ -33,9 +33,17 @@ struct ReviewManagedMarkdownContent {
 }
 
 enum ReviewManagedMarkdownBlock {
-    case markdown(MarkdownContent)
+    /// A Markdown fragment together with only the accepted inline formulas it references.
+    case markdown(MarkdownContent, inlineMath: [ReviewInlineMathReference])
     case formula(ReviewFormulaContent)
     case managedMedia(ReviewManagedMediaReference)
+}
+
+/// An accepted inline formula together with the `fcmath:` source that addresses it from the
+/// Markdown fragment it lives in.
+struct ReviewInlineMathReference {
+    let source: String
+    let formula: ReviewFormulaContent
 }
 
 struct ReviewFormulaContent {
@@ -246,31 +254,110 @@ private func makeReviewSpeakableTextWithoutMath(
     return normalizeReviewSpeakableLines(lines: speakableLines)
 }
 
+/// Private scheme for accepted inline formulas routed through the Markdown inline image path.
+/// It never reaches card storage, and managed media parsing ignores it because
+/// `managedMediaAssetId(reference:)` requires the `fcasset:` prefix.
+let reviewInlineMathImageScheme = "fcmath"
+
+/// ASCII punctuation, which CommonMark lets a backslash escape back to the literal character.
+/// Escaping all of it keeps a LaTeX alt text from breaking out of the `![alt](url)` syntax.
+private let reviewMarkdownEscapableCharacters: Set<Character> = Set(##"!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##)
+
+/// The reference is content-derived so that two cards whose only difference is the formula parse
+/// to different inline nodes. Equal nodes would keep MarkdownUI's view identity, its cached
+/// `inlineImages` state, and its `.task(id:)`, and the previous card's formula would keep showing.
+private func reviewInlineMathImageSource(index: Int, latex: String) -> String {
+    "\(reviewInlineMathImageScheme):\(index)-\(reviewInlineMathDigest(latex: latex))"
+}
+
+/// FNV-1a over UTF-8. Deterministic across process launches, unlike Swift's seeded `Hasher`.
+private func reviewInlineMathDigest(latex: String) -> String {
+    var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+    for byte in latex.utf8 {
+        hash ^= UInt64(byte)
+        hash = hash &* 0x0000_0100_0000_01b3
+    }
+
+    let hexDigest = String(hash, radix: 16)
+    return String(repeating: "0", count: max(0, 16 - hexDigest.count)) + hexDigest
+}
+
+/// The alt text carries the LaTeX because a paragraph holding nothing but the formula reaches
+/// MarkdownUI's `ImageView`, which overrides the image label with `.accessibilityLabel(alt)`.
+private func makeReviewInlineMathImageReference(source: String, latex: String) -> String {
+    "![\(reviewMarkdownEscapedAltText(text: latex))](\(source))"
+}
+
+private func reviewMarkdownEscapedAltText(text: String) -> String {
+    var escapedText = ""
+    escapedText.reserveCapacity(text.count * 2)
+
+    for character in text {
+        if reviewMarkdownEscapableCharacters.contains(character) {
+            escapedText.append("\\")
+        }
+        escapedText.append(character)
+    }
+
+    return escapedText
+}
+
 private func makeReviewSegmentedMarkdownContent(
     mathBlocks: [ReviewMathBlock]
 ) -> ReviewManagedMarkdownContent {
     var blocks: [ReviewManagedMarkdownBlock] = []
-    var normalizesNextMarkdownFragment = false
+    var inlineMath: [ReviewInlineMathReference] = []
+    var pendingMarkdown = ""
+
+    func flushPendingMarkdown() {
+        let markdownText = pendingMarkdown
+        pendingMarkdown = ""
+        guard markdownText.isEmpty == false else {
+            return
+        }
+
+        if let managedMarkdownContent = makeReviewManagedMarkdownContent(
+            text: markdownText,
+            inlineMath: inlineMath
+        ) {
+            blocks.append(contentsOf: managedMarkdownContent.blocks)
+        } else {
+            appendReviewMarkdownBlock(text: markdownText, inlineMath: inlineMath, blocks: &blocks)
+        }
+    }
 
     for mathBlock in mathBlocks {
         switch mathBlock {
         case .markdown(let text):
-            let renderedText = normalizesNextMarkdownFragment
-                ? normalizeReviewInlineMathParagraphContinuation(markdown: text)
-                : text
-            if let managedMarkdownContent = makeReviewManagedMarkdownContent(text: renderedText) {
-                blocks.append(contentsOf: managedMarkdownContent.blocks)
-            } else {
-                appendReviewMarkdownBlock(text: renderedText, blocks: &blocks)
-            }
-            normalizesNextMarkdownFragment = false
+            pendingMarkdown += text
+        case .formula(let formula) where formula.continuesParagraph:
+            // An accepted inline formula stays inside its paragraph as an inline image reference.
+            let source = reviewInlineMathImageSource(index: inlineMath.count, latex: formula.latex)
+            pendingMarkdown += makeReviewInlineMathImageReference(source: source, latex: formula.latex)
+            inlineMath.append(ReviewInlineMathReference(source: source, formula: formula))
         case .formula(let formula):
+            flushPendingMarkdown()
             blocks.append(.formula(formula))
-            normalizesNextMarkdownFragment = formula.continuesParagraph
         }
     }
+    flushPendingMarkdown()
 
     return ReviewManagedMarkdownContent(blocks: blocks)
+}
+
+/// Each Markdown block gets only the formulas its own fragment addresses, so a render failure is
+/// reported once, under the block that actually holds the broken formula.
+private func reviewInlineMathReferences(
+    text: String,
+    inlineMath: [ReviewInlineMathReference]
+) -> [ReviewInlineMathReference] {
+    guard inlineMath.isEmpty == false else {
+        return []
+    }
+
+    return inlineMath.filter { reference in
+        text.contains(reference.source)
+    }
 }
 
 private func hasStrongMarkdownCue(text: String) -> Bool {
@@ -314,7 +401,10 @@ private func normalizeReviewSpeakableInlineText(text: String) -> String {
         .trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
-private func makeReviewManagedMarkdownContent(text: String) -> ReviewManagedMarkdownContent? {
+private func makeReviewManagedMarkdownContent(
+    text: String,
+    inlineMath: [ReviewInlineMathReference] = []
+) -> ReviewManagedMarkdownContent? {
     var activeFence: ReviewMathFence? = nil
     var pendingMarkdownLines: [String] = []
     var blocks: [ReviewManagedMarkdownBlock] = []
@@ -335,7 +425,7 @@ private func makeReviewManagedMarkdownContent(text: String) -> ReviewManagedMark
             continue
         }
 
-        let lineBlocks = splitReviewManagedMediaLine(line: line)
+        let lineBlocks = splitReviewManagedMediaLine(line: line, inlineMath: inlineMath)
         if lineBlocks.contains(where: { block in
             if case .managedMedia = block {
                 return true
@@ -346,12 +436,20 @@ private func makeReviewManagedMarkdownContent(text: String) -> ReviewManagedMark
             continue
         }
 
-        appendReviewPendingMarkdownBlocks(lines: &pendingMarkdownLines, blocks: &blocks)
+        appendReviewPendingMarkdownBlocks(
+            lines: &pendingMarkdownLines,
+            inlineMath: inlineMath,
+            blocks: &blocks
+        )
         blocks.append(contentsOf: lineBlocks)
         didFindManagedMedia = true
     }
 
-    appendReviewPendingMarkdownBlocks(lines: &pendingMarkdownLines, blocks: &blocks)
+    appendReviewPendingMarkdownBlocks(
+        lines: &pendingMarkdownLines,
+        inlineMath: inlineMath,
+        blocks: &blocks
+    )
     guard didFindManagedMedia else {
         return nil
     }
@@ -359,11 +457,14 @@ private func makeReviewManagedMarkdownContent(text: String) -> ReviewManagedMark
     return ReviewManagedMarkdownContent(blocks: blocks)
 }
 
-private func splitReviewManagedMediaLine(line: String) -> [ReviewManagedMarkdownBlock] {
+private func splitReviewManagedMediaLine(
+    line: String,
+    inlineMath: [ReviewInlineMathReference]
+) -> [ReviewManagedMarkdownBlock] {
     let fullRange = NSRange(line.startIndex..<line.endIndex, in: line)
     let matches = reviewManagedMediaReferenceExpression.matches(in: line, options: [], range: fullRange)
     guard matches.isEmpty == false else {
-        return [.markdown(makeReviewMarkdownContent(text: line))]
+        return makeReviewMarkdownOnlyBlocks(text: line, inlineMath: inlineMath)
     }
 
     var blocks: [ReviewManagedMarkdownBlock] = []
@@ -382,7 +483,7 @@ private func splitReviewManagedMediaLine(line: String) -> [ReviewManagedMarkdown
         }
 
         let precedingText = String(line[currentIndex..<matchRange.lowerBound])
-        appendReviewMarkdownBlock(text: precedingText, blocks: &blocks)
+        appendReviewMarkdownBlock(text: precedingText, inlineMath: inlineMath, blocks: &blocks)
 
         let label = reviewManagedMediaLabel(line: line, match: match)
         let isImageSyntax = match.range(at: 1).location != NSNotFound
@@ -401,28 +502,54 @@ private func splitReviewManagedMediaLine(line: String) -> [ReviewManagedMarkdown
     }
 
     guard didFindManagedMedia else {
-        return [.markdown(makeReviewMarkdownContent(text: line))]
+        return makeReviewMarkdownOnlyBlocks(text: line, inlineMath: inlineMath)
     }
 
-    appendReviewMarkdownBlock(text: String(line[currentIndex..<line.endIndex]), blocks: &blocks)
+    appendReviewMarkdownBlock(
+        text: String(line[currentIndex..<line.endIndex]),
+        inlineMath: inlineMath,
+        blocks: &blocks
+    )
     return blocks
+}
+
+private func makeReviewMarkdownOnlyBlocks(
+    text: String,
+    inlineMath: [ReviewInlineMathReference]
+) -> [ReviewManagedMarkdownBlock] {
+    [
+        .markdown(
+            makeReviewMarkdownContent(text: text),
+            inlineMath: reviewInlineMathReferences(text: text, inlineMath: inlineMath)
+        )
+    ]
 }
 
 private func appendReviewPendingMarkdownBlocks(
     lines: inout [String],
+    inlineMath: [ReviewInlineMathReference],
     blocks: inout [ReviewManagedMarkdownBlock]
 ) {
     let markdownText = lines.joined(separator: "\n")
     lines.removeAll()
-    appendReviewMarkdownBlock(text: markdownText, blocks: &blocks)
+    appendReviewMarkdownBlock(text: markdownText, inlineMath: inlineMath, blocks: &blocks)
 }
 
-private func appendReviewMarkdownBlock(text: String, blocks: inout [ReviewManagedMarkdownBlock]) {
+private func appendReviewMarkdownBlock(
+    text: String,
+    inlineMath: [ReviewInlineMathReference],
+    blocks: inout [ReviewManagedMarkdownBlock]
+) {
     guard text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
         return
     }
 
-    blocks.append(.markdown(makeReviewMarkdownContent(text: text)))
+    blocks.append(
+        .markdown(
+            makeReviewMarkdownContent(text: text),
+            inlineMath: reviewInlineMathReferences(text: text, inlineMath: inlineMath)
+        )
+    )
 }
 
 private func reviewManagedMediaLabel(line: String, match: NSTextCheckingResult) -> String? {

--- a/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMarkdownTheme.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMarkdownTheme.swift
@@ -2,6 +2,7 @@ import MarkdownUI
 import OSLog
 import RaTeX
 import SwiftUI
+import UIKit
 
 private let reviewMathFormulaLogger: Logger = Logger(
     subsystem: appBundleIdentifier(),
@@ -26,7 +27,7 @@ private func makeReviewMarkdownTheme(surfaceStyle: ReviewCardSurfaceStyle) -> Th
         .text {
             ForegroundColor(reviewMarkdownTextColor(surfaceStyle: surfaceStyle))
             BackgroundColor(nil)
-            FontSize(surfaceStyle == .front ? 18 : 17)
+            FontSize(reviewMarkdownTextFontSize(surfaceStyle: surfaceStyle))
         }
         .code {
             FontFamilyVariant(.monospaced)
@@ -164,6 +165,15 @@ private func makeReviewMarkdownTheme(surfaceStyle: ReviewCardSurfaceStyle) -> Th
         }
 }
 
+private func reviewMarkdownTextFontSize(surfaceStyle: ReviewCardSurfaceStyle) -> CGFloat {
+    switch surfaceStyle {
+    case .front:
+        return 18
+    case .back:
+        return 17
+    }
+}
+
 private func reviewMarkdownTextColor(surfaceStyle: ReviewCardSurfaceStyle) -> Color {
     switch surfaceStyle {
     case .front:
@@ -239,11 +249,84 @@ private func reviewMarkdownBorderColor(surfaceStyle: ReviewCardSurfaceStyle) -> 
 struct ReviewMarkdownText: View {
     let markdownContent: MarkdownContent
     let surfaceStyle: ReviewCardSurfaceStyle
+    let inlineMath: [ReviewInlineMathReference]
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.displayScale) private var displayScale
+    // Rasterized formulas must match the surrounding Markdown text, so both sizes come from
+    // `reviewMarkdownTextFontSize`. The theme applies it as an absolute `FontSize`, while
+    // `@ScaledMetric` additionally scales it with Dynamic Type.
+    @ScaledMetric(relativeTo: .body)
+    private var frontInlineFormulaFontSize: CGFloat = reviewMarkdownTextFontSize(surfaceStyle: .front)
+    @ScaledMetric(relativeTo: .body)
+    private var backInlineFormulaFontSize: CGFloat = reviewMarkdownTextFontSize(surfaceStyle: .back)
+
+    init(
+        markdownContent: MarkdownContent,
+        surfaceStyle: ReviewCardSurfaceStyle,
+        inlineMath: [ReviewInlineMathReference] = []
+    ) {
+        self.markdownContent = markdownContent
+        self.surfaceStyle = surfaceStyle
+        self.inlineMath = inlineMath
+    }
+
+    private var inlineFormulaFontSize: CGFloat {
+        switch self.surfaceStyle {
+        case .front:
+            return self.frontInlineFormulaFontSize
+        case .back:
+            return self.backInlineFormulaFontSize
+        }
+    }
+
+    private var inlineFormulaColor: UIColor {
+        UIColor(reviewMarkdownTextColor(surfaceStyle: self.surfaceStyle)).resolvedColor(
+            with: UITraitCollection { traits in
+                traits.userInterfaceStyle = self.colorScheme == .dark ? .dark : .light
+            }
+        )
+    }
+
+    // Inline formulas are rasterized, so the rendered Markdown must be rebuilt whenever the
+    // appearance, the Dynamic Type size, or the screen scale changes. The formula sources are
+    // folded in as well so that moving to a card whose only difference is the formula content
+    // cannot reuse the previous card's view identity and its cached inline images.
+    private var inlineFormulaRenderIdentity: String {
+        let sources = self.inlineMath.map(\.source).joined(separator: ",")
+        return "\(self.colorScheme)-\(self.inlineFormulaFontSize)-\(self.displayScale)-\(sources)"
+    }
+
+    private var localizedRenderError: String {
+        String(
+            localized: "Formula couldn't be rendered. Check the LaTeX syntax.",
+            table: "ReviewCards"
+        )
+    }
 
     var body: some View {
-        Markdown(markdownContent)
-            .markdownTheme(makeReviewMarkdownTheme(surfaceStyle: surfaceStyle))
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+        let rendering = makeReviewInlineMathRendering(
+            references: self.inlineMath,
+            fontSize: self.inlineFormulaFontSize,
+            color: self.inlineFormulaColor,
+            displayScale: self.displayScale
+        )
+
+        VStack(alignment: .leading, spacing: 6) {
+            Markdown(self.markdownContent)
+                .markdownTheme(makeReviewMarkdownTheme(surfaceStyle: self.surfaceStyle))
+                .markdownInlineImageProvider(ReviewMathInlineImageProvider(images: rendering.images))
+                .markdownImageProvider(ReviewMathBlockImageProvider(images: rendering.images))
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .id(self.inlineFormulaRenderIdentity)
+
+            if rendering.didFailRendering {
+                Label(self.localizedRenderError, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMathBlocks.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMathBlocks.swift
@@ -31,6 +31,17 @@ private struct ReviewInlineMathLine {
     let containsFormula: Bool
 }
 
+private struct ReviewMathDisplayConstruct {
+    let closingIndex: Int
+    let latex: String
+}
+
+private enum ReviewInlineMathClosingScan {
+    case candidate(String.Index)
+    case displayRun(String.Index)
+    case none
+}
+
 private let reviewMathReferenceDefinitionExpression = makeReviewContentRegularExpression(
     pattern: #"^ {0,3}\[(?:\\.|[^\\\]])+\]:"#
 )
@@ -61,7 +72,7 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
     while lineIndex < lines.count {
         let line = lines[lineIndex]
 
-        if line.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if reviewMathLineIsBlank(line: line.content) {
             pendingMarkdown += line.content + line.separator
             lineIndex += 1
             continue
@@ -96,13 +107,8 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
             continue
         }
 
-        if reviewMathLineIsDisplayDelimiter(line: line.content) {
-            guard let closingIndex = reviewMathDisplayClosingIndex(lines: lines, openingIndex: lineIndex) else {
-                pendingMarkdown += line.content + line.separator
-                lineIndex += 1
-                continue
-            }
-
+        // A display construct that fails any source rule stays literal and is rescanned as prose.
+        if let construct = reviewMathDisplayConstruct(lines: lines, openingIndex: lineIndex) {
             if pendingMarkdown.isEmpty == false {
                 blocks.append(.markdown(pendingMarkdown))
                 pendingMarkdown = ""
@@ -111,25 +117,20 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
             let originalSource = reviewMathDisplaySource(
                 lines: lines,
                 openingIndex: lineIndex,
-                closingIndex: closingIndex
-            )
-            let latex = reviewMathDisplayLatex(
-                lines: lines,
-                openingIndex: lineIndex,
-                closingIndex: closingIndex
+                closingIndex: construct.closingIndex
             )
             blocks.append(
                 .formula(
                     ReviewFormulaContent(
                         originalSource: originalSource,
-                        latex: latex,
+                        latex: construct.latex,
                         continuesParagraph: false
                     )
                 )
             )
-            pendingMarkdown += lines[closingIndex].separator
+            pendingMarkdown += lines[construct.closingIndex].separator
             didFindFormula = true
-            lineIndex = closingIndex + 1
+            lineIndex = construct.closingIndex + 1
             continue
         }
 
@@ -139,7 +140,7 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
 
             while lineIndex < lines.count {
                 while lineIndex < lines.count
-                    && lines[lineIndex].content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                    && reviewMathLineIsBlank(line: lines[lineIndex].content) == false {
                     let containerLine = lines[lineIndex]
                     pendingMarkdown += containerLine.content + containerLine.separator
 
@@ -161,7 +162,7 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
                 }
 
                 while lineIndex < lines.count
-                    && lines[lineIndex].content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    && reviewMathLineIsBlank(line: lines[lineIndex].content) {
                     pendingMarkdown += lines[lineIndex].content + lines[lineIndex].separator
                     lineIndex += 1
                 }
@@ -186,7 +187,7 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
         let paragraphStartIndex = lineIndex
         lineIndex += 1
         while lineIndex < lines.count
-            && lines[lineIndex].content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            && reviewMathLineIsBlank(line: lines[lineIndex].content) == false {
             if reviewMathSetextHeadingExpression.matches(lines[lineIndex].content) {
                 lineIndex += 1
                 break
@@ -331,22 +332,138 @@ private func reviewMathLineIsIndentedCode(line: String) -> Bool {
     return false
 }
 
-private func reviewMathLineIsDisplayDelimiter(line: String) -> Bool {
-    guard reviewMathLineIsIndentedCode(line: line) == false else {
-        return false
-    }
-
-    return line.trimmingCharacters(in: .whitespacesAndNewlines) == "$$"
+// The contract defines *space* as exactly U+0020 and U+0009, so a general whitespace
+// predicate must never stand in for this check.
+private func reviewMathCharacterIsSpace(_ character: Character) -> Bool {
+    character == " " || character == "\t"
 }
 
-private func reviewMathDisplayClosingIndex(
+private func reviewMathCharacterIsDigit(_ character: Character) -> Bool {
+    character.isASCII && character.isNumber
+}
+
+// CommonMark's blank line: a line holding only spaces and tabs, not only a zero-length line.
+private func reviewMathLineIsBlank(line: String) -> Bool {
+    line.allSatisfy { character in
+        reviewMathCharacterIsSpace(character)
+    }
+}
+
+private func reviewMathDollarRunLength(line: String, from index: String.Index) -> Int {
+    var length = 0
+    var cursor = index
+
+    while cursor < line.endIndex, line[cursor] == "$" {
+        length += 1
+        cursor = line.index(after: cursor)
+    }
+    return length
+}
+
+/// Start of the line content when at most three spaces and no tab precede it.
+private func reviewMathDisplayIndentationEnd(line: String) -> String.Index? {
+    var index = line.startIndex
+    var spaceCount = 0
+
+    while index < line.endIndex, line[index] == " " {
+        spaceCount += 1
+        index = line.index(after: index)
+    }
+    return spaceCount <= 3 ? index : nil
+}
+
+private func reviewMathDisplayOpeningRun(line: String) -> (contentStart: String.Index, length: Int)? {
+    guard let start = reviewMathDisplayIndentationEnd(line: line), start < line.endIndex, line[start] == "$" else {
+        return nil
+    }
+
+    let length = reviewMathDollarRunLength(line: line, from: start)
+    guard length >= 2 else {
+        return nil
+    }
+    return (line.index(start, offsetBy: length), length)
+}
+
+/// Length of the `$` run on a line whose whole content is that run.
+private func reviewMathDisplayClosingRunLength(line: String) -> Int? {
+    guard let start = reviewMathDisplayIndentationEnd(line: line), start < line.endIndex, line[start] == "$" else {
+        return nil
+    }
+
+    let length = reviewMathDollarRunLength(line: line, from: start)
+    let trailingContent = line[line.index(start, offsetBy: length)...]
+    guard trailingContent.allSatisfy({ character in reviewMathCharacterIsSpace(character) }) else {
+        return nil
+    }
+    return length
+}
+
+private func reviewMathUnescapedDollarIndex(line: String, from startIndex: String.Index) -> String.Index? {
+    var index = startIndex
+
+    while index < line.endIndex {
+        if line[index] == "$", reviewMathCharacterIsUnescaped(text: line, index: index) {
+            return index
+        }
+        index = line.index(after: index)
+    }
+    return nil
+}
+
+private func reviewMathDisplayConstruct(
     lines: [ReviewMathSourceLine],
     openingIndex: Int
-) -> Int? {
+) -> ReviewMathDisplayConstruct? {
+    guard reviewMathLineIsIndentedCode(line: lines[openingIndex].content) == false,
+          openingIndex == 0 || reviewMathLineIsBlank(line: lines[openingIndex - 1].content),
+          let opening = reviewMathDisplayOpeningRun(line: lines[openingIndex].content) else {
+        return nil
+    }
+
+    let openingLine = lines[openingIndex].content
+    let openingRemainder = openingLine[opening.contentStart...]
+    guard openingRemainder.allSatisfy({ character in reviewMathCharacterIsSpace(character) }) == false else {
+        return reviewMathMultipleLineDisplayConstruct(
+            lines: lines,
+            openingIndex: openingIndex,
+            openingRunLength: opening.length
+        )
+    }
+
+    guard let closingStart = reviewMathUnescapedDollarIndex(line: openingLine, from: opening.contentStart),
+          reviewMathDollarRunLength(line: openingLine, from: closingStart) == opening.length else {
+        return nil
+    }
+
+    let afterClosing = openingLine.index(closingStart, offsetBy: opening.length)
+    guard openingLine[afterClosing...].allSatisfy({ character in reviewMathCharacterIsSpace(character) }),
+          openingIndex == lines.count - 1 || reviewMathLineIsBlank(line: lines[openingIndex + 1].content) else {
+        return nil
+    }
+
+    return ReviewMathDisplayConstruct(
+        closingIndex: openingIndex,
+        latex: String(openingLine[opening.contentStart..<closingStart])
+    )
+}
+
+private func reviewMathMultipleLineDisplayConstruct(
+    lines: [ReviewMathSourceLine],
+    openingIndex: Int,
+    openingRunLength: Int
+) -> ReviewMathDisplayConstruct? {
     var index = openingIndex + 1
+
     while index < lines.count {
-        if reviewMathLineIsDisplayDelimiter(line: lines[index].content) {
-            return index
+        if let closingRunLength = reviewMathDisplayClosingRunLength(line: lines[index].content) {
+            guard closingRunLength == openingRunLength else {
+                return nil
+            }
+
+            return ReviewMathDisplayConstruct(
+                closingIndex: index,
+                latex: lines[(openingIndex + 1)..<index].map(\.content).joined(separator: "\n")
+            )
         }
         index += 1
     }
@@ -369,20 +486,6 @@ private func reviewMathDisplaySource(
         index += 1
     }
     return source
-}
-
-private func reviewMathDisplayLatex(
-    lines: [ReviewMathSourceLine],
-    openingIndex: Int,
-    closingIndex: Int
-) -> String {
-    guard closingIndex > openingIndex + 1 else {
-        return ""
-    }
-
-    return lines[(openingIndex + 1)..<closingIndex]
-        .map(\.content)
-        .joined(separator: "\n")
 }
 
 private func reviewMathLineStartsContainer(line: String) -> Bool {
@@ -408,9 +511,9 @@ private func reviewMathLineContinuesContainerAfterBlank(line: String) -> Bool {
     return firstCharacter == " " || firstCharacter == "\t" || reviewMathLineStartsContainer(line: line)
 }
 
+// A display opening run must be preceded by a blank line, so it never interrupts a paragraph.
 private func reviewMathLineStartsParagraphBoundary(line: String) -> Bool {
     if reviewMathLineIsIndentedCode(line: line)
-        || reviewMathLineIsDisplayDelimiter(line: line)
         || reviewMathFence(line: line) != nil {
         return true
     }
@@ -436,12 +539,8 @@ private func splitReviewMathParagraph(lines: [ReviewMathSourceLine]) -> [ReviewM
         return nil
     }
 
-    var parsedLines: [ReviewInlineMathLine] = []
-    for line in lines {
-        guard let parsedLine = splitReviewInlineMathLine(line: line.content) else {
-            return nil
-        }
-        parsedLines.append(parsedLine)
+    let parsedLines = lines.map { line in
+        splitReviewInlineMathLine(line: line.content)
     }
 
     guard parsedLines.contains(where: \.containsFormula) else {
@@ -493,7 +592,7 @@ private func reviewMathParagraphIsEligible(lines: [ReviewInlineMathLine]) -> Boo
     }
 }
 
-private func splitReviewInlineMathLine(line: String) -> ReviewInlineMathLine? {
+private func splitReviewInlineMathLine(line: String) -> ReviewInlineMathLine {
     var parts: [ReviewInlineMathPart] = []
     var pendingTextStart = line.startIndex
     var index = line.startIndex
@@ -505,34 +604,51 @@ private func splitReviewInlineMathLine(line: String) -> ReviewInlineMathLine? {
             continue
         }
 
-        let afterDollar = line.index(after: index)
-        if afterDollar < line.endIndex, line[afterDollar] == "$" {
-            index = line.index(after: afterDollar)
+        // A run of two or more `$` is always a display fence sequence, never an inline delimiter.
+        let openingRunLength = reviewMathDollarRunLength(line: line, from: index)
+        if openingRunLength >= 2 {
+            index = line.index(index, offsetBy: openingRunLength)
             continue
         }
 
-        guard let closingIndex = reviewInlineMathClosingIndex(line: line, openingIndex: index) else {
-            return nil
-        }
-
-        if pendingTextStart < index {
-            parts.append(.text(String(line[pendingTextStart..<index])))
-        }
-
+        // Pandoc opening guard: a non-space character immediately to the right.
         let latexStart = line.index(after: index)
-        let afterClosing = line.index(after: closingIndex)
-        parts.append(
-            .formula(
-                ReviewFormulaContent(
-                    originalSource: String(line[index..<afterClosing]),
-                    latex: String(line[latexStart..<closingIndex]),
-                    continuesParagraph: true
+        guard latexStart < line.endIndex, reviewMathCharacterIsSpace(line[latexStart]) == false else {
+            index = latexStart
+            continue
+        }
+
+        switch reviewInlineMathClosingScan(line: line, latexStart: latexStart) {
+        case .none:
+            // No later `$` on this line, so nothing on it is left to scan.
+            index = line.endIndex
+        case .displayRun(let resumeIndex):
+            index = resumeIndex
+        case .candidate(let closingIndex):
+            guard reviewInlineMathClosingGuardsHold(line: line, closingIndex: closingIndex) else {
+                // The `$` that failed as a closer is itself the next candidate opener.
+                index = closingIndex
+                continue
+            }
+
+            if pendingTextStart < index {
+                parts.append(.text(String(line[pendingTextStart..<index])))
+            }
+
+            let afterClosing = line.index(after: closingIndex)
+            parts.append(
+                .formula(
+                    ReviewFormulaContent(
+                        originalSource: String(line[index..<afterClosing]),
+                        latex: String(line[latexStart..<closingIndex]),
+                        continuesParagraph: true
+                    )
                 )
             )
-        )
-        didFindFormula = true
-        pendingTextStart = afterClosing
-        index = afterClosing
+            didFindFormula = true
+            pendingTextStart = afterClosing
+            index = afterClosing
+        }
     }
 
     if pendingTextStart < line.endIndex {
@@ -545,8 +661,8 @@ private func splitReviewInlineMathLine(line: String) -> ReviewInlineMathLine? {
     return ReviewInlineMathLine(parts: parts, containsFormula: didFindFormula)
 }
 
-private func reviewInlineMathClosingIndex(line: String, openingIndex: String.Index) -> String.Index? {
-    var index = line.index(after: openingIndex)
+private func reviewInlineMathClosingScan(line: String, latexStart: String.Index) -> ReviewInlineMathClosingScan {
+    var index = latexStart
 
     while index < line.endIndex {
         guard line[index] == "$", reviewMathCharacterIsUnescaped(text: line, index: index) else {
@@ -554,15 +670,27 @@ private func reviewInlineMathClosingIndex(line: String, openingIndex: String.Ind
             continue
         }
 
-        let afterDollar = line.index(after: index)
-        if afterDollar < line.endIndex, line[afterDollar] == "$" {
-            index = line.index(after: afterDollar)
-            continue
+        let runLength = reviewMathDollarRunLength(line: line, from: index)
+        if runLength >= 2 {
+            return .displayRun(line.index(index, offsetBy: runLength))
         }
-        return index
+        return .candidate(index)
     }
 
-    return nil
+    return .none
+}
+
+// Pandoc closing guard: a non-space character immediately to the left, and no digit to the right.
+private func reviewInlineMathClosingGuardsHold(line: String, closingIndex: String.Index) -> Bool {
+    guard reviewMathCharacterIsSpace(line[line.index(before: closingIndex)]) == false else {
+        return false
+    }
+
+    let afterClosingIndex = line.index(after: closingIndex)
+    guard afterClosingIndex < line.endIndex else {
+        return true
+    }
+    return reviewMathCharacterIsDigit(line[afterClosingIndex]) == false
 }
 
 private func reviewMathContainsUnsupportedInlineSyntax(text: String) -> Bool {
@@ -593,49 +721,6 @@ private func reviewMathLineHasHardBreak(line: String) -> Bool {
         return true
     }
     return line.reversed().prefix(while: { character in character == "\\" }).count.isMultiple(of: 2) == false
-}
-
-func normalizeReviewInlineMathParagraphContinuation(markdown: String) -> String {
-    guard let firstCharacter = markdown.first, firstCharacter != "\r", firstCharacter != "\n" else {
-        return markdown
-    }
-
-    // A mid-paragraph fragment must not acquire document-level block syntax after splitting.
-    let leadingWhitespaceCount = markdown.prefix(while: { character in
-        character == " " || character == "\t"
-    }).count
-    let content = String(markdown.dropFirst(leadingWhitespaceCount))
-    let normalizedPrefix = leadingWhitespaceCount == 0 ? "" : " "
-    let startsHeading = makeReviewContentRegularExpression(
-        pattern: #"^#{1,6}(?:[ \t]+|$)"#
-    ).matches(content)
-    let startsUnorderedList = makeReviewContentRegularExpression(
-        pattern: #"^[-+*](?:[ \t]+|$)"#
-    ).matches(content)
-    let startsThematicBreak = makeReviewContentRegularExpression(
-        pattern: #"^(?:-[ \t]*){3,}(?:\r?\n|$)"#
-    ).matches(content)
-    if startsHeading || startsUnorderedList || startsThematicBreak {
-        return normalizedPrefix + "\\" + content
-    }
-
-    let digitCount = content.prefix(while: { character in
-        "0123456789".contains(character)
-    }).count
-    guard digitCount > 0, digitCount <= 9, digitCount < content.count else {
-        return normalizedPrefix + content
-    }
-    let punctuationIndex = content.index(content.startIndex, offsetBy: digitCount)
-    let afterPunctuationIndex = content.index(after: punctuationIndex)
-    guard (content[punctuationIndex] == "." || content[punctuationIndex] == ")"),
-          afterPunctuationIndex == content.endIndex
-            || " \t\r\n".contains(content[afterPunctuationIndex]) else {
-        return normalizedPrefix + content
-    }
-
-    var escapedContent = content
-    escapedContent.insert("\\", at: punctuationIndex)
-    return normalizedPrefix + escapedContent
 }
 
 private func reviewMathSource(lines: [ReviewMathSourceLine]) -> String {

--- a/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMathInlineImageProvider.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMathInlineImageProvider.swift
@@ -1,0 +1,257 @@
+import MarkdownUI
+import OSLog
+import RaTeX
+import SwiftUI
+import UIKit
+
+/*
+ Accepted inline formulas stay inside their paragraph by travelling through the `MarkdownUI`
+ inline image path as `fcmath:<index>-<16 hex FNV-1a of the LaTeX>` references, built by
+ `reviewInlineMathImageSource(index:latex:)`. The digest is load-bearing and must not be
+ simplified away: `MarkdownUI` keys its inline-image state on the raw reference string, so a
+ bare `fcmath:<index>` makes two cards whose only difference is the formula parse to equal
+ inline nodes, and the next card keeps showing the previous card's rendered formula.
+
+ `MarkdownUI` has no math node and no baseline hook, and `TextInlineRenderer` composes an inline
+ image as `Text(image)`, so a formula with a descent sits slightly high. That is accepted in V1.
+ */
+
+private let reviewInlineMathLogger: Logger = Logger(
+    subsystem: appBundleIdentifier(),
+    category: "review_math"
+)
+private let reviewInlineMathImageCacheLimit: Int = 256
+/// Ceiling on a rasterized inline formula, in device pixels. `reviewInlineMathImageCache` is
+/// capped by entry count rather than by bytes, so one very long single-line formula must not be
+/// able to allocate an unbounded bitmap and hold it until the cache is cleared. Roughly 8 MB at
+/// four bytes per pixel, far above any inline formula that is still readable on one line.
+private let reviewInlineMathMaximumRasterPixelArea: CGFloat = 2_000_000
+
+struct ReviewInlineMathRendering {
+    let images: [String: Image]
+    let didFailRendering: Bool
+}
+
+private struct ReviewInlineMathImageKey: Hashable {
+    let latex: String
+    let originalSource: String
+    let fontSize: CGFloat
+    let color: UIColor
+    let displayScale: CGFloat
+}
+
+private struct ReviewInlineMathImageEntry {
+    let image: Image
+    let didFailRendering: Bool
+}
+
+@MainActor
+private var reviewInlineMathImageCache: [ReviewInlineMathImageKey: ReviewInlineMathImageEntry] = [:]
+
+@MainActor
+func makeReviewInlineMathRendering(
+    references: [ReviewInlineMathReference],
+    fontSize: CGFloat,
+    color: UIColor,
+    displayScale: CGFloat
+) -> ReviewInlineMathRendering {
+    guard references.isEmpty == false else {
+        return ReviewInlineMathRendering(images: [:], didFailRendering: false)
+    }
+
+    var images: [String: Image] = [:]
+    var didFailRendering = false
+
+    for reference in references {
+        let entry = reviewInlineMathImageEntry(
+            formula: reference.formula,
+            fontSize: fontSize,
+            color: color,
+            displayScale: displayScale
+        )
+        images[reference.source] = entry.image
+        didFailRendering = didFailRendering || entry.didFailRendering
+    }
+
+    return ReviewInlineMathRendering(images: images, didFailRendering: didFailRendering)
+}
+
+struct ReviewMathInlineImageProvider: InlineImageProvider {
+    let images: [String: Image]
+
+    // Never throws for a formula: `InlineText` drops every inline image in the paragraph when
+    // the provider throws, so a failed formula falls back to an image of its delimited source.
+    func image(with url: URL, label: String) async throws -> Image {
+        guard url.scheme == reviewInlineMathImageScheme else {
+            return try await DefaultInlineImageProvider.default.image(with: url, label: label)
+        }
+
+        return self.images[url.absoluteString] ?? Image(uiImage: UIImage())
+    }
+}
+
+// A paragraph holding nothing but formulas reaches `ImageView`/`ImageFlow` instead of
+// `InlineText`, which resolves images through the block image provider.
+struct ReviewMathBlockImageProvider: ImageProvider {
+    let images: [String: Image]
+
+    // Keyed on the scheme, not on a successful lookup, so an unknown `fcmath:` reference fails
+    // closed instead of reaching `NetworkImage` through the default provider.
+    @ViewBuilder
+    func makeImage(url: URL?) -> some View {
+        if let url, url.scheme == reviewInlineMathImageScheme {
+            self.images[url.absoluteString] ?? Image(uiImage: UIImage())
+        } else {
+            DefaultImageProvider.default.makeImage(url: url)
+        }
+    }
+}
+
+@MainActor
+private func reviewInlineMathImageEntry(
+    formula: ReviewFormulaContent,
+    fontSize: CGFloat,
+    color: UIColor,
+    displayScale: CGFloat
+) -> ReviewInlineMathImageEntry {
+    let cacheKey = ReviewInlineMathImageKey(
+        latex: formula.latex,
+        originalSource: formula.originalSource,
+        fontSize: fontSize,
+        color: color,
+        displayScale: displayScale
+    )
+    if let cachedEntry = reviewInlineMathImageCache[cacheKey] {
+        return cachedEntry
+    }
+
+    let entry = makeReviewInlineMathImageEntry(
+        formula: formula,
+        fontSize: fontSize,
+        color: color,
+        displayScale: displayScale
+    )
+    if reviewInlineMathImageCache.count >= reviewInlineMathImageCacheLimit {
+        reviewInlineMathImageCache.removeAll()
+    }
+    reviewInlineMathImageCache[cacheKey] = entry
+    return entry
+}
+
+@MainActor
+private func makeReviewInlineMathImageEntry(
+    formula: ReviewFormulaContent,
+    fontSize: CGFloat,
+    color: UIColor,
+    displayScale: CGFloat
+) -> ReviewInlineMathImageEntry {
+    RaTeXFontLoader.ensureLoaded()
+
+    do {
+        let displayList = try RaTeXEngine.shared.parse(formula.latex, displayMode: false, color: color)
+        let renderer = RaTeXRenderer(displayList: displayList, fontSize: fontSize)
+        if let image = makeReviewInlineMathFormulaImage(
+            renderer: renderer,
+            displayScale: displayScale,
+            label: formula.latex
+        ) {
+            return ReviewInlineMathImageEntry(image: image, didFailRendering: false)
+        }
+
+        reviewInlineMathLogger.error(
+            "Review inline formula is not rasterizable at the current size. latex=\(formula.latex, privacy: .private(mask: .hash))"
+        )
+    } catch {
+        reviewInlineMathLogger.error(
+            "Review inline formula rendering failed. latex=\(formula.latex, privacy: .private(mask: .hash)) error=\(error.localizedDescription, privacy: .public)"
+        )
+    }
+
+    return ReviewInlineMathImageEntry(
+        image: makeReviewInlineMathSourceImage(
+            formula: formula,
+            fontSize: fontSize,
+            color: color,
+            displayScale: displayScale
+        ),
+        didFailRendering: true
+    )
+}
+
+@MainActor
+private func makeReviewInlineMathFormulaImage(
+    renderer: RaTeXRenderer,
+    displayScale: CGFloat,
+    label: String
+) -> Image? {
+    let size = CGSize(width: renderer.width, height: renderer.totalHeight)
+    let scale = max(displayScale, 1)
+    guard size.width.isFinite, size.height.isFinite, size.width > 0, size.height > 0,
+          size.width * size.height * scale * scale <= reviewInlineMathMaximumRasterPixelArea else {
+        return nil
+    }
+
+    let renderedImage = makeReviewInlineMathRenderedImage(size: size, displayScale: displayScale) { context in
+        renderer.draw(in: context)
+    }
+    return makeReviewInlineMathImage(renderedImage: renderedImage, label: label)
+}
+
+@MainActor
+private func makeReviewInlineMathSourceImage(
+    formula: ReviewFormulaContent,
+    fontSize: CGFloat,
+    color: UIColor,
+    displayScale: CGFloat
+) -> Image {
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+        .foregroundColor: color
+    ]
+    let source = formula.originalSource as NSString
+    let sourceSize = source.size(withAttributes: attributes)
+    let height = max(sourceSize.height.rounded(.up), 1)
+    // This fallback draws the raw source, so the same ceiling has to bound it too: without the
+    // clamp, refusing an over-sized formula bitmap would just move the allocation here.
+    let scale = max(displayScale, 1)
+    let maximumWidth = (reviewInlineMathMaximumRasterPixelArea / (height * scale * scale)).rounded(.down)
+    let size = CGSize(
+        width: min(max(sourceSize.width.rounded(.up), 1), max(maximumWidth, 1)),
+        height: height
+    )
+
+    let renderedImage = makeReviewInlineMathRenderedImage(size: size, displayScale: displayScale) { _ in
+        source.draw(at: .zero, withAttributes: attributes)
+    }
+    // Every `Image` initializer that carries a `Text` label needs a `CGImage`, so the
+    // unreachable no-`CGImage` case labels an empty image with the LaTeX instead of exposing an
+    // SF Symbol name to VoiceOver.
+    return makeReviewInlineMathImage(renderedImage: renderedImage, label: formula.latex)
+        ?? Image(size: CGSize(width: 1, height: 1), label: Text(formula.latex), renderer: { _ in })
+}
+
+@MainActor
+private func makeReviewInlineMathRenderedImage(
+    size: CGSize,
+    displayScale: CGFloat,
+    draw: (CGContext) -> Void
+) -> UIImage {
+    let format = UIGraphicsImageRendererFormat.preferred()
+    format.opaque = false
+    if displayScale > 0 {
+        format.scale = displayScale
+    }
+
+    return UIGraphicsImageRenderer(size: size, format: format).image { context in
+        draw(context.cgContext)
+    }
+}
+
+@MainActor
+private func makeReviewInlineMathImage(renderedImage: UIImage, label: String) -> Image? {
+    guard let cgImage = renderedImage.cgImage else {
+        return nil
+    }
+
+    return Image(cgImage, scale: renderedImage.scale, orientation: .up, label: Text(label))
+}


### PR DESCRIPTION
Implements the merged cross-client math contract (`docs/review-markdown-rendering.md`) on the iOS review screen. This completes the four-client set: the contract, the catalog website, the web app and Android are already on `main`.

## What changes

- An accepted `$...$` span renders **inside its paragraph** instead of becoming a separate block in the card's `VStack`.
- A `$$...$$` run that opens and closes on one line is display math.
- The scanner implements the contract's source-level rules directly: maximal dollar runs, the pandoc delimiter guards including the digit clause, the failed-closer-becomes-next-opener rule, equal-length closing runs, block start/end tests, and the CommonMark blank line. *space* is exactly U+0020 and U+0009, so `Character.isWhitespace` — which accepts U+00A0 — cannot make this client disagree with the other three.

Accepted spans travel through MarkdownUI's inline-image path as `fcmath:<index>-<16 hex FNV-1a of the LaTeX>` references carrying their LaTeX as an escaped Markdown alt.

## Two mechanics that are load-bearing, both found in review

**The reference must be content-derived.** MarkdownUI keys inline-image state on the raw reference string, and `BlockSequence` iterates `ForEach(id: \.self)`. With a bare `fcmath:<index>`, two card sides differing only in formula content (`Simplify $\frac{2}{4}$.` vs `$\frac{3}{9}$.` — the normal shape of a maths deck) produce byte-identical Markdown and identical `InlineNode`s, so `@State inlineImages` survives the card change and `.task(id:)` never re-runs: card N's formula renders on card N+1, permanently. FNV-1a rather than Swift's `Hasher`, which is per-process seeded.

**The alt must be non-empty.** A paragraph whose only inline is a formula routes through `ParagraphView` → `ImageView`, which applies `.accessibilityLabel(self.data.alt)` and would override the provider's own label with `""`, leaving VoiceOver with no LaTeX at all.

The provider never throws: `InlineText` collapses a throw into an empty dictionary, which would drop every inline image in the paragraph, not just the failing one.

## Reviewed three times

Round 1 found the card-identity bug above and the lost accessibility label. Round 2 found a **P0: the target did not compile** — `Image(cgImage:scale:orientation:label:)` does not exist; the SDK's first parameter is unlabelled, and that call was the sole producer of every formula image. This repository compiles iOS only after merge, so no PR gate would have caught it. Round 3 re-verified every API against the pinned SDK and SwiftPM checkouts and found no issues.

## Needs a device check before the visual result is trusted

**SwiftUI's baseline placement of `Text(Image)` is unverified.** No simulator run was authorised during implementation. The approach assumes SwiftUI seats an inline image's bottom edge on the text baseline, which puts a formula's own baseline `depth` points high — zero for `x`, `f(x)`, `x^2`, `\pi`; visible for an inline `\frac`. **If SwiftUI instead centres the image on the line, every inline formula is misplaced**, and the recorded fallback is a custom `Layout` reading RaTeX's `RaTeXFormulaAscentKey` — a different architecture needing its own plan.

Worth checking in the same pass: crispness at 3x, colour and size following the theme and Dynamic Type, `$$` blocks still scrolling horizontally, and a formula-only card side (which takes the `ImageFlow` path rather than `InlineText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)