### PR TITLE
Send product analytics from the web app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useCallback, useEffect, useRef, useState, type ReactEle
 import { BrowserRouter, NavLink, Navigate, Route, Routes as RouterRoutes, useLocation, useParams } from "react-router";
 import { AccountMenu } from "./AccountMenu";
 import { AccountDeletionRecoveryGate } from "./accountDeletionRecovery";
+import { AnalyticsLifecycle } from "./analytics";
 import { AppDataProvider, useAppData } from "./appData";
 import { AppErrorDialogProvider } from "./appError/AppErrorContext";
 import { buildLoginUrl, buildLogoutUrl } from "./api";
@@ -789,6 +790,7 @@ export default function App(): ReactElement {
   return (
     <AppErrorBoundary fallback={<AppCrashFallback />}>
       <BrowserRouter>
+        <AnalyticsLifecycle />
         <AppErrorDialogProvider>
           <TestModeProvider>
             <SentryRoutes>

--- a/apps/web/src/analytics/AnalyticsLifecycle.tsx
+++ b/apps/web/src/analytics/AnalyticsLifecycle.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router";
+import { setCurrentAnalyticsSurface, startAnalytics, track } from "./client";
+import { resolveAnalyticsSurface } from "./surfaces";
+
+/**
+ * Owns the analytics background task and the two route-driven events. Rendered inside the router so
+ * every route, authenticated or not, is covered.
+ */
+export function AnalyticsLifecycle(): null {
+  const location = useLocation();
+  const hasTrackedColdOpenRef = useRef<boolean>(false);
+  const hasLeftForegroundRef = useRef<boolean>(false);
+
+  useEffect(() => startAnalytics(), []);
+
+  useEffect(() => {
+    const surface = resolveAnalyticsSurface(location.pathname);
+    setCurrentAnalyticsSurface(surface);
+
+    if (hasTrackedColdOpenRef.current === false) {
+      hasTrackedColdOpenRef.current = true;
+      track({ name: "app_opened", launchType: "cold" });
+    }
+
+    // A route with no shared surface emits nothing: `screen` is a closed cross-client enum and a
+    // route path is never sent in its place.
+    if (surface !== null) {
+      track({ name: "screen_viewed", screen: surface });
+    }
+  }, [location.pathname]);
+
+  // `warm` is a return to the foreground after actually having left it, which is what `app_opened`
+  // has to mean on all three clients for the counts to be comparable. `visible` on its own is not
+  // that: it also arrives for the first paint of a page that loaded hidden, so a real departure has
+  // to be observed first. There is deliberately no minimum-away threshold — tab switching really is
+  // more frequent than app switching, and `warm` is compared within a platform rather than across.
+  useEffect(() => {
+    function reportForegroundReturn(): void {
+      if (hasLeftForegroundRef.current === false) {
+        return;
+      }
+
+      hasLeftForegroundRef.current = false;
+      track({ name: "app_opened", launchType: "warm" });
+    }
+
+    function handleVisibilityChange(): void {
+      if (document.visibilityState === "hidden") {
+        hasLeftForegroundRef.current = true;
+        return;
+      }
+
+      reportForegroundReturn();
+    }
+
+    function handlePageHide(): void {
+      hasLeftForegroundRef.current = true;
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    // Leaving for and returning from the back-forward cache is a real departure and return, and not
+    // every browser pairs it with a `hidden`/`visible` transition. The shared flag is what keeps the
+    // two signal pairs from reporting the same return twice, and it leaves the `pageshow` of the
+    // initial load — which follows no departure — reporting nothing.
+    window.addEventListener("pagehide", handlePageHide);
+    window.addEventListener("pageshow", reportForegroundReturn);
+    return (): void => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pagehide", handlePageHide);
+      window.removeEventListener("pageshow", reportForegroundReturn);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -1,0 +1,723 @@
+import {
+  ApiError,
+  getCachedSessionCsrfToken,
+  sendAnalyticsEventsBatch,
+  type AnalyticsIngestResult,
+} from "../api";
+import {
+  analyticsCatalogSlugPattern,
+  type AnalyticsDropReason,
+  type AnalyticsEvent,
+  type AnalyticsSurface,
+  type AnalyticsWireBatch,
+} from "./events";
+import {
+  readAnalyticsAnonymousId,
+  readAnalyticsSessionId,
+  readStoredAnalyticsEnabled,
+  resetAnalyticsIdentity,
+  writeStoredAnalyticsEnabled,
+} from "./identity";
+import {
+  reportAnalyticsInvalidBatch,
+  reportAnalyticsQueueDiscardedOnReset,
+  reportAnalyticsQueueFailure,
+  reportAnalyticsQueueOverflow,
+  reportAnalyticsQueueTtlExpiry,
+  reportAnalyticsSustainedDeliveryFailure,
+} from "./observation";
+import {
+  appendAnalyticsEvents,
+  claimAnalyticsQueueOwner,
+  clearAnalyticsQueue,
+  readOldestAnalyticsEvents,
+  removeAnalyticsEvents,
+  type AnalyticsQueueRecord,
+  type QueuedAnalyticsEvent,
+} from "./queue";
+import {
+  buildAnalyticsWireContext,
+  measureAnalyticsWireEventBytes,
+  toAnalyticsTimestamp,
+  toAnalyticsWireEvent,
+} from "./wire";
+
+/**
+ * Product analytics client. Emitting an event is fire-and-forget into a durable local queue: nothing
+ * here is awaited by a user action, and every network path runs on a background task.
+ */
+
+/** Shared with iOS and Android. */
+const batchEventLimit = 50;
+const flushThresholdEventCount = 20;
+const analyticsEventByteLimit = 4 * 1024;
+const retryBaseDelayMs = 1000;
+const retryMaxDelayMs = 60 * 60 * 1000;
+const sustainedFailureWindowMs = 60 * 60 * 1000;
+const periodicFlushIntervalMs = 60 * 1000;
+/**
+ * Requests one flush may spend. A whole-batch refusal splits and retries, and an unbounded split of a
+ * fully refused 50-event batch is ~99 back-to-back requests against a 20 rps endpoint throttle. The
+ * budget must stay above the depth needed to isolate one event from a full batch — seven requests for
+ * fifty events — or a split could stop before dropping anything and never converge.
+ */
+const flushRequestBudget = 12;
+
+function readInitialEnabled(): boolean {
+  try {
+    return readStoredAnalyticsEnabled();
+  } catch {
+    return true;
+  }
+}
+
+let isEnabled = readInitialEnabled();
+let currentSurface: AnalyticsSurface | null = null;
+let pendingRecords: Array<AnalyticsQueueRecord> = [];
+let pendingDropCounts = new Map<AnalyticsDropReason, number>();
+let persistTask: Promise<void> = Promise.resolve();
+let persistTimerId: number | null = null;
+let flushTimerId: number | null = null;
+let flushDueAtMs: number | null = null;
+let trackedSinceFlushCount = 0;
+let consecutiveFailureCount = 0;
+let firstDeliveryFailureAtMs: number | null = null;
+let lastFailureStatusCode: number | null = null;
+let retryNotBeforeMs = 0;
+let isFlushing = false;
+let hasDeliveredInFlush = false;
+let remainingFlushRequestCount = 0;
+/**
+ * The account the current credential belongs to, published by the session layer once it has verified
+ * the session. The queue stores the account it was filled under, so the two are compared as data
+ * rather than trusted to be cleared in the right order: nothing ships until they name one person.
+ */
+let confirmedOwnerId: string | null = null;
+/**
+ * Cleared the moment a new owner is published, set again only once the queue's stored owner has been
+ * reconciled with it. It never widens what may be sent — the stored-owner comparison in `runFlush` is
+ * the guarantee — it only keeps a flush out of the window in which a claim has already rewritten the
+ * stored owner but the outgoing `anonymous_id` has not been rotated yet.
+ */
+let isQueueOwnerReconciled = false;
+/**
+ * Bumped every time the queue and the identity behind it are torn down, by `reset()`, by the kill
+ * switch, or by a newly published owner. A flush captures it at the start and rechecks it before it
+ * may send or purge anything, so work started under one identity can never be attributed to, or
+ * delete events of, the next one.
+ */
+let analyticsGeneration = 0;
+
+/** Losses are counted here and emitted as `analytics_events_dropped` on the next flush. */
+function countDropped(reason: AnalyticsDropReason, count: number): void {
+  if (count <= 0) {
+    return;
+  }
+
+  pendingDropCounts.set(reason, (pendingDropCounts.get(reason) ?? 0) + count);
+}
+
+function enqueueEvent(event: AnalyticsEvent): void {
+  const nowMs = Date.now();
+  const sessionId = readAnalyticsSessionId(nowMs);
+  const wireEvent = toAnalyticsWireEvent(event, nowMs, currentSurface);
+  const byteSize = measureAnalyticsWireEventBytes(wireEvent);
+  if (byteSize > analyticsEventByteLimit) {
+    countDropped("rejected", 1);
+    return;
+  }
+
+  pendingRecords.push({
+    eventId: wireEvent.eventId,
+    sessionId,
+    createdAtMs: nowMs,
+    byteSize,
+    wireEvent,
+  });
+}
+
+function persistPendingRecords(): Promise<void> {
+  persistTask = persistTask.then(async (): Promise<void> => {
+    if (pendingRecords.length === 0) {
+      return;
+    }
+
+    const records = pendingRecords;
+    pendingRecords = [];
+    try {
+      const overflowCount = await appendAnalyticsEvents(records);
+      if (overflowCount > 0) {
+        countDropped("queue_overflow", overflowCount);
+        reportAnalyticsQueueOverflow(overflowCount);
+      }
+    } catch (error) {
+      reportAnalyticsQueueFailure(error);
+    }
+  });
+  return persistTask;
+}
+
+function schedulePersist(): void {
+  if (persistTimerId !== null) {
+    return;
+  }
+
+  // Coalesces a burst of tracked events into one IndexedDB transaction, off the interaction path.
+  persistTimerId = window.setTimeout((): void => {
+    persistTimerId = null;
+    try {
+      void persistPendingRecords();
+      if (trackedSinceFlushCount >= flushThresholdEventCount) {
+        scheduleFlush(0);
+      }
+    } catch {
+      // Nothing scheduled by analytics may surface as an uncaught error.
+    }
+  }, 0);
+}
+
+function createBackoffDelayMs(failureCount: number): number {
+  const exponentialDelayMs = retryBaseDelayMs * 2 ** (failureCount - 1);
+  const cappedDelayMs = Math.min(exponentialDelayMs, retryMaxDelayMs);
+  return Math.floor(Math.random() * cappedDelayMs);
+}
+
+function scheduleFlush(delayMs: number): void {
+  const dueAtMs = Date.now() + delayMs;
+  if (flushTimerId !== null && flushDueAtMs !== null && flushDueAtMs <= dueAtMs) {
+    return;
+  }
+
+  if (flushTimerId !== null) {
+    window.clearTimeout(flushTimerId);
+  }
+
+  flushDueAtMs = dueAtMs;
+  flushTimerId = window.setTimeout((): void => {
+    flushTimerId = null;
+    flushDueAtMs = null;
+    try {
+      void runFlush();
+    } catch {
+      // Nothing scheduled by analytics may surface as an uncaught error.
+    }
+  }, delayMs);
+}
+
+function drainDropReports(): void {
+  if (pendingDropCounts.size === 0) {
+    return;
+  }
+
+  const dropCounts = [...pendingDropCounts.entries()];
+  pendingDropCounts = new Map<AnalyticsDropReason, number>();
+  for (const [reason, count] of dropCounts) {
+    enqueueEvent({ name: "analytics_events_dropped", reason, count });
+  }
+}
+
+/**
+ * The wire envelope carries one session id for the whole batch, so a batch stops at the first event
+ * from a different session.
+ */
+function takeLeadingSessionRun(
+  events: ReadonlyArray<QueuedAnalyticsEvent>,
+): ReadonlyArray<QueuedAnalyticsEvent> {
+  const batchSessionId = events[0].sessionId;
+  const boundaryIndex = events.findIndex((event) => event.sessionId !== batchSessionId);
+  return boundaryIndex === -1 ? events : events.slice(0, boundaryIndex);
+}
+
+function buildWireBatch(events: ReadonlyArray<QueuedAnalyticsEvent>): AnalyticsWireBatch {
+  return {
+    // Stamped at request time, not at event time: the server derives every stored `occurred_at` from
+    // the interval between this and each event's `clientOccurredAt`.
+    clientSentAt: toAnalyticsTimestamp(Date.now()),
+    anonymousId: readAnalyticsAnonymousId(),
+    sessionId: events[0].sessionId,
+    context: buildAnalyticsWireContext(),
+    events: events.map((event) => event.wireEvent),
+  };
+}
+
+function trackSustainedDeliveryFailure(statusCode: number): void {
+  const nowMs = Date.now();
+  if (firstDeliveryFailureAtMs === null) {
+    firstDeliveryFailureAtMs = nowMs;
+    return;
+  }
+
+  if (nowMs - firstDeliveryFailureAtMs > sustainedFailureWindowMs) {
+    reportAnalyticsSustainedDeliveryFailure(statusCode);
+  }
+}
+
+/**
+ * Removing sent events is a local queue operation, not part of delivery: a failure here must be
+ * reported as the storage failure it is instead of arming the transport backoff as if the server had
+ * refused the batch. Returns whether the queue actually shrank, because a failed purge would
+ * otherwise let the backlog drain re-read and resend the same events without end.
+ */
+async function purgeSentEvents(events: ReadonlyArray<QueuedAnalyticsEvent>): Promise<boolean> {
+  try {
+    await removeAnalyticsEvents(events);
+    return true;
+  } catch (error) {
+    reportAnalyticsQueueFailure(error);
+    return false;
+  }
+}
+
+/**
+ * A batch carrying nothing but `analytics_events_dropped`. Counting its refusal would emit a fresh
+ * drop event that the same refusal takes out again: the queue never changes and the client posts
+ * forever at whatever rate its loop allows. The whole-batch and the per-event refusal paths share
+ * this one rule so neither can be closed without the other.
+ */
+function isDropOnlyBatch(events: ReadonlyArray<QueuedAnalyticsEvent>): boolean {
+  return events.every((event) => event.wireEvent.eventName === "analytics_events_dropped");
+}
+
+async function handleDeliveryFailure(
+  error: unknown,
+  events: ReadonlyArray<QueuedAnalyticsEvent>,
+  flushGeneration: number,
+): Promise<void> {
+  // The queue these events came from has been discarded. Nothing here may purge from, count against,
+  // or arm a backoff for the identity that replaced it.
+  if (flushGeneration !== analyticsGeneration) {
+    return;
+  }
+
+  const statusCode = error instanceof ApiError ? error.statusCode : 0;
+
+  // 400 and 413 refuse the whole batch and carry no per-event report. Resending the same bytes fails
+  // identically forever, so the batch is split until a single poison event is isolated and dropped.
+  if (statusCode === 400 || statusCode === 413) {
+    reportAnalyticsInvalidBatch(statusCode);
+    if (events.length === 1) {
+      await purgeSentEvents(events);
+      // A refused drop event must not regenerate itself. Only this one rejection goes uncounted:
+      // losses counted elsewhere in the same flush are untouched, so a real `queue_overflow` or
+      // `ttl_expired` count is still carried into the next drop event.
+      if (isDropOnlyBatch(events) === false) {
+        countDropped("rejected", 1);
+      }
+
+      return;
+    }
+
+    const midpoint = Math.ceil(events.length / 2);
+    await deliverBatch(events.slice(0, midpoint), flushGeneration);
+    await deliverBatch(events.slice(midpoint), flushGeneration);
+    return;
+  }
+
+  // Everything else keeps the events queued: 429 and 5xx are transient, and 401, 403 and 410 wait
+  // for a future valid credential rather than spinning.
+  if (statusCode === 429 || statusCode >= 500) {
+    trackSustainedDeliveryFailure(statusCode);
+  }
+
+  consecutiveFailureCount += 1;
+  lastFailureStatusCode = statusCode;
+  // `Retry-After` is an optimisation, never a precondition: only the analytics writer's own 429 and
+  // 503 carry it, and the gateway throttle's 429 never does.
+  const retryAfterMs = error instanceof ApiError ? error.retryAfterMs : null;
+  const delayMs = retryAfterMs ?? createBackoffDelayMs(consecutiveFailureCount);
+  retryNotBeforeMs = Date.now() + delayMs;
+  scheduleFlush(delayMs);
+}
+
+async function deliverBatch(
+  events: ReadonlyArray<QueuedAnalyticsEvent>,
+  flushGeneration: number,
+): Promise<void> {
+  // Rechecked synchronously immediately before the batch is built, and nothing between this line and
+  // the request may await: `buildWireBatch` reads the current `anonymousId`, so a `reset()` landing
+  // in the queue round trips above would otherwise ship the previous account's events under the next
+  // account's id. The server resolves `analytics.identity_links` first-link-wins on an append-only
+  // table, so that merge of two people is permanent and has no repair path.
+  if (flushGeneration !== analyticsGeneration) {
+    return;
+  }
+
+  // A 429 or a transport failure earlier in this split armed a backoff; the rest of the split honours
+  // it instead of firing the delay away on the same stack.
+  if (Date.now() < retryNotBeforeMs) {
+    return;
+  }
+
+  // What the budget cuts short stays queued and is picked up by the next flush, which still
+  // converges because every refused single event leaves the queue.
+  if (remainingFlushRequestCount <= 0) {
+    return;
+  }
+
+  remainingFlushRequestCount -= 1;
+
+  let result: AnalyticsIngestResult;
+  try {
+    result = await sendAnalyticsEventsBatch(buildWireBatch(events));
+  } catch (error) {
+    await handleDeliveryFailure(error, events, flushGeneration);
+    return;
+  }
+
+  consecutiveFailureCount = 0;
+  firstDeliveryFailureAtMs = null;
+  lastFailureStatusCode = null;
+  retryNotBeforeMs = 0;
+  // A reset landed while the request was in flight; it already discarded everything that was sent,
+  // and the loss was accounted for there.
+  if (flushGeneration !== analyticsGeneration) {
+    return;
+  }
+
+  // A 200 finishes the batch: `accepted` is a count only and rejected events are permanently
+  // refused, so every event that was sent leaves the queue.
+  hasDeliveredInFlush = await purgeSentEvents(events);
+  // The same exemption the whole-batch refusal above applies. A per-event refusal of
+  // `analytics_events_dropped` inside a 200 — a catalog change rather than a defect in this client —
+  // would otherwise purge one drop event and emit another for a net-zero queue, turning a silent
+  // client into one request per periodic tick forever. Suppressing only this batch's count leaves a
+  // `queue_overflow` or `ttl_expired` accrued elsewhere in the same flush intact.
+  if (isDropOnlyBatch(events) === false) {
+    countDropped("rejected", result.rejectedCount);
+  }
+}
+
+async function runFlush(): Promise<void> {
+  if (isEnabled === false || isFlushing) {
+    return;
+  }
+
+  const nowMs = Date.now();
+  if (nowMs < retryNotBeforeMs) {
+    scheduleFlush(retryNotBeforeMs - nowMs);
+    return;
+  }
+
+  isFlushing = true;
+  trackedSinceFlushCount = 0;
+  const flushGeneration = analyticsGeneration;
+  try {
+    drainDropReports();
+    await persistPendingRecords();
+
+    const queued = await readOldestAnalyticsEvents(batchEventLimit, Date.now());
+    if (queued.expiredCount > 0) {
+      countDropped("ttl_expired", queued.expiredCount);
+      reportAnalyticsQueueTtlExpiry(queued.expiredCount);
+    }
+
+    // Never send an unauthenticated batch, and never send one whose owner is not the account the
+    // credential belongs to. The owner comes back from the same transaction that produced these
+    // events, so this is a comparison of two recorded facts rather than an assumption about when the
+    // session layer's cleanup happens to run. Refusing here only holds events back: they stay in the
+    // queue under the 14-day TTL and ship on a later load that does confirm an owner.
+    if (
+      queued.events.length === 0
+      || confirmedOwnerId === null
+      || isQueueOwnerReconciled === false
+      || queued.ownerId !== confirmedOwnerId
+      || getCachedSessionCsrfToken() === null
+    ) {
+      return;
+    }
+
+    hasDeliveredInFlush = false;
+    remainingFlushRequestCount = flushRequestBudget;
+    const sendableEvents = takeLeadingSessionRun(queued.events);
+    await deliverBatch(sendableEvents, flushGeneration);
+    // More events are waiting either because the read filled the batch limit, or because a session
+    // boundary cut the sent run short. Both drain immediately: a backlog that crossed several
+    // sessions would otherwise advance by one session run per periodic timer tick.
+    const hasQueuedRemainder = queued.events.length >= batchEventLimit
+      || sendableEvents.length < queued.events.length;
+    if (hasDeliveredInFlush && hasQueuedRemainder) {
+      scheduleFlush(0);
+    }
+  } catch (error) {
+    reportAnalyticsQueueFailure(error);
+  } finally {
+    isFlushing = false;
+  }
+}
+
+/**
+ * Reconciles the queue's stored owner with the published one. A queue that turns out to belong to
+ * somebody else is discarded here, together with the `anonymous_id` created alongside it, rather than
+ * being shipped under the new credential: `analytics.identity_links` resolves first-link-wins on an
+ * append-only table, so fusing two people there is permanent and has no repair path.
+ */
+function claimQueueOwner(userId: string): void {
+  // Chained onto the persist task like every other queue operation, so a claim can neither interleave
+  // with a write nor leave the chain rejected for the writes behind it.
+  persistTask = persistTask.then(async (): Promise<void> => {
+    try {
+      const claim = await claimAnalyticsQueueOwner(userId);
+      if (claim.didReplaceForeignOwner) {
+        resetAnalyticsIdentity();
+        if (claim.discardedEventCount > 0) {
+          reportAnalyticsQueueDiscardedOnReset(claim.discardedEventCount);
+        }
+      }
+
+      // A newer owner was published while this claim ran; its own claim opens the gate instead.
+      if (confirmedOwnerId !== userId) {
+        return;
+      }
+
+      isQueueOwnerReconciled = true;
+      scheduleFlush(0);
+    } catch (error) {
+      // The store is unusable, so there is nothing readable to ship either; the gate stays shut.
+      reportAnalyticsQueueFailure(error);
+    }
+  });
+}
+
+/**
+ * Publishes the account the current credential belongs to. Call it wherever the session layer has
+ * verified a session; publishing late only delays delivery, and never publishing at all only holds
+ * events in the queue for the next page load, because nothing is sent until a published owner and the
+ * queue's stored owner name the same person.
+ */
+export function setAnalyticsConfirmedOwner(userId: string): void {
+  try {
+    if (confirmedOwnerId === userId) {
+      return;
+    }
+
+    // Shuts the gate and invalidates any flush already in flight before the claim can touch a
+    // record: work started under the previous owner may no longer send or purge from here.
+    confirmedOwnerId = userId;
+    isQueueOwnerReconciled = false;
+    analyticsGeneration += 1;
+    consecutiveFailureCount = 0;
+    firstDeliveryFailureAtMs = null;
+    lastFailureStatusCode = null;
+    retryNotBeforeMs = 0;
+    claimQueueOwner(userId);
+  } catch {
+    // The gate is already shut; a failure here can only cost delivery, never misattribute an event.
+  }
+}
+
+/** Records the surface stamped onto every event that does not declare its own. */
+export function setCurrentAnalyticsSurface(surface: AnalyticsSurface | null): void {
+  currentSurface = surface;
+}
+
+/**
+ * Emits one event into the local queue. Synchronous, returns void, and cannot throw: a user action
+ * is never blocked, delayed, or failed by anything in this module.
+ */
+export function track(event: AnalyticsEvent): void {
+  try {
+    if (isEnabled === false) {
+      return;
+    }
+
+    enqueueEvent(event);
+    trackedSinceFlushCount += 1;
+    schedulePersist();
+  } catch {
+    // A failure inside analytics is swallowed on purpose; the queue reporting path covers the rest.
+  }
+}
+
+/**
+ * `package_slug` is a declared string property with a slug pattern, so a slug the catalog cannot
+ * produce is skipped rather than shipped as an event the server would reject.
+ */
+export function trackCatalogDeckInstallStarted(packageSlug: string): void {
+  if (analyticsCatalogSlugPattern.test(packageSlug) === false) {
+    return;
+  }
+
+  track({ name: "catalog_deck_install_started", packageSlug });
+}
+
+export function flush(): void {
+  void runFlush();
+}
+
+/**
+ * Starts the IndexedDB write for everything tracked so far instead of waiting for the coalescing
+ * timer. The page-hide paths run it right after the collectors have emitted their closing events: the
+ * `setTimeout` that normally batches the write never gets a chance to run once the page is going away.
+ */
+function persistTrackedAnalyticsEvents(): void {
+  try {
+    if (persistTimerId !== null) {
+      window.clearTimeout(persistTimerId);
+      persistTimerId = null;
+    }
+
+    void persistPendingRecords();
+  } catch {
+    // Nothing scheduled by analytics may surface as an uncaught error.
+  }
+}
+
+function sumPendingDropCounts(): number {
+  let total = 0;
+  for (const count of pendingDropCounts.values()) {
+    total += count;
+  }
+
+  return total;
+}
+
+function discardQueuedWork(shouldReportDiscard: boolean, shouldReleaseOwner: boolean): void {
+  // Invalidates any flush already in flight before a single record is touched, so it can neither
+  // send the discarded events under the next identity nor delete records belonging to it.
+  analyticsGeneration += 1;
+  // Counted before the queue is emptied: an unreported drop is itself a silent loss.
+  const unreportedLossCount = pendingRecords.length + sumPendingDropCounts();
+  pendingRecords = [];
+  pendingDropCounts = new Map<AnalyticsDropReason, number>();
+  consecutiveFailureCount = 0;
+  firstDeliveryFailureAtMs = null;
+  lastFailureStatusCode = null;
+  retryNotBeforeMs = 0;
+  persistTask = persistTask.then(async (): Promise<void> => {
+    try {
+      const clearedEventCount = await clearAnalyticsQueue(shouldReleaseOwner);
+      const discardedEventCount = unreportedLossCount + clearedEventCount;
+      if (shouldReportDiscard && discardedEventCount > 0) {
+        reportAnalyticsQueueDiscardedOnReset(discardedEventCount);
+      }
+    } catch (error) {
+      reportAnalyticsQueueFailure(error);
+    }
+  });
+}
+
+/**
+ * Rotates `anonymous_id` and drops queued events so they cannot be attributed to the next account.
+ *
+ * The plan's "before logout" flush trigger is deliberately not implemented here, because on web
+ * there is no moment at which it would be safe. Signing out leaves for the auth origin, so every
+ * caller of this function runs on a *later* app start: `logout_marker` and `account_deleted_marker`
+ * run when the credential is already gone, and `confirmed_account_switch` / `reauth_owner_unknown`
+ * run right after `getSession()` returned a session belonging to somebody else. Flushing there would
+ * post the previous account's events on the new account's credential, which is exactly the
+ * unrepairable identity merge the whole reset path exists to prevent. What the trigger was meant to
+ * catch is instead covered by the existing tab-hidden flush, which fires while the credential is
+ * still the user's own as the sign-out link navigates away. The events this call does discard are
+ * counted and reported rather than lost silently.
+ */
+export function reset(): void {
+  try {
+    // The stored queue owner is released with the events: the next account confirmed on this browser
+    // then adopts an empty queue instead of inheriting one, and until one is confirmed the gate in
+    // `runFlush` refuses to send at all.
+    confirmedOwnerId = null;
+    isQueueOwnerReconciled = false;
+    discardQueuedWork(true, true);
+    resetAnalyticsIdentity();
+  } catch {
+    // Logout cleanup must not fail because analytics could not reset.
+  }
+}
+
+/** Kill switch. Honored immediately and remembered, so analytics can be turned off without a release. */
+export function setEnabled(enabled: boolean): void {
+  try {
+    isEnabled = enabled;
+    writeStoredAnalyticsEnabled(enabled);
+    if (enabled === false) {
+      // Not reported: turning analytics off is a deliberate operator action, and the discard is its
+      // documented effect rather than a loss anybody needs to be told about. The stored queue owner
+      // is kept, because the queue is emptied rather than handed to somebody else, so turning
+      // analytics back on does not have to wait for another verification to publish one.
+      discardQueuedWork(false, false);
+      return;
+    }
+
+    scheduleFlush(0);
+  } catch {
+    // The in-memory flag already took effect.
+  }
+}
+
+/**
+ * Callbacks that must emit their closing events before the page-hide flush reads the queue. Two
+ * independent `visibilitychange` listeners run in registration order, which no caller controls, and a
+ * screen whose event lands after the flush keeps it queued until a later trigger — which for a
+ * sign-out navigation is a boot that discards it at the identity boundary. Registering here makes the
+ * dependency explicit instead of leaving it to whichever listener was added first.
+ */
+const pageHideCollectors = new Set<() => void>();
+
+export function registerAnalyticsPageHideCollector(collector: () => void): () => void {
+  pageHideCollectors.add(collector);
+  return (): void => {
+    pageHideCollectors.delete(collector);
+  };
+}
+
+function runPageHideCollectors(): void {
+  for (const collector of [...pageHideCollectors]) {
+    try {
+      collector();
+    } catch {
+      // One collector failing must not stop the others, the persist, or the flush.
+    }
+  }
+}
+
+export function startAnalytics(): () => void {
+  function handleVisibilityChange(): void {
+    if (document.visibilityState === "hidden") {
+      runPageHideCollectors();
+      persistTrackedAnalyticsEvents();
+      flush();
+    }
+  }
+
+  function handleOnline(): void {
+    // Connectivity returning is exactly the signal a transport backoff was waiting for; a throttle
+    // or server backoff keeps its delay.
+    if (lastFailureStatusCode === 0) {
+      consecutiveFailureCount = 0;
+      lastFailureStatusCode = null;
+      retryNotBeforeMs = 0;
+    }
+
+    flush();
+  }
+
+  function handlePageHide(): void {
+    runPageHideCollectors();
+    persistTrackedAnalyticsEvents();
+  }
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("online", handleOnline);
+  window.addEventListener("pagehide", handlePageHide);
+  const intervalId = window.setInterval((): void => {
+    flush();
+  }, periodicFlushIntervalMs);
+  flush();
+
+  return (): void => {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    window.removeEventListener("online", handleOnline);
+    window.removeEventListener("pagehide", handlePageHide);
+    window.clearInterval(intervalId);
+    if (persistTimerId !== null) {
+      window.clearTimeout(persistTimerId);
+      persistTimerId = null;
+    }
+    void persistPendingRecords();
+    if (flushTimerId !== null) {
+      window.clearTimeout(flushTimerId);
+      flushTimerId = null;
+      flushDueAtMs = null;
+    }
+  };
+}

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -1,0 +1,183 @@
+/**
+ * Hand-written mirror of the backend product analytics catalog
+ * (`apps/backend/src/productAnalytics/catalog.ts`). The union is closed on `name`, so an event the
+ * server would reject cannot be constructed. `guest_upgrade_completed` and `catalog_deck_installed`
+ * are server-derived and deliberately absent.
+ */
+
+export type AnalyticsSurface =
+  | "review"
+  | "catalog"
+  | "deck_detail"
+  | "onboarding"
+  | "card_editor"
+  | "cards"
+  | "progress"
+  | "settings"
+  | "ai";
+
+export type AnalyticsNetworkState = "wifi" | "cellular" | "offline" | "unknown";
+
+export type AnalyticsLaunchType = "cold" | "warm";
+
+export type AnalyticsOnboardingStep =
+  | "language"
+  | "goal"
+  | "notifications"
+  | "first_deck"
+  | "first_review"
+  | "signin";
+
+export type AnalyticsOnboardingOutcome = "completed" | "skipped";
+
+export type AnalyticsSignInFailureReason =
+  | "invalid_code"
+  | "expired_code"
+  | "rate_limited"
+  | "offline"
+  | "server_error"
+  | "cancelled";
+
+export type AnalyticsDeckScope = "all" | "deck" | "filter";
+
+export type AnalyticsReviewSessionEndReason = "completed" | "abandoned" | "interrupted";
+
+export type AnalyticsReviewAnswerFailureReason =
+  | "offline"
+  | "timeout"
+  | "sync_conflict"
+  | "server_error";
+
+export type AnalyticsCardCreateEntryPoint =
+  | "cards"
+  | "deck_detail"
+  | "review"
+  | "ai"
+  | "quick_action";
+
+export type AnalyticsSyncFailureReason =
+  | "offline"
+  | "timeout"
+  | "conflict"
+  | "unauthorized"
+  | "server_error"
+  | "storage_full";
+
+export type AnalyticsDropReason = "queue_overflow" | "ttl_expired" | "rejected";
+
+/**
+ * `screen` is a top-level event field on the wire, legal on every event and required only for
+ * `screen_viewed`. Only `screen_viewed` declares it here; every other event is stamped with the
+ * surface the user is on when it is tracked.
+ */
+export type AnalyticsEvent =
+  | Readonly<{
+    name: "app_opened";
+    launchType: AnalyticsLaunchType;
+  }>
+  | Readonly<{
+    name: "screen_viewed";
+    screen: AnalyticsSurface;
+  }>
+  | Readonly<{
+    name: "onboarding_step_completed";
+    step: AnalyticsOnboardingStep;
+    outcome: AnalyticsOnboardingOutcome;
+  }>
+  | Readonly<{
+    name: "signin_failed";
+    reason: AnalyticsSignInFailureReason;
+  }>
+  | Readonly<{
+    name: "review_session_started";
+    deckScope: AnalyticsDeckScope;
+  }>
+  | Readonly<{
+    name: "review_session_ended";
+    endReason: AnalyticsReviewSessionEndReason;
+    answeredCount: number;
+    durationMs: number;
+  }>
+  | Readonly<{
+    name: "review_answer_failed";
+    reason: AnalyticsReviewAnswerFailureReason;
+  }>
+  | Readonly<{
+    name: "card_create_started";
+    entryPoint: AnalyticsCardCreateEntryPoint;
+  }>
+  | Readonly<{
+    name: "sync_failed";
+    reason: AnalyticsSyncFailureReason;
+  }>
+  | Readonly<{
+    name: "catalog_deck_install_started";
+    packageSlug: string;
+  }>
+  | Readonly<{
+    name: "analytics_events_dropped";
+    reason: AnalyticsDropReason;
+    count: number;
+  }>;
+
+export type AnalyticsEventProperties = Readonly<Record<string, string | number>>;
+
+/** Wire shape of one event. Every key is sent explicitly, with `null` where there is no value. */
+export type AnalyticsWireEvent = Readonly<{
+  eventId: string;
+  eventName: AnalyticsEvent["name"];
+  clientOccurredAt: string;
+  networkState: AnalyticsNetworkState | null;
+  screen: AnalyticsSurface | null;
+  properties: AnalyticsEventProperties | null;
+  experimentAssignments: null;
+}>;
+
+export type AnalyticsWireContext = Readonly<{
+  osVersion: string | null;
+  deviceModel: string | null;
+  deviceLocale: string | null;
+  timezone: string | null;
+}>;
+
+export type AnalyticsWireBatch = Readonly<{
+  clientSentAt: string;
+  anonymousId: string | null;
+  sessionId: string | null;
+  context: AnalyticsWireContext;
+  events: ReadonlyArray<AnalyticsWireEvent>;
+}>;
+
+export const analyticsCatalogSlugPattern = /^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$/u;
+
+/** Catalog property names are snake_case on the wire; the union carries them as camelCase. */
+export function buildAnalyticsEventProperties(event: AnalyticsEvent): AnalyticsEventProperties | null {
+  switch (event.name) {
+    case "app_opened":
+      return { launch_type: event.launchType };
+    case "screen_viewed":
+      return null;
+    case "onboarding_step_completed":
+      return { step: event.step, outcome: event.outcome };
+    case "signin_failed":
+      return { reason: event.reason };
+    case "review_session_started":
+      return { deck_scope: event.deckScope };
+    case "review_session_ended":
+      return {
+        end_reason: event.endReason,
+        answered_count: event.answeredCount,
+        duration_ms: event.durationMs,
+      };
+    case "review_answer_failed":
+      return { reason: event.reason };
+    case "card_create_started":
+      return { entry_point: event.entryPoint };
+    case "sync_failed":
+      return { reason: event.reason };
+    case "catalog_deck_install_started":
+      return { package_slug: event.packageSlug };
+    case "analytics_events_dropped":
+      return { reason: event.reason, count: event.count };
+  }
+}

--- a/apps/web/src/analytics/failureReasons.ts
+++ b/apps/web/src/analytics/failureReasons.ts
@@ -1,0 +1,68 @@
+import { ApiError, ApiNetworkError } from "../api";
+import type {
+  AnalyticsReviewAnswerFailureReason,
+  AnalyticsSyncFailureReason,
+} from "./events";
+
+/**
+ * Maps a caught failure onto the catalog's closed reason vocabulary. The vocabulary is shared with
+ * iOS and Android, so the mapping stays on transport-level facts every client can observe.
+ */
+
+function isBrowserOffline(): boolean {
+  return navigator.onLine === false;
+}
+
+function isQuotaExceededError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "QuotaExceededError";
+}
+
+export function toAnalyticsSyncFailureReason(error: unknown): AnalyticsSyncFailureReason {
+  if (isQuotaExceededError(error)) {
+    return "storage_full";
+  }
+
+  if (error instanceof ApiNetworkError) {
+    return isBrowserOffline() ? "offline" : "timeout";
+  }
+
+  if (error instanceof ApiError) {
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      return "unauthorized";
+    }
+
+    if (error.statusCode === 409) {
+      return "conflict";
+    }
+
+    if (error.statusCode === 408 || error.statusCode === 504) {
+      return "timeout";
+    }
+
+    return "server_error";
+  }
+
+  return isBrowserOffline() ? "offline" : "server_error";
+}
+
+export function toAnalyticsReviewAnswerFailureReason(
+  error: unknown,
+): AnalyticsReviewAnswerFailureReason {
+  if (error instanceof ApiNetworkError) {
+    return isBrowserOffline() ? "offline" : "timeout";
+  }
+
+  if (error instanceof ApiError) {
+    if (error.statusCode === 409) {
+      return "sync_conflict";
+    }
+
+    if (error.statusCode === 408 || error.statusCode === 504) {
+      return "timeout";
+    }
+
+    return "server_error";
+  }
+
+  return isBrowserOffline() ? "offline" : "server_error";
+}

--- a/apps/web/src/analytics/identity.ts
+++ b/apps/web/src/analytics/identity.ts
@@ -1,0 +1,201 @@
+/**
+ * Analytics identity. `anonymous_id` is per install and must never outlive an explicit logout, so it
+ * has its own `flashcards-` prefixed key and is deliberately not the shared installation id from
+ * `clientIdentity.ts`, which stays stable across users for sync.
+ */
+
+const anonymousIdStorageKey = "flashcards-analytics-anonymous-id";
+const sessionStorageKey = "flashcards-analytics-session";
+export const analyticsEnabledStorageKey = "flashcards-analytics-enabled";
+
+/** Shared with iOS and Android: a new session after 30 minutes with no emitted analytics event. */
+const sessionInactivityTimeoutMs = 30 * 60 * 1000;
+
+// `track` runs on click handlers, so the session heartbeat is persisted at most this often rather
+// than on every event: a synchronous storage write does not belong on the interaction path, and the
+// only thing this write protects is session continuity across a reload, against a 30-minute timeout.
+const sessionPersistIntervalMs = 60 * 1000;
+
+type AnalyticsSessionState = Readonly<{
+  sessionId: string;
+  lastEventAtMs: number;
+}>;
+
+// Browser storage throws in a few real configurations (Safari private browsing, storage disabled by
+// policy). Analytics must never surface that to the user, so the ids live in memory when the store
+// is unusable and the batch still ships with a consistent pair.
+let inMemoryAnonymousId: string | null = null;
+let inMemorySessionState: AnalyticsSessionState | null = null;
+let sessionPersistedAtMs = 0;
+
+function readBrowserStorageItem(storageKey: string): string | null {
+  try {
+    return window.localStorage.getItem(storageKey);
+  } catch {
+    return null;
+  }
+}
+
+function writeBrowserStorageItem(storageKey: string, value: string): void {
+  try {
+    window.localStorage.setItem(storageKey, value);
+  } catch {
+    // The in-memory copy carries this browsing context; nothing else can be done.
+  }
+}
+
+function removeBrowserStorageItem(storageKey: string): void {
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // Nothing to do: the in-memory copy has already been cleared by the caller.
+  }
+}
+
+function toHexByte(value: number): string {
+  return value.toString(16).padStart(2, "0");
+}
+
+/**
+ * UUID version 7. `crypto.randomUUID()` produces version 4, which the ingest endpoint rejects as a
+ * generic `invalid_event`, so event ids are generated explicitly here.
+ */
+export function createAnalyticsUuidV7(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  const timestampMs = Date.now();
+  bytes[0] = Math.floor(timestampMs / 2 ** 40) & 0xff;
+  bytes[1] = Math.floor(timestampMs / 2 ** 32) & 0xff;
+  bytes[2] = Math.floor(timestampMs / 2 ** 24) & 0xff;
+  bytes[3] = Math.floor(timestampMs / 2 ** 16) & 0xff;
+  bytes[4] = Math.floor(timestampMs / 2 ** 8) & 0xff;
+  bytes[5] = timestampMs & 0xff;
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, toHexByte).join("");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+function isAnalyticsUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u.test(value);
+}
+
+function readStoredAnonymousId(): string | null {
+  const storedValue = readBrowserStorageItem(anonymousIdStorageKey);
+  if (storedValue === null) {
+    return null;
+  }
+
+  const anonymousId = storedValue.trim().toLowerCase();
+  return isAnalyticsUuid(anonymousId) ? anonymousId : null;
+}
+
+export function readAnalyticsAnonymousId(): string {
+  const storedAnonymousId = readStoredAnonymousId();
+  if (storedAnonymousId !== null) {
+    inMemoryAnonymousId = storedAnonymousId;
+    return storedAnonymousId;
+  }
+
+  const nextAnonymousId = inMemoryAnonymousId ?? crypto.randomUUID().toLowerCase();
+  inMemoryAnonymousId = nextAnonymousId;
+  writeBrowserStorageItem(anonymousIdStorageKey, nextAnonymousId);
+  return nextAnonymousId;
+}
+
+function readStoredSessionState(): AnalyticsSessionState | null {
+  const storedValue = readBrowserStorageItem(sessionStorageKey);
+  if (storedValue === null) {
+    return inMemorySessionState;
+  }
+
+  try {
+    const parsedValue: unknown = JSON.parse(storedValue);
+    if (typeof parsedValue !== "object" || parsedValue === null || Array.isArray(parsedValue)) {
+      return inMemorySessionState;
+    }
+
+    const { sessionId, lastEventAtMs } = parsedValue as Readonly<{
+      sessionId?: unknown;
+      lastEventAtMs?: unknown;
+    }>;
+    if (
+      typeof sessionId !== "string"
+      || isAnalyticsUuid(sessionId) === false
+      || typeof lastEventAtMs !== "number"
+      || Number.isFinite(lastEventAtMs) === false
+    ) {
+      return inMemorySessionState;
+    }
+
+    return { sessionId, lastEventAtMs };
+  } catch {
+    return inMemorySessionState;
+  }
+}
+
+function writeSessionState(sessionState: AnalyticsSessionState, isNewSession: boolean): void {
+  const previousSessionState = inMemorySessionState;
+  inMemorySessionState = sessionState;
+  if (
+    isNewSession === false
+    && previousSessionState !== null
+    && sessionState.lastEventAtMs - sessionPersistedAtMs < sessionPersistIntervalMs
+  ) {
+    return;
+  }
+
+  sessionPersistedAtMs = sessionState.lastEventAtMs;
+  writeBrowserStorageItem(sessionStorageKey, JSON.stringify(sessionState));
+}
+
+/**
+ * Returns the current session id and records the event time that keeps it alive. Persisted so a page
+ * reload continues the same session, which is what makes web session counts comparable with the
+ * mobile clients.
+ */
+export function readAnalyticsSessionId(nowMs: number): string {
+  const sessionState = readStoredSessionState();
+  if (
+    sessionState !== null
+    && nowMs >= sessionState.lastEventAtMs
+    && nowMs - sessionState.lastEventAtMs <= sessionInactivityTimeoutMs
+  ) {
+    writeSessionState({ sessionId: sessionState.sessionId, lastEventAtMs: nowMs }, false);
+    return sessionState.sessionId;
+  }
+
+  const sessionId = crypto.randomUUID().toLowerCase();
+  writeSessionState({ sessionId, lastEventAtMs: nowMs }, true);
+  return sessionId;
+}
+
+/** Rotates `anonymous_id` and starts a fresh session. Called only from the logout cleanup path. */
+export function resetAnalyticsIdentity(): void {
+  inMemoryAnonymousId = null;
+  inMemorySessionState = null;
+  sessionPersistedAtMs = 0;
+  removeBrowserStorageItem(anonymousIdStorageKey);
+  removeBrowserStorageItem(sessionStorageKey);
+}
+
+export function readStoredAnalyticsEnabled(): boolean {
+  return readBrowserStorageItem(analyticsEnabledStorageKey) !== "0";
+}
+
+export function writeStoredAnalyticsEnabled(enabled: boolean): void {
+  if (enabled) {
+    removeBrowserStorageItem(analyticsEnabledStorageKey);
+    return;
+  }
+
+  writeBrowserStorageItem(analyticsEnabledStorageKey, "0");
+}

--- a/apps/web/src/analytics/index.ts
+++ b/apps/web/src/analytics/index.ts
@@ -1,0 +1,15 @@
+export {
+  flush,
+  reset,
+  setAnalyticsConfirmedOwner,
+  setEnabled,
+  track,
+  trackCatalogDeckInstallStarted,
+} from "./client";
+export type { AnalyticsEvent, AnalyticsSyncFailureReason } from "./events";
+export {
+  toAnalyticsReviewAnswerFailureReason,
+  toAnalyticsSyncFailureReason,
+} from "./failureReasons";
+export { AnalyticsLifecycle } from "./AnalyticsLifecycle";
+export { useReviewSessionAnalytics } from "./useReviewSessionAnalytics";

--- a/apps/web/src/analytics/observation.ts
+++ b/apps/web/src/analytics/observation.ts
@@ -1,0 +1,122 @@
+import {
+  captureWebException,
+  captureWebWarning,
+  normalizeCaughtError,
+  type AnalyticsDeliveryWarningDetails,
+  type WebObservationScope,
+} from "../observability/webObservability";
+import { AnalyticsQueueError } from "./queue";
+
+/**
+ * Reports only what the server cannot see. Per-event rejections are deliberately not reported: the
+ * ingest endpoint already captures contract violations with cross-client grouping, and the loss is
+ * carried into the data itself by `analytics_events_dropped`. Ordinary offline and transient network
+ * failures are expected behavior and are not reported either.
+ */
+
+type AnalyticsWarningKind = AnalyticsDeliveryWarningDetails["eventName"];
+
+// Every report in this file is capped at one per session. Analytics failure modes are sticky rather
+// than one-off — an unusable IndexedDB stays unusable for the whole session — and the periodic flush
+// timer would otherwise turn a single unavailable store into a report a minute, forever.
+const reportedKeys = new Set<string>();
+
+function shouldReportOnceInSession(reportKey: string): boolean {
+  if (reportedKeys.has(reportKey)) {
+    return false;
+  }
+
+  reportedKeys.add(reportKey);
+  return true;
+}
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildAnalyticsObservationScope(statusCode: number | null): WebObservationScope {
+  return {
+    app: "web",
+    feature: "analytics",
+    userId: null,
+    workspaceId: null,
+    installationId: null,
+    route: getCurrentRoute(),
+    requestId: null,
+    statusCode,
+    code: null,
+  };
+}
+
+function captureOnceInSession(
+  eventName: AnalyticsWarningKind,
+  count: number | null,
+  statusCode: number | null,
+): void {
+  if (shouldReportOnceInSession(eventName) === false) {
+    return;
+  }
+
+  captureWebWarning({
+    action: "analytics_delivery_degraded",
+    scope: buildAnalyticsObservationScope(statusCode),
+    details: { eventName, count, statusCode },
+  });
+}
+
+export function reportAnalyticsQueueOverflow(count: number): void {
+  captureOnceInSession("analytics_queue_overflow", count, null);
+}
+
+export function reportAnalyticsQueueTtlExpiry(count: number): void {
+  captureOnceInSession("analytics_queue_ttl_expired", count, null);
+}
+
+/**
+ * Undelivered events dropped by an identity reset. The catalog's `analytics_events_dropped` cannot
+ * carry this loss: its `reason` is a frozen enum of `queue_overflow`, `ttl_expired` and `rejected`,
+ * and reusing `rejected` for a local discard would corrupt the one signal that reports server-side
+ * refusals. Observability is therefore the only place this loss can be made visible.
+ */
+export function reportAnalyticsQueueDiscardedOnReset(count: number): void {
+  captureOnceInSession("analytics_queue_discarded_on_reset", count, null);
+}
+
+/** A whole-batch refusal means this client is off contract and is losing every event it sends. */
+export function reportAnalyticsInvalidBatch(statusCode: number): void {
+  captureOnceInSession("analytics_batch_invalid", null, statusCode);
+}
+
+export function reportAnalyticsSustainedDeliveryFailure(statusCode: number): void {
+  captureOnceInSession("analytics_delivery_unavailable", null, statusCode);
+}
+
+/**
+ * The local queue failing to open, write, or read back is invisible everywhere else. Keyed by
+ * operation so each distinct failure is still reported once, while a store that is unusable for the
+ * whole session — a private window, blocked site data, an exhausted quota — reports a handful of
+ * exceptions instead of one per periodic flush.
+ */
+export function reportAnalyticsQueueFailure(error: unknown): void {
+  if (error instanceof AnalyticsQueueError === false) {
+    return;
+  }
+
+  if (shouldReportOnceInSession(`analytics_queue_failed:${error.operation}`) === false) {
+    return;
+  }
+
+  captureWebException({
+    action: "analytics_queue_failed",
+    error: normalizeCaughtError(error),
+    scope: buildAnalyticsObservationScope(null),
+    details: {
+      operation: error.operation,
+      indexedDbErrorName: error.indexedDbErrorName,
+    },
+  });
+}

--- a/apps/web/src/analytics/queue.ts
+++ b/apps/web/src/analytics/queue.ts
@@ -1,0 +1,384 @@
+import type { AnalyticsWireEvent } from "./events";
+
+/**
+ * Durable analytics queue. It lives in its own IndexedDB database rather than in
+ * `flashcards-web-sync` so a flush can never contend with, block, or be blocked by the app's own
+ * local data, its migrations, or its browser-data reset.
+ */
+
+const databaseName = "flashcards-analytics";
+const databaseVersion = 1;
+const eventsStoreName = "events";
+const metaStoreName = "meta";
+const totalsRecordKey = "totals";
+const ownerRecordKey = "owner";
+
+/** Shared with iOS and Android. */
+export const analyticsQueueEventLimit = 5000;
+export const analyticsQueueByteLimit = 5 * 1024 * 1024;
+export const analyticsQueueTtlMs = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * `sessionId` is stored per event because the wire envelope carries one session id for the whole
+ * batch: events created in different sessions must not be shipped together.
+ */
+export type AnalyticsQueueRecord = Readonly<{
+  eventId: string;
+  sessionId: string;
+  createdAtMs: number;
+  byteSize: number;
+  wireEvent: AnalyticsWireEvent;
+}>;
+
+export type QueuedAnalyticsEvent = AnalyticsQueueRecord & Readonly<{
+  sequence: number;
+}>;
+
+export type AnalyticsQueueReadResult = Readonly<{
+  events: ReadonlyArray<QueuedAnalyticsEvent>;
+  expiredCount: number;
+  /**
+   * The account the queued events were created under, read back in the same transaction that
+   * produced them, or `null` while the queue has never been claimed. A caller compares it with the
+   * account the current credential belongs to instead of reasoning about when its own reset runs.
+   */
+  ownerId: string | null;
+}>;
+
+export type AnalyticsQueueOwnerClaim = Readonly<{
+  /** The queue held another account's events; they were discarded by the claim. */
+  didReplaceForeignOwner: boolean;
+  discardedEventCount: number;
+}>;
+
+type AnalyticsQueueTotals = {
+  key: typeof totalsRecordKey;
+  eventCount: number;
+  byteCount: number;
+};
+
+type AnalyticsQueueOwner = Readonly<{
+  key: typeof ownerRecordKey;
+  ownerId: string;
+}>;
+
+export type AnalyticsQueueOperation = "open" | "append" | "read" | "remove" | "clear" | "claim";
+
+export class AnalyticsQueueError extends Error {
+  readonly operation: AnalyticsQueueOperation;
+  readonly indexedDbErrorName: string | null;
+
+  constructor(operation: AnalyticsQueueOperation, cause: unknown) {
+    super(`Analytics queue ${operation} failed`);
+    this.name = "AnalyticsQueueError";
+    this.operation = operation;
+    this.indexedDbErrorName = readErrorName(cause);
+  }
+}
+
+function readErrorName(cause: unknown): string | null {
+  if (typeof cause !== "object" || cause === null || "name" in cause === false) {
+    return null;
+  }
+
+  const errorName = (cause as Readonly<{ name: unknown }>).name;
+  return typeof errorName === "string" && errorName.trim() !== "" ? errorName : null;
+}
+
+function openAnalyticsDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, databaseVersion);
+
+    request.onerror = (): void => {
+      reject(new AnalyticsQueueError("open", request.error));
+    };
+
+    request.onupgradeneeded = (): void => {
+      const database = request.result;
+      if (database.objectStoreNames.contains(eventsStoreName) === false) {
+        database.createObjectStore(eventsStoreName, { keyPath: "sequence", autoIncrement: true });
+      }
+      if (database.objectStoreNames.contains(metaStoreName) === false) {
+        database.createObjectStore(metaStoreName, { keyPath: "key" });
+      }
+    };
+
+    request.onsuccess = (): void => {
+      // Release the connection as soon as another tab needs to upgrade or delete this database.
+      request.result.onversionchange = (): void => {
+        request.result.close();
+      };
+      resolve(request.result);
+    };
+  });
+}
+
+function createEmptyTotals(): AnalyticsQueueTotals {
+  return { key: totalsRecordKey, eventCount: 0, byteCount: 0 };
+}
+
+function toTotals(value: unknown): AnalyticsQueueTotals {
+  if (typeof value !== "object" || value === null) {
+    return createEmptyTotals();
+  }
+
+  const { eventCount, byteCount } = value as Readonly<{ eventCount?: unknown; byteCount?: unknown }>;
+  if (
+    typeof eventCount !== "number"
+    || Number.isFinite(eventCount) === false
+    || typeof byteCount !== "number"
+    || Number.isFinite(byteCount) === false
+  ) {
+    return createEmptyTotals();
+  }
+
+  return { key: totalsRecordKey, eventCount, byteCount };
+}
+
+function toOwnerId(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const { ownerId } = value as Readonly<{ ownerId?: unknown }>;
+  return typeof ownerId === "string" && ownerId !== "" ? ownerId : null;
+}
+
+function subtractFromTotals(totals: AnalyticsQueueTotals, byteSize: number): void {
+  totals.eventCount = Math.max(0, totals.eventCount - 1);
+  totals.byteCount = Math.max(0, totals.byteCount - byteSize);
+}
+
+function runAnalyticsQueueTransaction<ResultType>(
+  operation: AnalyticsQueueOperation,
+  run: (transaction: IDBTransaction, resolveResult: (result: ResultType) => void) => void,
+): Promise<ResultType> {
+  return openAnalyticsDatabase().then((database): Promise<ResultType> => {
+    let transaction: IDBTransaction;
+    try {
+      transaction = database.transaction([eventsStoreName, metaStoreName], "readwrite");
+    } catch (error) {
+      database.close();
+      return Promise.reject(new AnalyticsQueueError(operation, error));
+    }
+
+    const activeTransaction = transaction;
+    return new Promise<ResultType>((resolve, reject) => {
+      let result: ResultType | undefined = undefined;
+      let hasResult = false;
+
+      activeTransaction.onabort = (): void => {
+        database.close();
+        reject(new AnalyticsQueueError(operation, activeTransaction.error));
+      };
+
+      activeTransaction.oncomplete = (): void => {
+        database.close();
+        if (hasResult === false) {
+          reject(new AnalyticsQueueError(operation, new Error("Transaction completed without a result")));
+          return;
+        }
+
+        resolve(result as ResultType);
+      };
+
+      try {
+        run(activeTransaction, (transactionResult: ResultType): void => {
+          result = transactionResult;
+          hasResult = true;
+        });
+      } catch (error) {
+        activeTransaction.abort();
+        reject(new AnalyticsQueueError(operation, error));
+      }
+    });
+  });
+}
+
+/**
+ * Appends events and enforces the queue caps by dropping the oldest records. Returns how many
+ * records overflow removed so the loss can be counted into `analytics_events_dropped`.
+ */
+export function appendAnalyticsEvents(
+  records: ReadonlyArray<AnalyticsQueueRecord>,
+): Promise<number> {
+  return runAnalyticsQueueTransaction<number>("append", (transaction, resolveResult) => {
+    const eventsStore = transaction.objectStore(eventsStoreName);
+    const metaStore = transaction.objectStore(metaStoreName);
+    const totalsRequest = metaStore.get(totalsRecordKey);
+
+    totalsRequest.onsuccess = (): void => {
+      const totals = toTotals(totalsRequest.result);
+      for (const record of records) {
+        eventsStore.add(record);
+        totals.eventCount += 1;
+        totals.byteCount += record.byteSize;
+      }
+
+      let overflowCount = 0;
+      const cursorRequest = eventsStore.openCursor();
+      cursorRequest.onsuccess = (): void => {
+        const cursor = cursorRequest.result;
+        const isOverCap = totals.eventCount > analyticsQueueEventLimit
+          || totals.byteCount > analyticsQueueByteLimit;
+        if (cursor === null || isOverCap === false) {
+          metaStore.put(totals);
+          resolveResult(overflowCount);
+          return;
+        }
+
+        const droppedEvent = cursor.value as QueuedAnalyticsEvent;
+        cursor.delete();
+        subtractFromTotals(totals, droppedEvent.byteSize);
+        overflowCount += 1;
+        cursor.continue();
+      };
+    };
+  });
+}
+
+/**
+ * Reads the oldest events, dropping any that outlived the queue TTL on the way. Expired records are
+ * removed here rather than on a timer so every flush attempt keeps the queue bounded.
+ */
+export function readOldestAnalyticsEvents(limit: number, nowMs: number): Promise<AnalyticsQueueReadResult> {
+  return runAnalyticsQueueTransaction<AnalyticsQueueReadResult>("read", (transaction, resolveResult) => {
+    const eventsStore = transaction.objectStore(eventsStoreName);
+    const metaStore = transaction.objectStore(metaStoreName);
+    const ownerRequest = metaStore.get(ownerRecordKey);
+
+    ownerRequest.onsuccess = (): void => {
+      const ownerId = toOwnerId(ownerRequest.result);
+      const totalsRequest = metaStore.get(totalsRecordKey);
+
+      totalsRequest.onsuccess = (): void => {
+        const totals = toTotals(totalsRequest.result);
+        const expiresBeforeMs = nowMs - analyticsQueueTtlMs;
+        const events: Array<QueuedAnalyticsEvent> = [];
+        let expiredCount = 0;
+
+        const cursorRequest = eventsStore.openCursor();
+        cursorRequest.onsuccess = (): void => {
+          const cursor = cursorRequest.result;
+          if (cursor === null) {
+            metaStore.put(totals);
+            resolveResult({ events, expiredCount, ownerId });
+            return;
+          }
+
+          const queuedEvent = cursor.value as QueuedAnalyticsEvent;
+          if (queuedEvent.createdAtMs < expiresBeforeMs) {
+            cursor.delete();
+            subtractFromTotals(totals, queuedEvent.byteSize);
+            expiredCount += 1;
+            cursor.continue();
+            return;
+          }
+
+          events.push(queuedEvent);
+          if (events.length >= limit) {
+            metaStore.put(totals);
+            resolveResult({ events, expiredCount, ownerId });
+            return;
+          }
+
+          cursor.continue();
+        };
+      };
+    };
+  });
+}
+
+export function removeAnalyticsEvents(events: ReadonlyArray<QueuedAnalyticsEvent>): Promise<void> {
+  if (events.length === 0) {
+    return Promise.resolve();
+  }
+
+  const sequences = new Set(events.map((event) => event.sequence));
+  const lowestSequence = Math.min(...sequences);
+  const highestSequence = Math.max(...sequences);
+
+  return runAnalyticsQueueTransaction<null>("remove", (transaction, resolveResult) => {
+    const eventsStore = transaction.objectStore(eventsStoreName);
+    const metaStore = transaction.objectStore(metaStoreName);
+    const totalsRequest = metaStore.get(totalsRecordKey);
+
+    totalsRequest.onsuccess = (): void => {
+      const totals = toTotals(totalsRequest.result);
+      const cursorRequest = eventsStore.openCursor(IDBKeyRange.bound(lowestSequence, highestSequence));
+      cursorRequest.onsuccess = (): void => {
+        const cursor = cursorRequest.result;
+        if (cursor === null) {
+          metaStore.put(totals);
+          resolveResult(null);
+          return;
+        }
+
+        const queuedEvent = cursor.value as QueuedAnalyticsEvent;
+        if (sequences.has(queuedEvent.sequence)) {
+          cursor.delete();
+          subtractFromTotals(totals, queuedEvent.byteSize);
+        }
+
+        cursor.continue();
+      };
+    };
+  }).then((): void => undefined);
+}
+
+/**
+ * Empties the queue and returns how many undelivered events it discarded, so the loss is reportable.
+ * Releasing the owner leaves the queue unclaimed, which is what a logout wants: the next account
+ * confirmed on this browser adopts an empty queue instead of inheriting one.
+ */
+export function clearAnalyticsQueue(shouldReleaseOwner: boolean): Promise<number> {
+  return runAnalyticsQueueTransaction<number>("clear", (transaction, resolveResult) => {
+    const eventsStore = transaction.objectStore(eventsStoreName);
+    const metaStore = transaction.objectStore(metaStoreName);
+    const totalsRequest = metaStore.get(totalsRecordKey);
+
+    totalsRequest.onsuccess = (): void => {
+      const discardedEventCount = toTotals(totalsRequest.result).eventCount;
+      eventsStore.clear();
+      metaStore.put(createEmptyTotals());
+      if (shouldReleaseOwner) {
+        metaStore.delete(ownerRecordKey);
+      }
+
+      resolveResult(discardedEventCount);
+    };
+  });
+}
+
+/**
+ * Records `ownerId` as the owner of everything in the queue, emptying it first when it was filled
+ * under a different account. Both halves run in one transaction, so the queue is never readable while
+ * its stored owner already names the account that just signed in.
+ */
+export function claimAnalyticsQueueOwner(ownerId: string): Promise<AnalyticsQueueOwnerClaim> {
+  return runAnalyticsQueueTransaction<AnalyticsQueueOwnerClaim>("claim", (transaction, resolveResult) => {
+    const eventsStore = transaction.objectStore(eventsStoreName);
+    const metaStore = transaction.objectStore(metaStoreName);
+    const ownerRequest = metaStore.get(ownerRecordKey);
+
+    ownerRequest.onsuccess = (): void => {
+      const storedOwnerId = toOwnerId(ownerRequest.result);
+      const nextOwner: AnalyticsQueueOwner = { key: ownerRecordKey, ownerId };
+      metaStore.put(nextOwner);
+      // An unclaimed queue holds events created before any credential existed. Those belong to the
+      // account signing in now, so it adopts them rather than discarding them.
+      if (storedOwnerId === null || storedOwnerId === ownerId) {
+        resolveResult({ didReplaceForeignOwner: false, discardedEventCount: 0 });
+        return;
+      }
+
+      const totalsRequest = metaStore.get(totalsRecordKey);
+      totalsRequest.onsuccess = (): void => {
+        const discardedEventCount = toTotals(totalsRequest.result).eventCount;
+        eventsStore.clear();
+        metaStore.put(createEmptyTotals());
+        resolveResult({ didReplaceForeignOwner: true, discardedEventCount });
+      };
+    };
+  });
+}

--- a/apps/web/src/analytics/surfaces.ts
+++ b/apps/web/src/analytics/surfaces.ts
@@ -1,0 +1,66 @@
+import {
+  cardsRoute,
+  chatRoute,
+  progressRoute,
+  reviewRoute,
+  settingsDecksRoute,
+  settingsHubRoute,
+} from "../routes";
+import type { AnalyticsSurface } from "./events";
+
+const catalogImportRoutePrefix = "/catalog/import/";
+
+function isDeckDetailRoute(pathname: string): boolean {
+  if (pathname.startsWith(`${settingsDecksRoute}/`) === false) {
+    return false;
+  }
+
+  const deckSegments = pathname.slice(settingsDecksRoute.length + 1).split("/");
+  return deckSegments.length === 1 && deckSegments[0] !== "" && deckSegments[0] !== "new";
+}
+
+/**
+ * Maps a web route onto the platform-independent surface enum shared with iOS and Android. Routes
+ * with no shared surface return null and emit no `screen_viewed`; a route path is never sent.
+ *
+ * A route that renders no screen maps to null, redirect-only routes included. `/` is a bare
+ * `<Navigate replace to={reviewRoute} />`, so counting it as `review` would emit `screen_viewed`
+ * twice for every cold start at the site root — permanently, on an append-only table, and only on
+ * web, where iOS and Android have no such route. The legacy `/decks`, `/decks/:deckId`,
+ * `/decks/:deckId/edit` and `/tags` redirects reach the same null by falling through.
+ */
+export function resolveAnalyticsSurface(pathname: string): AnalyticsSurface | null {
+  if (pathname === reviewRoute) {
+    return "review";
+  }
+
+  if (pathname === cardsRoute) {
+    return "cards";
+  }
+
+  if (pathname.startsWith(`${cardsRoute}/`)) {
+    return "card_editor";
+  }
+
+  if (pathname === progressRoute) {
+    return "progress";
+  }
+
+  if (pathname === chatRoute) {
+    return "ai";
+  }
+
+  if (pathname.startsWith(catalogImportRoutePrefix)) {
+    return "catalog";
+  }
+
+  if (isDeckDetailRoute(pathname)) {
+    return "deck_detail";
+  }
+
+  if (pathname === settingsHubRoute || pathname.startsWith(`${settingsHubRoute}/`)) {
+    return "settings";
+  }
+
+  return null;
+}

--- a/apps/web/src/analytics/useReviewSessionAnalytics.ts
+++ b/apps/web/src/analytics/useReviewSessionAnalytics.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ReviewFilter } from "../types";
+import { registerAnalyticsPageHideCollector, track } from "./client";
+import type { AnalyticsDeckScope, AnalyticsReviewSessionEndReason } from "./events";
+
+type ActiveReviewSession = {
+  startedAtMs: number;
+  answeredCount: number;
+};
+
+type UseReviewSessionAnalyticsParams = Readonly<{
+  reviewFilter: ReviewFilter | null;
+  isReviewQueueEmpty: boolean;
+}>;
+
+type UseReviewSessionAnalyticsResult = Readonly<{
+  recordReviewAnswerSettled: (wasAnswerSaved: boolean) => void;
+  recordReviewAnswerStarted: () => void;
+}>;
+
+export function toAnalyticsDeckScope(reviewFilter: ReviewFilter): AnalyticsDeckScope {
+  switch (reviewFilter.kind) {
+    case "allCards":
+      return "all";
+    case "deck":
+      return "deck";
+    case "tags":
+      return "filter";
+  }
+}
+
+/**
+ * Tracks one review session per review scope. A session ends `completed` when the queue empties
+ * after at least one answer, `abandoned` when the user leaves the screen, and `interrupted` when the
+ * review scope changes underneath it or the page goes away.
+ *
+ * The page-away case is why this hook carries its own unload handling. Closing the tab, reloading,
+ * or navigating off the origin mid-review is an ordinary way to end a web review session, and React
+ * runs no effect cleanup for any of it. Without this, `review_session_started` would systematically
+ * outnumber `review_session_ended`, and `answered_count` and `duration_ms` — the only quantitative
+ * fields in the whole client catalog — would only ever describe sessions that ended by in-app
+ * navigation. `product_events` is append-only, so that bias would never be correctable.
+ *
+ * An answer is announced to this hook before it is submitted and again once it settles, because the
+ * review screen empties its queue optimistically and only then awaits the IndexedDB write. Treating
+ * the empty queue as a finished session while that write is in flight would close every session one
+ * answer short and leave the settled answer to open a phantom second one.
+ */
+export function useReviewSessionAnalytics(
+  params: UseReviewSessionAnalyticsParams,
+): UseReviewSessionAnalyticsResult {
+  const { reviewFilter, isReviewQueueEmpty } = params;
+  const deckScope = reviewFilter === null ? null : toAnalyticsDeckScope(reviewFilter);
+  const sessionRef = useRef<ActiveReviewSession | null>(null);
+  const isUnmountingRef = useRef<boolean>(false);
+  const isEndedByPageHideRef = useRef<boolean>(false);
+  const pendingAnswerCountRef = useRef<number>(0);
+  const [settledAnswerRevision, setSettledAnswerRevision] = useState<number>(0);
+
+  const endSession = useCallback(function endSession(endReason: AnalyticsReviewSessionEndReason): void {
+    const session = sessionRef.current;
+    if (session === null) {
+      return;
+    }
+
+    sessionRef.current = null;
+    track({
+      name: "review_session_ended",
+      endReason,
+      answeredCount: session.answeredCount,
+      durationMs: Math.max(0, Date.now() - session.startedAtMs),
+    });
+  }, []);
+
+  const startSession = useCallback(function startSession(nextDeckScope: AnalyticsDeckScope): void {
+    isEndedByPageHideRef.current = false;
+    sessionRef.current = {
+      startedAtMs: Date.now(),
+      answeredCount: 0,
+    };
+    track({ name: "review_session_started", deckScope: nextDeckScope });
+  }, []);
+
+  // Declared before the session effect on purpose: React runs cleanups in declaration order, so this
+  // flag is already set when the session cleanup below decides between `abandoned` and `interrupted`.
+  useEffect(() => {
+    isUnmountingRef.current = false;
+    return (): void => {
+      isUnmountingRef.current = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (deckScope === null) {
+      return undefined;
+    }
+
+    startSession(deckScope);
+    return (): void => {
+      endSession(isUnmountingRef.current ? "abandoned" : "interrupted");
+    };
+  }, [deckScope, endSession, startSession]);
+
+  // Completion is decided only while no answer is in flight, and `settledAnswerRevision` re-runs the
+  // decision once one settles, so the count that ships with `completed` always includes the answer
+  // that emptied the queue. The re-run reads the queue state committed after the submit, which is
+  // what keeps a queue refilled by the follow-up chunk load from being reported as finished.
+  useEffect(() => {
+    if (
+      isReviewQueueEmpty === false
+      || pendingAnswerCountRef.current > 0
+      || (sessionRef.current?.answeredCount ?? 0) === 0
+    ) {
+      return;
+    }
+
+    endSession("completed");
+  }, [endSession, isReviewQueueEmpty, settledAnswerRevision]);
+
+  useEffect(() => {
+    function endSessionForPageHide(): void {
+      if (sessionRef.current === null) {
+        return;
+      }
+
+      isEndedByPageHideRef.current = true;
+      endSession("interrupted");
+    }
+
+    // The page came back and this screen is still mounted, so the user resumes reviewing under a
+    // fresh session rather than inside one whose end has already been reported. Guarded by the flag,
+    // so a session that ended `completed` is not silently restarted, and so the two restore signals
+    // below cannot start two sessions.
+    function restartSessionAfterPageHide(): void {
+      if (isEndedByPageHideRef.current === false || sessionRef.current !== null || deckScope === null) {
+        return;
+      }
+
+      startSession(deckScope);
+    }
+
+    function handleVisibilityChange(): void {
+      if (document.visibilityState === "visible") {
+        restartSessionAfterPageHide();
+      }
+    }
+
+    // The hidden half is deliberately not a listener of its own. The analytics client runs every
+    // registered collector, then persists, then flushes, so this event is in the batch the tab hide
+    // itself ships instead of waiting for a later trigger — and for the hide that is a sign-out
+    // navigation, the later trigger is a boot whose identity reset discards the event.
+    const unregisterPageHideCollector = registerAnalyticsPageHideCollector(endSessionForPageHide);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    // A back-forward cache restore is the other way a hidden page becomes live again.
+    window.addEventListener("pageshow", restartSessionAfterPageHide);
+    return (): void => {
+      unregisterPageHideCollector();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pageshow", restartSessionAfterPageHide);
+    };
+  }, [deckScope, endSession, startSession]);
+
+  const recordReviewAnswerStarted = useCallback(function recordReviewAnswerStarted(): void {
+    pendingAnswerCountRef.current += 1;
+  }, []);
+
+  const recordReviewAnswerSettled = useCallback(function recordReviewAnswerSettled(
+    wasAnswerSaved: boolean,
+  ): void {
+    pendingAnswerCountRef.current = Math.max(0, pendingAnswerCountRef.current - 1);
+    // A submit that did not save is rolled back into the queue and already reported by
+    // `review_answer_failed`, so it must leave behind neither a counted answer nor a completion.
+    if (wasAnswerSaved === false) {
+      return;
+    }
+
+    // The other half of the phantom-session defect: an answer that settles after its session was
+    // already reported must not resurrect one. Only a screen still mounted and still in the
+    // foreground can legitimately be mid-review with no open session — the queue refilled after a
+    // `completed` — and an unmount or a page hide mid-submit has already reported the answer's real
+    // session, so the settled answer belongs to no session at all.
+    if (sessionRef.current === null) {
+      if (deckScope === null || isUnmountingRef.current || document.visibilityState !== "visible") {
+        return;
+      }
+
+      startSession(deckScope);
+    }
+
+    const session = sessionRef.current;
+    if (session !== null) {
+      session.answeredCount += 1;
+    }
+
+    setSettledAnswerRevision((currentRevision) => currentRevision + 1);
+  }, [deckScope, startSession]);
+
+  return { recordReviewAnswerSettled, recordReviewAnswerStarted };
+}

--- a/apps/web/src/analytics/wire.ts
+++ b/apps/web/src/analytics/wire.ts
@@ -1,0 +1,100 @@
+import {
+  buildAnalyticsEventProperties,
+  type AnalyticsEvent,
+  type AnalyticsNetworkState,
+  type AnalyticsSurface,
+  type AnalyticsWireContext,
+  type AnalyticsWireEvent,
+} from "./events";
+import { createAnalyticsUuidV7 } from "./identity";
+
+/** `context` string fields are capped at 200 characters by the ingest endpoint. */
+const contextStringMaxLength = 200;
+const wireEventTextEncoder = new TextEncoder();
+
+type NetworkInformation = Readonly<{
+  type?: string;
+}>;
+
+type NavigatorWithConnection = Navigator & Readonly<{
+  connection?: NetworkInformation;
+}>;
+
+/**
+ * The ingest endpoint accepts UTC only: a timezone offset fails `z.string().datetime()` and rejects
+ * the event, or the whole batch when it is `clientSentAt`. `toISOString` is always `Z`-suffixed UTC.
+ */
+export function toAnalyticsTimestamp(atMs: number): string {
+  return new Date(atMs).toISOString();
+}
+
+/**
+ * Captured per event rather than per batch: an offline-first client only ever flushes while online,
+ * so a flush-time reading could never record `offline`.
+ */
+export function readAnalyticsNetworkState(): AnalyticsNetworkState {
+  if (navigator.onLine === false) {
+    return "offline";
+  }
+
+  const connectionType = (navigator as NavigatorWithConnection).connection?.type;
+  if (connectionType === "wifi") {
+    return "wifi";
+  }
+
+  if (connectionType === "cellular") {
+    return "cellular";
+  }
+
+  return "unknown";
+}
+
+function toContextString(value: string): string | null {
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
+    return null;
+  }
+
+  return trimmedValue.slice(0, contextStringMaxLength);
+}
+
+function readTimezone(): string | null {
+  try {
+    return toContextString(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Describes the device at flush time. The browser exposes no trustworthy OS version or device model,
+ * so both are sent as explicit nulls rather than as a parsed user agent string.
+ */
+export function buildAnalyticsWireContext(): AnalyticsWireContext {
+  return {
+    osVersion: null,
+    deviceModel: null,
+    deviceLocale: toContextString(navigator.language),
+    timezone: readTimezone(),
+  };
+}
+
+export function toAnalyticsWireEvent(
+  event: AnalyticsEvent,
+  occurredAtMs: number,
+  currentSurface: AnalyticsSurface | null,
+): AnalyticsWireEvent {
+  return {
+    eventId: createAnalyticsUuidV7(),
+    eventName: event.name,
+    clientOccurredAt: toAnalyticsTimestamp(occurredAtMs),
+    networkState: readAnalyticsNetworkState(),
+    screen: event.name === "screen_viewed" ? event.screen : currentSurface,
+    properties: buildAnalyticsEventProperties(event),
+    experimentAssignments: null,
+  };
+}
+
+export function measureAnalyticsWireEventBytes(wireEvent: AnalyticsWireEvent): number {
+  return wireEventTextEncoder.encode(JSON.stringify(wireEvent)).length;
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -25,6 +25,12 @@ export {
   updateCommunityProfile,
 } from "./api/endpoints/account";
 export {
+  sendAnalyticsEventsBatch,
+} from "./api/endpoints/analytics";
+export type {
+  AnalyticsIngestResult,
+} from "./api/endpoints/analytics";
+export {
   queryCards,
 } from "./api/endpoints/cards";
 export {

--- a/apps/web/src/api/endpoints/analytics.ts
+++ b/apps/web/src/api/endpoints/analytics.ts
@@ -1,0 +1,57 @@
+import type { AnalyticsWireBatch } from "../../analytics/events";
+import { webAppVersion } from "../../clientIdentity";
+import { requestJson, type RequestOptions } from "../transport/transport";
+
+export type AnalyticsIngestResult = Readonly<{
+  acceptedCount: number;
+  rejectedCount: number;
+}>;
+
+/**
+ * Analytics runs entirely in the background, so it never joins auth recovery: a batch that meets an
+ * expired session must not refresh the session or redirect the browser to sign in. It stays queued
+ * and ships on a later flush. Network retries are owned by the analytics client's own backoff.
+ */
+const analyticsRequestOptions: RequestOptions = {
+  authRecoveryMode: "skip",
+  networkRetryMode: "none",
+  prepareForAuthRedirect: null,
+};
+
+// A malformed 200 body still means the server finished the batch, so the payload is read
+// defensively rather than through a contract parser that would throw and hold the events back.
+function readEventCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+function readRejectedCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+/**
+ * Posts one analytics batch. The path carries no trailing slash on purpose: `/v1/analytics/events/`
+ * answers 404 and misses the endpoint's own API Gateway throttle and alarms.
+ *
+ * `X-Client-Platform` and `X-Client-Version` are the only source of the append-only `platform` and
+ * `app_version` columns, and this repository sets them per endpoint rather than globally.
+ */
+export async function sendAnalyticsEventsBatch(batch: AnalyticsWireBatch): Promise<AnalyticsIngestResult> {
+  const payload = await requestJson("/analytics/events", {
+    method: "POST",
+    headers: {
+      "X-Client-Platform": "web",
+      "X-Client-Version": webAppVersion,
+    },
+    body: JSON.stringify(batch),
+  }, analyticsRequestOptions);
+
+  if (typeof payload.value !== "object" || payload.value === null || Array.isArray(payload.value)) {
+    return { acceptedCount: 0, rejectedCount: 0 };
+  }
+
+  const { accepted, rejected } = payload.value as Readonly<{ accepted?: unknown; rejected?: unknown }>;
+  return {
+    acceptedCount: readEventCount(accepted),
+    rejectedCount: readRejectedCount(rejected),
+  };
+}

--- a/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
@@ -9,6 +9,7 @@ import {
   clearAllLocalBrowserData,
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
+import { reset as resetAnalytics } from "../../../analytics";
 import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import { putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import type {
@@ -78,6 +79,13 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
   ): Promise<void> {
     indexedDbOpenRecoveryState.throwIfFailed();
 
+    // Rotates `anonymous_id` and drops queued analytics events so a second person on this browser
+    // cannot inherit the first person's analytics identity or their unsent events. Do not flush
+    // first: this runs after the previous credential is gone or after `getSession()` already
+    // returned somebody else's session, so a batch sent here would post the previous account's
+    // events on the new account's credential. The discarded events are counted and reported inside
+    // `reset()`.
+    resetAnalytics();
     workspaceBootstrapGenerationRef.current += 1;
     deferredBootstrapWorkspaceRef.current = null;
     setSession(null);

--- a/apps/web/src/appData/session/browserSessionRecovery.ts
+++ b/apps/web/src/appData/session/browserSessionRecovery.ts
@@ -1,4 +1,5 @@
 import { isAccountDeletionAttemptStorageKey } from "../../accountDeletion/accountDeletionAttempt";
+import { analyticsEnabledStorageKey } from "../../analytics/identity";
 import { AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY } from "../../chat/preferences/AIChatPreferencesContext";
 import { INSTALLATION_ID_STORAGE_KEY } from "../../clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../i18n/runtime";
@@ -27,6 +28,7 @@ const PRESERVED_BROWSER_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
   LOCALE_PREFERENCE_STORAGE_KEY,
   AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY,
   TEST_MODE_STORAGE_KEY,
+  analyticsEnabledStorageKey,
 ];
 
 type BrowserStorageKeyPredicate = (storageKey: string) => boolean;
@@ -173,10 +175,11 @@ export function clearAuthResetRequired(): void {
  * or a confirmed account switch.
  *
  * The stable installation id, explicit locale preference, AI chat suggestions
- * setting, and hidden test-mode flag are intentionally retained because they are
- * browser-scoped preferences rather than user-scoped session state. Keeping them
- * preserves device identity, UI language, local chat UI preferences, and local
- * tester tooling across re-login while still clearing application data.
+ * setting, hidden test-mode flag, and analytics kill switch are intentionally
+ * retained because they are browser-scoped preferences rather than user-scoped
+ * session state. Keeping them preserves device identity, UI language, local chat
+ * UI preferences, local tester tooling, and an explicit analytics opt-out across
+ * re-login while still clearing application data.
  */
 export async function clearAllLocalBrowserData(
   reason: LocalBrowserDataCleanupReason,

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -18,6 +18,7 @@ import {
   setAccountDeletionPending,
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
+import { setAnalyticsConfirmedOwner } from "../../../analytics";
 import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../i18n";
 import { loadCloudSettings, putCloudSettings } from "../../../localDb/sync/cloudSettings";
@@ -238,6 +239,11 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
         return;
       }
 
+      // Publishes the account this browser's credential belongs to. The analytics queue stores the
+      // account it was filled under, so this is what lets analytics compare the two and either ship
+      // or discard; until it is published nothing is sent, which is why it is only reached once the
+      // session is verified and any user-scoped cleanup has already run.
+      setAnalyticsConfirmedOwner(currentSession.userId);
       setSessionVerificationState("verified");
     } catch (error) {
       const normalizedError = normalizeCaughtError(error);
@@ -343,6 +349,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             return false;
           }
 
+          setAnalyticsConfirmedOwner(currentSession.userId);
           setSessionVerificationState("verified");
           setSessionErrorMessage("");
           setErrorMessage("");

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -59,6 +59,7 @@ import {
   isWorkspaceNotFoundError,
   isWorkspaceSyncDiscardedError,
   observeSyncFailure,
+  observeSyncSuccess,
 } from "../observation/syncErrorObservation";
 import {
   createCardLocally,
@@ -628,6 +629,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           invalidateLocalReviewSchedule();
         }
         setErrorMessage("");
+        // Re-arms the `sync_failed` analytics transition for this workspace: its next failure after
+        // a healthy run is a new failure and is emitted, while repeats of an ongoing one stay
+        // suppressed and another workspace's ongoing failure keeps its own suppression.
+        observeSyncSuccess(workspaceId);
         runMediaUploadTransfersForWorkspace(workspace);
       } catch (error) {
         const normalizedError = normalizeCaughtError(error);

--- a/apps/web/src/appData/sync/observation/syncErrorObservation.ts
+++ b/apps/web/src/appData/sync/observation/syncErrorObservation.ts
@@ -1,4 +1,9 @@
 import {
+  toAnalyticsSyncFailureReason,
+  track,
+  type AnalyticsSyncFailureReason,
+} from "../../../analytics";
+import {
   ApiContractError,
   ApiError,
   isAuthRedirectError,
@@ -13,6 +18,36 @@ import { isBrowserApiNetworkError } from "../../../observability/apiNetworkError
 const workspaceNotFoundErrorCode = "WORKSPACE_NOT_FOUND";
 const workspaceSyncDiscardedErrorName = "WorkspaceSyncDiscardedError";
 const syncFailureCapturedProperty = "__flashcardsSyncFailureCaptured";
+
+type TrackedSyncFailure = Readonly<{
+  userId: string;
+  reason: AnalyticsSyncFailureReason;
+}>;
+
+/**
+ * `sync_failed` is emitted on the transition into failure rather than once per failed run. Sync runs
+ * on every resume, poll and local write, so an extended offline stretch would otherwise fill a
+ * meaningful share of the 5000-event analytics queue with identical rows and let drop-oldest evict
+ * the review events that carry the only quantitative fields in the catalog.
+ *
+ * The transition is kept per workspace because sync itself is per workspace: for an account with one
+ * healthy and one persistently failing workspace, a single shared entry would have every healthy run
+ * re-arm the gate and every failing run emit again — one `sync_failed` per sync cycle, exactly the
+ * flood the gate exists to prevent. The account and the reason are part of the transition too, so a
+ * failure that changes cause is emitted again, and so is the first failure seen by a different
+ * account after an in-page switch. iOS and Android emit on the same transition, which is what keeps
+ * the three clients comparable.
+ */
+const lastTrackedSyncFailureByWorkspace = new Map<string, TrackedSyncFailure>();
+
+/**
+ * Re-arms the transition for the workspace that synced cleanly. Deliberately scoped to that
+ * workspace: a healthy sync says nothing about another workspace's ongoing failure, and clearing
+ * theirs too would let the next failing run emit again on every cycle.
+ */
+export function observeSyncSuccess(workspaceId: string): void {
+  lastTrackedSyncFailureByWorkspace.delete(workspaceId);
+}
 
 type SyncFailureCapturedCarrier = Readonly<{
   __flashcardsSyncFailureCaptured?: true;
@@ -215,6 +250,22 @@ export function getSyncFailureObservationCaptureState(error: unknown): boolean |
 }
 
 export function observeSyncFailure(input: SyncFailureObservationInput): boolean {
+  // Reached only for genuine sync failures: auth redirects, discarded workspaces and stale workspace
+  // lookups return before this call.
+  const analyticsFailureReason = toAnalyticsSyncFailureReason(input.error);
+  const lastTrackedFailure = lastTrackedSyncFailureByWorkspace.get(input.workspaceId);
+  if (
+    lastTrackedFailure === undefined
+    || lastTrackedFailure.userId !== input.userId
+    || lastTrackedFailure.reason !== analyticsFailureReason
+  ) {
+    lastTrackedSyncFailureByWorkspace.set(input.workspaceId, {
+      userId: input.userId,
+      reason: analyticsFailureReason,
+    });
+    track({ name: "sync_failed", reason: analyticsFailureReason });
+  }
+
   const wasApiContractCaptured = captureApiContractError(input.error, {
     feature: "sync",
     sourceAction: "sync_workspace_refresh",

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react";
 import type { Scope } from "@sentry/react";
+import type { AnalyticsQueueOperation } from "../analytics/queue";
 import { isIndexedDbOpenRecoveryError } from "../localDb/core/indexedDbOpenRecovery";
 import { isBrowserApiNetworkError } from "./apiNetworkErrorPolicy";
 import { isWebSentryEnabled } from "./instrument";
@@ -15,7 +16,8 @@ export type WebObservationFeature =
   | "feedback"
   | "mobile_app_promo"
   | "progress"
-  | "settings";
+  | "settings"
+  | "analytics";
 
 export type WebObservationScope = Readonly<{
   app: "web";
@@ -336,6 +338,13 @@ export type IndexedDbOpenRecoveryFailureDetails = Readonly<{
   recoveryOwner: "app_error_dialog_provider";
 }>;
 
+// `operation` is the analytics queue's own union rather than a copy of it: the copy this replaces
+// had already drifted a value behind the queue, and a copy can only ever drift again.
+export type AnalyticsQueueFailureDetails = Readonly<{
+  operation: AnalyticsQueueOperation;
+  indexedDbErrorName: string | null;
+}>;
+
 export type WebAppOperation =
   | "session_resume"
   | "account_deletion_submit"
@@ -489,6 +498,12 @@ export type WebExceptionEvent =
     error: Error;
     scope: WebObservationScope;
     details: WebAppOperationFailureDetails;
+  }>
+  | Readonly<{
+    action: "analytics_queue_failed";
+    error: Error;
+    scope: WebObservationScope;
+    details: AnalyticsQueueFailureDetails;
   }>;
 
 export type ApiContractWarningDetails = Readonly<{
@@ -708,6 +723,20 @@ export type ProgressTimezoneInvalidWarningDetails = Readonly<{
   errorName: string;
 }>;
 
+// Losses the server cannot see, and which `analytics_events_dropped` cannot report when delivery is
+// the thing that is broken. Per-event rejections are deliberately absent: the ingest endpoint already
+// captures contract violations with cross-client grouping.
+export type AnalyticsDeliveryWarningDetails = Readonly<{
+  eventName:
+    | "analytics_queue_overflow"
+    | "analytics_queue_ttl_expired"
+    | "analytics_queue_discarded_on_reset"
+    | "analytics_batch_invalid"
+    | "analytics_delivery_unavailable";
+  count: number | null;
+  statusCode: number | null;
+}>;
+
 export type WebWarningEvent =
   | Readonly<{
     action: "api_contract_warning";
@@ -733,6 +762,11 @@ export type WebWarningEvent =
     action: "progress_timezone_invalid";
     scope: WebObservationScope;
     details: ProgressTimezoneInvalidWarningDetails;
+  }>
+  | Readonly<{
+    action: "analytics_delivery_degraded";
+    scope: WebObservationScope;
+    details: AnalyticsDeliveryWarningDetails;
   }>;
 
 type SentryContextValue =
@@ -845,6 +879,14 @@ export function buildWebExceptionFingerprint(event: WebExceptionEvent): Array<st
   }
 
   if (event.action === "app_operation_failed") {
+    return ["{{ default }}", event.action, event.details.operation];
+  }
+
+  // Queue failures are reported once per operation (`analytics/observation.ts`) precisely so the
+  // distinct ones survive that cap; grouping them all under the action would throw that away, and an
+  // owner claim that fails — which shuts the flush gate for the whole session — would be hidden
+  // behind whichever operation happened to be seen first.
+  if (event.action === "analytics_queue_failed") {
     return ["{{ default }}", event.action, event.details.operation];
   }
 

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link } from "react-router";
+import { track } from "../../../analytics";
 import { useAppData } from "../../../appData";
 import { normalizeTagKey } from "../../../appData/domain";
 import {
@@ -871,7 +872,14 @@ export function CardsScreen(): ReactElement {
           </div>
           <div className="screen-actions">
             <span className="badge">{visibleCountLabel}</span>
-            <Link className="primary-btn" to="/cards/new" data-testid="cards-new-card">{t("cardForm.title.new")}</Link>
+            <Link
+              className="primary-btn"
+              to="/cards/new"
+              data-testid="cards-new-card"
+              onClick={() => track({ name: "card_create_started", entryPoint: "cards" })}
+            >
+              {t("cardForm.title.new")}
+            </Link>
           </div>
         </div>
 

--- a/apps/web/src/screens/catalog/CatalogImportAuthenticatedFlow.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportAuthenticatedFlow.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useRef, useState, type ReactElement } from "react";
+import { trackCatalogDeckInstallStarted } from "../../analytics";
 import {
   confirmCatalogPackageInstall,
   isAuthRedirectError,
@@ -616,6 +617,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     activeInstallRequestRef.current = requestGeneration;
     setIsInstalling(true);
     setErrorMessage("");
+    trackCatalogDeckInstallStarted(preview.packageVersion.slug);
     try {
       indexedDbOpenRecoveryState.throwIfFailed();
       if (currentAttempt === null) {

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, type ReactElement } from "react";
 import { Link } from "react-router";
 import type { ReviewRating } from "../../../../../backend/src/scheduling";
+import { track } from "../../../analytics";
 import { useI18n } from "../../../i18n";
 import { cardsRoute, chatRoute } from "../../../routes";
 import type { Card } from "../../../types";
@@ -217,7 +218,11 @@ function ReviewEmptyPane(props: ReviewEmptyPaneProps): ReactElement {
           : t("reviewScreen.empty.noCardsBody")}
       </p>
       <div className="review-empty-actions">
-        <Link className="ghost-btn" to={`${cardsRoute}/new`}>
+        <Link
+          className="ghost-btn"
+          to={`${cardsRoute}/new`}
+          onClick={() => track({ name: "card_create_started", entryPoint: "review" })}
+        >
           {t("reviewScreen.actions.createCard")}
         </Link>
         <p className="review-empty-or">{t("reviewScreen.empty.or")}</p>

--- a/apps/web/src/screens/review/data/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/data/useReviewScreenData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { toAnalyticsReviewAnswerFailureReason, track } from "../../../analytics";
 import { ALL_CARDS_REVIEW_FILTER } from "../../../appData/domain";
 import {
   markIndexedDbOpenRecoveryFailureAndCheckActive,
@@ -625,6 +626,10 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         showCapturedTechnicalError(error);
         setErrorMessage(t("appError.technicalError.message"));
       }
+      track({
+        name: "review_answer_failed",
+        reason: toAnalyticsReviewAnswerFailureReason(error),
+      });
       return "failed";
     }
 

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { ReviewRating } from "../../../../backend/src/scheduling";
+import { useReviewSessionAnalytics } from "../../analytics";
 import { useAppData, useReviewLeaderboardBadge, useReviewProgressBadge } from "../../appData";
 import {
   markIndexedDbOpenRecoveryFailureAndCheckActive,
@@ -199,6 +200,10 @@ export function useReviewScreenController(
     userId: session?.userId ?? null,
     workspaceId: activeWorkspace?.workspaceId ?? null,
   });
+  const { recordReviewAnswerSettled, recordReviewAnswerStarted } = useReviewSessionAnalytics({
+    reviewFilter: hasLoadedReviewData ? resolvedReviewFilter : null,
+    isReviewQueueEmpty: activeReviewQueue.length === 0,
+  });
   const handoffCardToAi = useAiCardHandoff();
   const {
     feedbackDialogProps,
@@ -272,6 +277,10 @@ export function useReviewScreenController(
       rating,
     });
     let reviewSubmissionOutcome: ReviewSubmissionOutcome = "failed";
+    // Claimed before the submit: `handleReviewData` removes the card from the queue optimistically
+    // and only then awaits the IndexedDB write, so the review session must already know an answer is
+    // in flight by the time an empty queue becomes observable.
+    recordReviewAnswerStarted();
 
     try {
       reviewSubmissionOutcome = await handleReviewData(card, rating);
@@ -301,6 +310,7 @@ export function useReviewScreenController(
         void maybeOpenPostReviewPrompt();
       }
     } finally {
+      recordReviewAnswerSettled(reviewSubmissionOutcome === "saved");
       if (reviewSubmissionOutcome !== "cancelled" && indexedDbOpenRecoveryState.hasFailed() === false) {
         setIsSubmitting(false);
         if (reviewSubmissionOutcome === "stale") {


### PR DESCRIPTION
`POST /v1/analytics/events` has been live and unused since the backend shipped. This is the first client to send it real traffic, so every identity link it writes is a first link.

## What it does

A type-strict analytics module in `apps/web/src/analytics/`. Events are a closed discriminated union mirroring the backend's frozen catalog — a typo or an undeclared property does not compile, and there is no `track(name, properties)` anywhere. Events queue in their own IndexedDB database, flush in batches of 20–50, and `track()` is synchronous, cannot throw, and never touches the network on an interaction path.

Nine of the eleven client events have web call sites. `signin_failed` and `onboarding_step_completed` do not: sign-in happens entirely on the separate auth origin and the web app has no onboarding flow. That omission was verified against the routes rather than assumed.

## The two invariants that took the work

**Queue ownership is a stored fact, not an ordering.** The queue records the account it belongs to, the session layer publishes the verified account, and a batch is sent only when the two agree. An early return, a slow await, a failed IndexedDB open, or a code path nobody has written yet all leave the gate shut rather than open. This matters because the server derives `user_id` from the credential the batch arrives on, `product_events` is append-only, and `analytics.identity_links` resolves first-link-wins with no repair path — so one person's events delivered under another's credential is unrepairable, not merely wrong.

An earlier version guarded this with an ordering argument and a generation counter. The counter was correct and still left a hole, because it only started protecting from the moment `reset()` was called and on web that moment is late.

**Review sessions are decided from a count that already includes the in-flight answer.** The previous shape decided completion from a passive effect racing an IndexedDB write: on the last card the optimistic queue removal made the queue look empty before the write resolved, so every completed session reported one answer too few and then opened a phantom second session behind it. A one-card session never reported completion at all. `answered_count` and `duration_ms` are the only two numeric measures in the catalog.

## Verification

Five review rounds, each by a reviewer that had not written or fixed the patch; the fifth returned no findings at any severity. No unit tests, per this repository's testing philosophy.

Manual check after deploy, on `/review` with DevTools filtered to `analytics/events`:

1. Answer down to the last card, then hide the tab to force a flush. The batch should carry exactly one `review_session_started` and one `review_session_ended` whose `answered_count` equals the cards answered.
2. The request URL must end `/v1/analytics/events` with **no** trailing slash, and carry `X-Client-Platform: web`, `X-Client-Version` and `X-CSRF-Token`.
3. Every `clientSentAt` and `clientOccurredAt` must end in `Z`, and every `eventId` must have `7` at string index 14 — check the payload, not the generator: `b.events.every(e => e.eventId[14] === "7")`.
4. The response must be `200` with an **empty** `rejected` array. A `200` alone proves nothing; a fully rejected batch also answers `200`.
5. Load the site root: exactly one `screen_viewed{screen:"review"}`, not two. Switch tabs away and back: exactly one `app_opened{launch_type:"warm"}` per round trip, none on first load.
6. Network → Offline, answer a few cards and navigate: no request is attempted and the queue grows with `networkState: "offline"`. Back online, one batch ships with the old `clientOccurredAt` values and a current `clientSentAt`.
7. Block `*/analytics/events` and throttle to Slow 3G: reviewing, card creation and navigation must stay fully responsive with no visible error.

Then confirm the rows landed: `SELECT event_name, platform, app_version, count(*) FROM analytics.product_events WHERE server_received_at > now() - interval '15 minutes' GROUP BY 1,2,3;` — `platform` must be `web`. Both columns NULL means the `X-Client-*` headers did not arrive.

## Accepted residuals

- A stale tab left open while another tab switches accounts can append into a queue the other tab has re-claimed. The stale tab's own gate refuses to send, it self-heals within 60 s of becoming visible, the rows at risk are catalog enums with no free text, and `identity_links` is not fused.
- `/settings/test*` with test mode off double-counts one `screen_viewed`; reachable only by manual URL entry from a test-mode user.
- A session restarted from the settle path starts its clock at the settle, so the first answer's think time is excluded from that session's `duration_ms`.
- A persistent IndexedDB purge failure re-posts the same leading events once a minute. The server dedupes them, one Sentry exception is reported per session, and the stuck head is evicted by the queue cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)