### PR TITLE
Clamp the inline formula colour before handing it to RaTeX

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMarkdownTheme.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Content/ReviewMarkdownTheme.swift
@@ -246,6 +246,37 @@ private func reviewMarkdownBorderColor(surfaceStyle: ReviewCardSurfaceStyle) -> 
     }
 }
 
+/// Makes a `UIColor` safe to hand to RaTeX as a formula colour.
+///
+/// Do not simplify this clamp away. RaTeX's FFI validates red, green, blue, and alpha against
+/// `[0, 1]` strictly and rejects the whole formula otherwise, while a dynamic SwiftUI `Color`
+/// resolved through `UIColor` can come back a colour-space-conversion rounding step outside that
+/// range: an observed `red == 1.0000001` made every inline formula fail with `invalid color.r`.
+func reviewMathRenderableColor(_ color: UIColor) -> UIColor {
+    // RaTeX rejects a non-finite component too, and `min`/`max` propagate `NaN`.
+    func clamped(_ value: CGFloat) -> CGFloat {
+        value.isFinite ? min(max(value, 0), 1) : 0
+    }
+
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    // A pattern colour, or one in a colour space `getRed` cannot convert, leaves the components
+    // undefined, so the display formula colour — a literal safely inside `[0, 1]` — stands in
+    // rather than unvalidated garbage reaching RaTeX.
+    guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+        return UIColor(reviewMathFormulaColor)
+    }
+
+    return UIColor(
+        red: clamped(red),
+        green: clamped(green),
+        blue: clamped(blue),
+        alpha: clamped(alpha)
+    )
+}
+
 struct ReviewMarkdownText: View {
     let markdownContent: MarkdownContent
     let surfaceStyle: ReviewCardSurfaceStyle
@@ -281,10 +312,12 @@ struct ReviewMarkdownText: View {
     }
 
     private var inlineFormulaColor: UIColor {
-        UIColor(reviewMarkdownTextColor(surfaceStyle: self.surfaceStyle)).resolvedColor(
-            with: UITraitCollection { traits in
-                traits.userInterfaceStyle = self.colorScheme == .dark ? .dark : .light
-            }
+        reviewMathRenderableColor(
+            UIColor(reviewMarkdownTextColor(surfaceStyle: self.surfaceStyle)).resolvedColor(
+                with: UITraitCollection { traits in
+                    traits.userInterfaceStyle = self.colorScheme == .dark ? .dark : .light
+                }
+            )
         )
     }
 


### PR DESCRIPTION
Hotfix for the inline-math feature merged in #1586. **Without this, no inline formula renders on iOS at all.**

## The bug

Found by building the app and running it on an iPhone 17 Pro simulator:

```
[review_math] Review inline formula rendering failed. latex=H
error=RaTeX parse error: invalid color.r: expected a float in [0, 1], got 1.0000001
```

`latex=H` is `$H$` — valid LaTeX. The colour was rejected, not the formula.

Resolving a dynamic SwiftUI colour through `UIColor(...).resolvedColor(with:)` returns components that can land marginally outside `[0, 1]` after colour-space conversion. RaTeX's FFI validates each component strictly (`crates/ratex-ffi/src/lib.rs` `validate_color`: non-finite, then `(0.0..=1.0).contains`) and throws, and `RaTeXEngine.ffiColor(from:)` does not clamp on the way in.

The display-math path never hit this because it passes a fixed literal (`254/255`). **The inline path broke precisely by doing the more correct thing** — using the real theme colour instead of a hardcoded one.

The failure contract held while it was broken: each card still showed the delimited formula source plus the localized render error, so nothing disappeared.

## The fix

Clamp all four components into `[0, 1]` before the colour reaches RaTeX, guarding non-finite values first because Swift's `min`/`max` propagate `NaN`, and falling back to the display colour when `getRed` cannot read the components at all.

## Verified on device

Rebuilt and re-run after the fix: `$H$` renders as real math italic, `$y_1$` renders with its subscript. Two behaviours were confirmed visually and match the recorded design:

- a zero-depth formula sits exactly on the surrounding text baseline;
- a formula with depth sits raised by its depth, because SwiftUI seats an inline image's bottom edge on the text baseline.

That second point resolves the one assumption the feature was built on and could not verify statically. **It holds** — the recorded fallback (a custom `Layout` reading `RaTeXFormulaAscentKey`) is not needed.

## Why review did not catch it

Three static review rounds passed over this code. They could not have found it: the code is correct, the APIs exist, the types check. Only the runtime value is out of range, and this repository compiles iOS after merge, so nothing before this ran the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)