### PR TITLE
Send product analytics from the Android app

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -329,6 +329,9 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.activity.compose)
+    // `ProcessLifecycleOwner`: `app_opened` must follow the process entering the foreground, not an
+    // activity resume, which also fires on a rotation and on returning from a system dialog.
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/FlashcardsAndroidTestRunner.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/FlashcardsAndroidTestRunner.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
+import com.flashcardsopensourceapp.app.analytics.disableProductAnalyticsForProcess
 import com.flashcardsopensourceapp.app.observability.androidSentryEnvironmentOverrideArgumentKey
 import com.flashcardsopensourceapp.app.observability.setAndroidSentryEnvironmentOverride
 import com.flashcardsopensourceapp.app.observability.setDefaultAndroidSentryEnvironmentOverride
@@ -18,6 +19,10 @@ class FlashcardsAndroidTestRunner : AndroidJUnitRunner() {
         context: Context
     ): Application {
         setDefaultAndroidSentryEnvironmentOverride(environment = defaultInstrumentationSentryEnvironment)
+        // Before the application exists, so no graph in this process ever emits. The live-smoke
+        // flow signs into a real account, and a synthetic `app_opened` or `review_session_ended`
+        // written to production `product_events` is indistinguishable from a real person's row.
+        disableProductAnalyticsForProcess()
         return super.newApplication(cl, className, context)
     }
 

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
@@ -9,6 +9,8 @@ import com.flashcardsopensourceapp.app.FlashcardsApplication
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.currentBlockingSystemDialogSummaryOrNull
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.dismissBlockingSystemDialogIfPresent
 import com.flashcardsopensourceapp.app.prompts.guestreview.guestSignInAfterReviewPromptPreferencesName
+import com.flashcardsopensourceapp.core.observability.analytics.analyticsIdentityPreferencesName
+import com.flashcardsopensourceapp.core.observability.analytics.analyticsQueueDatabaseName
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.CountDownLatch
@@ -22,7 +24,8 @@ private val testOnlyPreferenceNames: List<String> = listOf(
     guestSignInAfterReviewPromptPreferencesName,
     "flashcards-ai-chat-preferences",
     "flashcards-ai-chat-history",
-    "flashcards-ai-chat-guest-session"
+    "flashcards-ai-chat-guest-session",
+    analyticsIdentityPreferencesName
 )
 
 open class AppStateResetRule : ExternalResource() {
@@ -45,6 +48,7 @@ internal fun resetAndroidTestAppState() {
         withTimeout(appResetTimeoutMillis) {
             application.closeAppGraph()
             clearTestOnlySharedPreferences(context = context)
+            clearAnalyticsQueueDatabase(context = context)
             application.recreateAppGraphAndAwaitStartup()
             application.appGraph.cloudAccountRepository.logout()
             application.closeAppGraph()
@@ -74,6 +78,15 @@ private fun waitForAndroidTestUiIdle(phase: String) {
                 "blockingSystemDialog=$blockingSystemDialogSummary"
         )
     }
+}
+
+/**
+ * `FlashcardsAndroidTestRunner` disables product analytics for the whole instrumentation process,
+ * so nothing should be queued here. This clears anything an earlier build of the app left on the
+ * device, so a run can never inherit a queue or an analytics identity from outside the suite.
+ */
+private fun clearAnalyticsQueueDatabase(context: Context) {
+    context.deleteDatabase(analyticsQueueDatabaseName)
 }
 
 private fun clearTestOnlySharedPreferences(context: Context) {

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <application
         android:name=".FlashcardsApplication"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/AutoSyncController.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/AutoSyncController.kt
@@ -15,7 +15,9 @@ private const val immediateAutoSyncDebounceWindowMillis: Long = 1_000L
 
 class AutoSyncController(
     private val appScope: CoroutineScope,
-    private val autoSyncEventRepository: AutoSyncEventRepository
+    private val autoSyncEventRepository: AutoSyncEventRepository,
+    private val reportSyncFailure: (Throwable) -> Unit = {},
+    private val reportSyncSucceeded: () -> Unit = {}
 ) {
     private val pollingResetState = MutableStateFlow(value = 0L)
     private var lastImmediateAutoSyncTriggerAtMillis: Long? = null
@@ -54,10 +56,15 @@ class AutoSyncController(
         appScope.launch {
             try {
                 autoSyncEventRepository.runAutoSync(request = request)
+                // Re-arms the next failure, so `sync_failed` keeps measuring failure episodes
+                // rather than how often the app happens to retry.
+                reportSyncSucceeded()
             } catch (error: CancellationException) {
                 throw error
-            } catch (_: Exception) {
-                // Auto-triggered sync failures stay silent on content surfaces.
+            } catch (error: Exception) {
+                // Auto-triggered sync failures stay silent on content surfaces, but they are still
+                // counted: reporting is fire-and-forget and never changes what the user sees.
+                reportSyncFailure(error)
             }
         }
     }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -53,6 +53,7 @@ internal fun CloudCredentialRecoveryGateContainer(
             cloudAccountRepository = appGraph.cloudAccountRepository,
             syncRepository = appGraph.syncRepository,
             messageController = appGraph.appMessageBus,
+            analytics = appGraph.analytics,
             applicationContext = context.applicationContext
         )
     )
@@ -84,7 +85,9 @@ internal fun CloudCredentialRecoveryGateContainer(
         eraseErrorMessage = ""
         eraseErrorTechnicalDetails = null
         eraseErrorTechnicalDetailsReportId = null
-        signInViewModel.cancelSignIn()
+        // Entering the gate composition, which also happens on every configuration change and on
+        // every process start while recovery is active. Not a cancelled sign-in.
+        signInViewModel.resetSignInState()
     }
 
     LaunchedEffect(postAuthUiState.completionToken) {
@@ -95,6 +98,8 @@ internal fun CloudCredentialRecoveryGateContainer(
     }
 
     fun returnToOverview() {
+        // The only real cancel here: reachable only from the email, code and post-auth steps, so a
+        // sign-in was genuinely in progress.
         signInViewModel.cancelSignIn()
         gateStep = CloudCredentialRecoveryGateStep.OVERVIEW
     }
@@ -111,7 +116,8 @@ internal fun CloudCredentialRecoveryGateContainer(
         eraseErrorTechnicalDetails = eraseErrorTechnicalDetails,
         eraseErrorTechnicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
         onSignIn = {
-            signInViewModel.cancelSignIn()
+            // The person is starting a sign-in, not abandoning one.
+            signInViewModel.resetSignInState()
             eraseErrorMessage = ""
             eraseErrorTechnicalDetails = null
             eraseErrorTechnicalDetailsReportId = null
@@ -183,7 +189,8 @@ internal fun CloudCredentialRecoveryGateContainer(
                 eraseErrorTechnicalDetailsReportId = null
                 try {
                     appGraph.cloudAccountRepository.eraseLocalDataForCredentialRecovery()
-                    signInViewModel.cancelSignIn()
+                    // The erase succeeded and the gate is finished; no sign-in was abandoned.
+                    signInViewModel.resetSignInState()
                     isEraseConfirmationVisible = false
                     onRecoveryGateFinished()
                 } catch (error: CancellationException) {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.ui.Alignment
@@ -56,6 +57,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.flashcardsopensourceapp.app.analytics.analyticsSurfaceForRoute
+import com.flashcardsopensourceapp.app.analytics.analyticsSyncFailureReason
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.di.AppStartupState
 import com.flashcardsopensourceapp.app.navigation.AppNavHost
@@ -88,6 +91,8 @@ import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
 import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncSource
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsEvent
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.core.ui.AppTechnicalError
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.components.AppTechnicalErrorDialog
@@ -98,6 +103,7 @@ import com.flashcardsopensourceapp.feature.settings.SettingsAttentionBadge
 import com.flashcardsopensourceapp.feature.settings.SettingsAttentionSummary
 import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionIssues
 import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionSummary
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -344,6 +350,34 @@ fun FlashcardsApp(
             )
         }
 
+        val currentAnalyticsSurface: AnalyticsSurface? = analyticsSurfaceForRoute(route = currentRoute)
+        // Saved, not remembered: a configuration change rebuilds the composition, and re-emitting
+        // the surface already reported would put a duplicate `screen_viewed` into an append-only
+        // table for every rotation.
+        var lastEmittedAnalyticsSurfaceName: String? by rememberSaveable {
+            mutableStateOf<String?>(value = null)
+        }
+
+        LaunchedEffect(currentRoute) {
+            val visitedSurface: AnalyticsSurface? = currentAnalyticsSurface
+            if (visitedSurface == null) {
+                // A route that exists but maps onto no shared surface still ends the previous
+                // surface's visit, so `review -> unmapped -> review` records two views rather than
+                // one. Every destination registered today does map; this keeps the count honest
+                // when one is added that does not. A null route is the frame before the graph
+                // settles — not a visit, and clearing on it would re-emit on every rotation.
+                if (currentRoute.isNullOrBlank().not()) {
+                    lastEmittedAnalyticsSurfaceName = null
+                }
+                return@LaunchedEffect
+            }
+            if (lastEmittedAnalyticsSurfaceName == visitedSurface.name) {
+                return@LaunchedEffect
+            }
+            lastEmittedAnalyticsSurfaceName = visitedSurface.name
+            appGraph.analytics.track(event = AnalyticsEvent.ScreenViewed(screen = visitedSurface))
+        }
+
         LaunchedEffect(isAppResumed, appGraph.reviewReminderAttentionController) {
             if (isAppResumed.not()) {
                 return@LaunchedEffect
@@ -529,6 +563,17 @@ fun FlashcardsApp(
                 delay(foregroundSyncPollingIntervalMillis(destination = currentDestination))
                 runCatching {
                     appGraph.syncRepository.syncNow()
+                }.onSuccess {
+                    appGraph.syncFailureAnalyticsReporter.reportSuccess()
+                }.onFailure { error ->
+                    if (error !is CancellationException) {
+                        // This loop polls every 15 s on Review and Cards. Reporting through the
+                        // shared gate makes an offline stretch cost one `sync_failed`, not one per
+                        // poll, so the event keeps measuring failure incidence.
+                        appGraph.syncFailureAnalyticsReporter.reportFailure(
+                            reason = analyticsSyncFailureReason(error = error)
+                        )
+                    }
                 }
             }
         }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApplication.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApplication.kt
@@ -1,7 +1,12 @@
 package com.flashcardsopensourceapp.app
 
 import android.app.Application
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
+import com.flashcardsopensourceapp.app.analytics.consumeAnalyticsForegroundEntry
+import com.flashcardsopensourceapp.app.analytics.markAnalyticsProcessBackgrounded
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.di.AppStartupState
 import com.flashcardsopensourceapp.app.navigation.AppNotificationTapHandoffRequest
@@ -9,6 +14,8 @@ import com.flashcardsopensourceapp.app.notifications.AppNotificationTapRequest
 import com.flashcardsopensourceapp.app.observability.AndroidObservabilityStartup
 import com.flashcardsopensourceapp.app.observability.startAndroidObservability
 import com.flashcardsopensourceapp.app.runtime.isAndroidRuntimeSupported
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsEvent
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsLaunchType
 import com.flashcardsopensourceapp.data.local.notifications.appNotificationWorkLimit
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Dispatchers
@@ -62,6 +69,64 @@ class FlashcardsApplication : Application(), Configuration.Provider {
 
         observabilityStartup = startAndroidObservability(application = this)
         publishAppGraph(appGraph = createAppGraph())
+        observeProcessLifecycleForAnalytics()
+    }
+
+    /**
+     * Registers the `app_opened`, session-close and background-flush hook once per process, next to
+     * the process-scoped flags in `analytics/AppAnalyticsSupport.kt` that it maintains.
+     *
+     * It deliberately does not live in the composition. `FlashcardsApp` returns early while startup
+     * is loading, when startup failed and while the credential-recovery gate is up, so an observer
+     * registered there would be disposed with the flag still saying "foregrounded": a subsequent
+     * background would leave `ON_STOP` unobserved, and the next real foreground return would see a
+     * stale flag and produce no `app_opened`. It is also not put in `AppGraph`, which is rebuilt
+     * several times per instrumentation run and off the main thread, where `addObserver` throws.
+     *
+     * The process lifecycle rather than the activity one: `ON_START` here fires only when the app
+     * actually enters the foreground, and ignores configuration changes and returns from a
+     * permission dialog, a photo picker or any other activity, every one of which looks like a warm
+     * launch on the activity lifecycle.
+     *
+     * `ON_STOP` here is also the only real "the person stopped using the app" signal in the process,
+     * which is why an open review session is closed from it. A `ViewModel` teardown callback fires
+     * for none of the cases that matter — a call, a notification, a screen lock and a swipe away all
+     * leave the view-model store intact, and a process kill never calls it — so a session left to
+     * that would absorb the whole interruption into `duration_ms`.
+     */
+    private fun observeProcessLifecycleForAnalytics() {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_START -> {
+                        val appGraph = appGraphOrNull ?: return@LifecycleEventObserver
+                        val launchType: AnalyticsLaunchType? = consumeAnalyticsForegroundEntry()
+                        if (launchType != null) {
+                            appGraph.analytics.track(
+                                event = AnalyticsEvent.AppOpened(launchType = launchType)
+                            )
+                        }
+                        // After `app_opened`, so a review session reopened on return cannot precede
+                        // the launch it belongs to.
+                        appGraph.analyticsForegroundTransitions.notifyForegroundEntered()
+                    }
+
+                    Lifecycle.Event.ON_STOP -> {
+                        // Cleared even without a graph, so the flag never outlives the foreground.
+                        markAnalyticsProcessBackgrounded()
+                        val appGraph = appGraphOrNull ?: return@LifecycleEventObserver
+                        // Strictly before the flush. Listeners close their open measurements by
+                        // calling `track`, and `track` and `flush` are ordered by the same channel,
+                        // so a session-end handed off after the flush request would miss it and wait
+                        // for the next trigger — which on a device that is put down never comes.
+                        appGraph.analyticsForegroundTransitions.notifyForegroundLeft()
+                        appGraph.analytics.flush()
+                    }
+
+                    else -> Unit
+                }
+            }
+        )
     }
 
     suspend fun closeAppGraph() {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/SyncWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/SyncWorker.kt
@@ -5,6 +5,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkerParameters
+import com.flashcardsopensourceapp.app.analytics.analyticsSyncFailureReason
 
 class SyncWorker(
     context: Context,
@@ -15,8 +16,18 @@ class SyncWorker(
 
         return try {
             application.appGraph.syncRepository.scheduleSync()
+            runCatching {
+                application.appGraph.syncFailureAnalyticsReporter.reportSuccess()
+            }
             Result.success()
         } catch (error: Exception) {
+            // WorkManager retries this worker on its own backoff, so the report is gated on the
+            // transition into failure: one event per failure episode, not one per attempt.
+            runCatching {
+                application.appGraph.syncFailureAnalyticsReporter.reportFailure(
+                    reason = analyticsSyncFailureReason(error = error)
+                )
+            }
             Result.retry()
         }
     }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/analytics/AppAnalyticsSupport.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/analytics/AppAnalyticsSupport.kt
@@ -1,0 +1,199 @@
+package com.flashcardsopensourceapp.app.analytics
+
+import android.database.sqlite.SQLiteFullException
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsCredential
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsCredentialProvider
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsLaunchType
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSyncFailureReason
+import com.flashcardsopensourceapp.data.local.ai.store.GuestAiSessionStore
+import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.cloud.shouldRefreshCloudIdToken
+import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val maxAnalyticsFailureCauseDepth: Int = 8
+
+/**
+ * Process-scoped so exactly one launch per process is `cold`. It deliberately does not live in
+ * `AppGraph`, which can be torn down and rebuilt inside a running process.
+ */
+private val hasReportedColdLaunch = AtomicBoolean(false)
+
+/**
+ * Whether the process is currently in the foreground, so `app_opened` counts foreground entries
+ * rather than observer registrations.
+ *
+ * `ProcessLifecycleOwner` already ignores configuration changes and intra-app activity
+ * transitions, but adding an observer replays the current state to it. The observer is registered
+ * once per process from `FlashcardsApplication`, so that replay happens at most once; the flag
+ * keeps it a no-op regardless, so only a real background-to-foreground transition produces an
+ * event. It is process-scoped for the same reason the observer is: `AppGraph` is rebuilt inside a
+ * running process, and `FlashcardsApp` returns early on three branches before the composition
+ * reaches any effect.
+ */
+private val isProcessForegrounded = AtomicBoolean(false)
+
+/**
+ * Process-wide kill switch, set by the instrumentation runner before the application exists.
+ *
+ * Instrumentation signs into a real account in the live-smoke flow, so anything a test run emitted
+ * would land in production `product_events` indistinguishable from a real person's rows. This is
+ * process-scoped rather than graph-scoped because the graph is rebuilt several times per test and
+ * most instrumentation classes never touch the reset rule.
+ */
+private val productAnalyticsDisabledForProcess = AtomicBoolean(false)
+
+internal fun disableProductAnalyticsForProcess() {
+    productAnalyticsDisabledForProcess.set(true)
+}
+
+internal fun isProductAnalyticsDisabledForProcess(): Boolean {
+    return productAnalyticsDisabledForProcess.get()
+}
+
+/** Returns null when the process was already foregrounded, which is not a new app open. */
+internal fun consumeAnalyticsForegroundEntry(): AnalyticsLaunchType? {
+    if (isProcessForegrounded.compareAndSet(false, true).not()) {
+        return null
+    }
+    return if (hasReportedColdLaunch.compareAndSet(false, true)) {
+        AnalyticsLaunchType.COLD
+    } else {
+        AnalyticsLaunchType.WARM
+    }
+}
+
+internal fun markAnalyticsProcessBackgrounded() {
+    isProcessForegrounded.set(false)
+}
+
+/**
+ * Supplies the human-authenticated transport the analytics endpoint requires.
+ *
+ * It deliberately never refreshes a token: analytics may not drive auth traffic. When no usable
+ * credential exists the events simply stay queued, which the 14-day queue TTL and the 30-day
+ * server window make free for an ordinary sign-up delay.
+ */
+internal class AppAnalyticsCredentialProvider(
+    private val cloudPreferencesStore: CloudPreferencesStore,
+    private val guestAiSessionStore: GuestAiSessionStore,
+    private val currentTimeMillisProvider: () -> Long = System::currentTimeMillis
+) : AnalyticsCredentialProvider {
+    override suspend fun currentCredential(): AnalyticsCredential? {
+        val configuration: CloudServiceConfiguration = cloudPreferencesStore.currentServerConfiguration()
+        val cloudSettings: CloudSettings = cloudPreferencesStore.currentCloudSettings()
+
+        return when (cloudSettings.cloudState) {
+            CloudAccountState.LINKED -> bearerCredential(configuration = configuration)
+            CloudAccountState.GUEST -> guestCredential(configuration = configuration)
+            CloudAccountState.DISCONNECTED, CloudAccountState.LINKING_READY -> null
+        }
+    }
+
+    private fun bearerCredential(configuration: CloudServiceConfiguration): AnalyticsCredential? {
+        val credentials: StoredCloudCredentials = cloudPreferencesStore.loadCredentials() ?: return null
+        if (
+            shouldRefreshCloudIdToken(
+                idTokenExpiresAtMillis = credentials.idTokenExpiresAtMillis,
+                nowMillis = currentTimeMillisProvider()
+            )
+        ) {
+            return null
+        }
+
+        return AnalyticsCredential(
+            apiBaseUrl = configuration.apiBaseUrl,
+            authorizationHeader = "Bearer ${credentials.idToken}"
+        )
+    }
+
+    private fun guestCredential(configuration: CloudServiceConfiguration): AnalyticsCredential? {
+        val guestSession: StoredGuestAiSession = guestAiSessionStore.loadAnySession(
+            configuration = configuration
+        ) ?: return null
+
+        return AnalyticsCredential(
+            apiBaseUrl = guestSession.apiBaseUrl,
+            authorizationHeader = "Guest ${guestSession.guestToken}"
+        )
+    }
+}
+
+/**
+ * Maps a Compose navigation route onto the shared cross-platform surface enum. Native destination
+ * names are never sent: cross-platform funnel comparison is the only reason the enum is shared.
+ *
+ * Every destination registered in `navigation/` is covered today, so nothing reachable falls
+ * through to `null`: `review` and `review/preview`; `cards`; `ai`; `progress`; the three
+ * `cards/editor/…` steps; `settings` and every `settings/…` leaf, of which
+ * `settings/decks/detail/{deckId}` and `settings/decks/all-cards` are the two that report
+ * `deck_detail` instead of `settings`.
+ *
+ * `catalog` and `onboarding` have no Android destination today, so no route maps onto them. When a
+ * destination is added that belongs on either, map it here: an unmapped route ends the previous
+ * surface's visit at the call site, so leaving it unmapped costs the view rather than corrupting
+ * the counts, but it still costs it.
+ */
+internal fun analyticsSurfaceForRoute(route: String?): AnalyticsSurface? {
+    val normalizedRoute: String = route?.trim().orEmpty()
+    if (normalizedRoute.isEmpty()) {
+        return null
+    }
+
+    return when {
+        normalizedRoute.startsWith(prefix = "cards/editor") -> AnalyticsSurface.CARD_EDITOR
+        normalizedRoute.startsWith(prefix = "settings/decks/detail") ||
+            normalizedRoute == "settings/decks/all-cards" -> AnalyticsSurface.DECK_DETAIL
+        normalizedRoute == "settings" || normalizedRoute.startsWith(prefix = "settings/") -> AnalyticsSurface.SETTINGS
+        normalizedRoute == "review" || normalizedRoute.startsWith(prefix = "review/") -> AnalyticsSurface.REVIEW
+        normalizedRoute == "cards" -> AnalyticsSurface.CARDS
+        normalizedRoute == "ai" -> AnalyticsSurface.AI
+        normalizedRoute == "progress" -> AnalyticsSurface.PROGRESS
+        else -> null
+    }
+}
+
+/** Maps a sync failure onto the closed reason set the server catalog declares. */
+internal fun analyticsSyncFailureReason(error: Throwable): AnalyticsSyncFailureReason {
+    var currentError: Throwable? = error
+    var depth = 0
+    while (currentError != null && depth < maxAnalyticsFailureCauseDepth) {
+        val inspectedError: Throwable = currentError
+        when (inspectedError) {
+            is SQLiteFullException -> return AnalyticsSyncFailureReason.STORAGE_FULL
+            is SyncBlockedException -> return AnalyticsSyncFailureReason.CONFLICT
+            is SocketTimeoutException -> return AnalyticsSyncFailureReason.TIMEOUT
+            is IOException -> return AnalyticsSyncFailureReason.OFFLINE
+            is CloudRemoteException -> return analyticsCloudSyncFailureReason(error = inspectedError)
+            else -> Unit
+        }
+        currentError = inspectedError.cause
+        depth += 1
+    }
+    return AnalyticsSyncFailureReason.SERVER_ERROR
+}
+
+private fun analyticsCloudSyncFailureReason(error: CloudRemoteException): AnalyticsSyncFailureReason {
+    if (
+        error.syncConflict != null ||
+        error.errorCode?.trim()?.uppercase() == "SYNC_WORKSPACE_FORK_REQUIRED"
+    ) {
+        return AnalyticsSyncFailureReason.CONFLICT
+    }
+
+    return when (error.statusCode) {
+        401, 403 -> AnalyticsSyncFailureReason.UNAUTHORIZED
+        408, 504 -> AnalyticsSyncFailureReason.TIMEOUT
+        409 -> AnalyticsSyncFailureReason.CONFLICT
+        else -> AnalyticsSyncFailureReason.SERVER_ERROR
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -19,7 +19,16 @@ import com.flashcardsopensourceapp.app.prompts.guestreview.SharedPreferencesGues
 import com.flashcardsopensourceapp.app.store.NoOpStoreReviewAnalyticsReporter
 import com.flashcardsopensourceapp.app.store.StoreReviewActivityProvider
 import com.flashcardsopensourceapp.app.store.StoreReviewRequestManager
+import com.flashcardsopensourceapp.app.analytics.AppAnalyticsCredentialProvider
+import com.flashcardsopensourceapp.app.analytics.analyticsSyncFailureReason
+import com.flashcardsopensourceapp.app.analytics.isProductAnalyticsDisabledForProcess
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.analytics.Analytics
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsClient
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsForegroundTransitions
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsIdentity
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsNetworkMonitor
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSyncFailureReporter
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
 import com.flashcardsopensourceapp.core.observability.shouldCaptureAndroidThrowable
@@ -188,6 +197,31 @@ class AppGraph(
     private val aiChatPreferencesStore = AiChatPreferencesStore(context = context)
     private val aiChatHistoryStore = AiChatHistoryStore(context = context)
     private val guestAiSessionStore = GuestAiSessionStore(context = context)
+    private val analyticsNetworkMonitor = AnalyticsNetworkMonitor(context = context, scope = appScope)
+    private val analyticsClient = AnalyticsClient(
+        context = context,
+        appScope = appScope,
+        okHttpClient = okHttpClient,
+        identity = AnalyticsIdentity(context = context),
+        credentialProvider = AppAnalyticsCredentialProvider(
+            cloudPreferencesStore = cloudPreferencesStore,
+            guestAiSessionStore = guestAiSessionStore
+        ),
+        networkStateProvider = analyticsNetworkMonitor,
+        observability = observability,
+        appVersion = appPackageInfo.versionName,
+        versionCode = appPackageInfo.longVersionCode.toInt()
+    )
+    val analytics: Analytics = analyticsClient
+
+    /**
+     * Delivers the process leaving and re-entering the foreground to whoever holds an open
+     * measurement. `FlashcardsApplication` notifies it from its `ProcessLifecycleOwner` observer,
+     * synchronously and before the background flush, so a session closed there is queued in time to
+     * go out with that flush.
+     */
+    val analyticsForegroundTransitions = AnalyticsForegroundTransitions()
+    val syncFailureAnalyticsReporter = AnalyticsSyncFailureReporter(analytics = analytics)
     val reviewPreferencesStore: ReviewPreferencesStore = SharedPreferencesReviewPreferencesStore(context = context)
     val storeReviewRequestStore: StoreReviewRequestStore = SharedPreferencesStoreReviewRequestStore(context = context)
     private val guestSignInAfterReviewPromptStore = SharedPreferencesGuestSignInAfterReviewPromptStore(
@@ -285,6 +319,33 @@ class AppGraph(
         guestAiSessionStore = guestAiSessionStore,
         onCloudIdentityReset = {
             strictRemindersManager.clearForCloudIdentityReset()
+            // Queued events belong to the person who is leaving, and the server attributes a batch
+            // to the credential that carries it, so they must never survive an identity boundary.
+            // `reset()` returns immediately and does no network work, so this never delays the
+            // action.
+            //
+            // Reached from exactly the three `CloudIdentityResetCoordinator` entry points that end
+            // one person's use of this install: `resetLocalStateForCloudIdentityChange` (logout, an
+            // account switch detected mid-sync or mid-refresh, an account deletion, a server
+            // change), `eraseLocalDataForCredentialRecovery` (the credential-recovery erase) and
+            // `disconnectDeletedCloudIdentityPreservingLocalState` (a `410 ACCOUNT_DELETED` sync
+            // answer, i.e. the account was deleted elsewhere).
+            //
+            // `disconnectCloudIdentityPreservingLocalState` deliberately does not reach here, and
+            // its callers are the complete "not a boundary" set:
+            //
+            // - reconciliation failures, where the same person recovers from a locally inconsistent
+            //   state and signs back into the same account, so rotating `anonymous_id` would split
+            //   one person's history instead of protecting the next person's;
+            // - `CloudGuestSessionCoordinator.clearStoredGuestCloudSessionLocalState`, which
+            //   disconnects a guest whose session the server answered `GUEST_AUTH_INVALID` for.
+            //   This is the least obvious member and the reason the set is enumerated rather than
+            //   claimed: queued events keep the guest's `anonymous_id` into the next credential on
+            //   purpose. It is the same install and the same person losing a server-side session,
+            //   not a person leaving — the same reasoning that keeps the guest-to-account upgrade
+            //   off this hook, where the `anonymous_id` has to carry through for
+            //   `analytics.identity_links` to join the guest and the account at all.
+            analytics.reset()
         }
     )
     private val cloudGuestSessionCoordinator = CloudGuestSessionCoordinator(
@@ -343,7 +404,13 @@ class AppGraph(
     val autoSyncEventRepository: AutoSyncEventRepository = localSyncRepository
     val autoSyncController = AutoSyncController(
         appScope = appScope,
-        autoSyncEventRepository = autoSyncEventRepository
+        autoSyncEventRepository = autoSyncEventRepository,
+        reportSyncFailure = { error ->
+            syncFailureAnalyticsReporter.reportFailure(
+                reason = analyticsSyncFailureReason(error = error)
+            )
+        },
+        reportSyncSucceeded = syncFailureAnalyticsReporter::reportSuccess
     )
     val cardsRepository: CardsRepository = LocalCardsRepository(
         database = database,
@@ -437,6 +504,13 @@ class AppGraph(
     val startupState: StateFlow<AppStartupState> = startupStateMutable.asStateFlow()
 
     init {
+        if (isProductAnalyticsDisabledForProcess()) {
+            // Instrumentation must never post synthetic rows into production `product_events`.
+            analytics.setEnabled(enabled = false)
+        }
+        analyticsNetworkMonitor.startObservingConnectivityRestored(
+            onConnectivityRestored = analytics::onConnectivityRestored
+        )
         startReviewHistoryAppliedObserver()
         startStartup()
     }
@@ -753,6 +827,7 @@ class AppGraph(
     }
 
     suspend fun close() {
+        analyticsNetworkMonitor.stopObservingConnectivityRestored()
         cloudCredentialRecoveryGateViewModelStoreOwner.viewModelStore.clear()
         startupJob?.cancelAndJoin()
         cloudIdentityObserverJob?.cancelAndJoin()
@@ -761,6 +836,8 @@ class AppGraph(
         reviewNotificationsManager.close()
         strictRemindersManager.close()
         appJob.cancelAndJoin()
+        // After the scope that owns the analytics worker is gone, so nothing is using the queue.
+        analyticsClient.close()
         closeAppDatabase(database = database)
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsRootNavGraph.kt
@@ -8,6 +8,9 @@ import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.SettingsNavigationTarget
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsCardCreateEntryPoint
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsEvent
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.feature.cards.createCardsViewModelFactory
 import com.flashcardsopensourceapp.feature.cards.list.CardsRoute
 import com.flashcardsopensourceapp.feature.cards.list.CardsViewModel
@@ -36,6 +39,12 @@ internal fun NavGraphBuilder.registerCardsRootDestination(
             onApplyFilter = cardsViewModel::applyFilter,
             onClearFilter = cardsViewModel::clearFilter,
             onCreateCard = {
+                appGraph.analytics.track(
+                    event = AnalyticsEvent.CardCreateStarted(
+                        entryPoint = AnalyticsCardCreateEntryPoint.CARDS,
+                        screen = AnalyticsSurface.CARDS
+                    )
+                )
                 appGraph.appHandoffCoordinator.requestCardEditor(cardId = null)
             },
             onOpenCard = { cardId ->

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -24,6 +24,9 @@ import com.flashcardsopensourceapp.app.navigation.SettingsNavigationTarget
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsCardCreateEntryPoint
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsEvent
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.data.local.ai.diagnostics.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
@@ -110,6 +113,8 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                     },
                     onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
                     reviewPreferencesStore = appGraph.reviewPreferencesStore,
+                    analytics = appGraph.analytics,
+                    analyticsForegroundTransitions = appGraph.analyticsForegroundTransitions,
                     visibleAppScreenRepository = appGraph.visibleAppScreenController,
                     workspaceRepository = appGraph.workspaceRepository
                 )
@@ -166,9 +171,21 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                     )
                 },
                 onCreateCard = {
+                    appGraph.analytics.track(
+                        event = AnalyticsEvent.CardCreateStarted(
+                            entryPoint = AnalyticsCardCreateEntryPoint.REVIEW,
+                            screen = AnalyticsSurface.REVIEW
+                        )
+                    )
                     appGraph.appHandoffCoordinator.requestCardEditor(cardId = null)
                 },
                 onCreateCardWithAi = {
+                    appGraph.analytics.track(
+                        event = AnalyticsEvent.CardCreateStarted(
+                            entryPoint = AnalyticsCardCreateEntryPoint.AI,
+                            screen = AnalyticsSurface.REVIEW
+                        )
+                    )
                     appGraph.appHandoffCoordinator.requestAiEntryPrefill(prefill = com.flashcardsopensourceapp.feature.ai.AiEntryPrefill.CREATE_CARD)
                     navigateToTopLevelDestination(
                         navController = navController,
@@ -265,6 +282,8 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                     },
                     onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
                     reviewPreferencesStore = appGraph.reviewPreferencesStore,
+                    analytics = appGraph.analytics,
+                    analyticsForegroundTransitions = appGraph.analyticsForegroundTransitions,
                     visibleAppScreenRepository = appGraph.visibleAppScreenController,
                     workspaceRepository = appGraph.workspaceRepository
                 )

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -50,6 +50,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                     cloudAccountRepository = appGraph.cloudAccountRepository,
                     syncRepository = appGraph.syncRepository,
                     messageController = appGraph.appMessageBus,
+                    analytics = appGraph.analytics,
                     applicationContext = context.applicationContext
                 )
             )
@@ -106,6 +107,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                     cloudAccountRepository = appGraph.cloudAccountRepository,
                     syncRepository = appGraph.syncRepository,
                     messageController = appGraph.appMessageBus,
+                    analytics = appGraph.analytics,
                     applicationContext = context.applicationContext
                 )
             )
@@ -153,6 +155,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                     cloudAccountRepository = appGraph.cloudAccountRepository,
                     syncRepository = appGraph.syncRepository,
                     messageController = appGraph.appMessageBus,
+                    analytics = appGraph.analytics,
                     applicationContext = context.applicationContext
                 )
             )

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
@@ -38,6 +38,7 @@ internal fun NavGraphBuilder.registerSettingsAccountNavGraph(
                 syncRepository = appGraph.syncRepository,
                 messageController = appGraph.appMessageBus,
                 technicalErrorController = appGraph.appMessageBus,
+                syncFailureReporter = appGraph.syncFailureAnalyticsReporter,
                 applicationContext = context.applicationContext
             )
         )

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
@@ -471,6 +471,24 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             feedback = null,
             technicalError = null
         )
+        is AndroidWarningIssueEvent.AnalyticsPipelineWarning -> SentryAndroidObservationContext(
+            feature = event.feature.tagValue,
+            action = event.action.tagValue,
+            http = null,
+            ai = null,
+            progress = null,
+            notifications = null,
+            feedback = null,
+            technicalError = null,
+            analytics = SentryAnalyticsContext(
+                analyticsAction = sanitizeSentryContextValue(
+                    fieldName = "analyticsAction",
+                    value = event.name.tagValue
+                ),
+                eventCount = event.eventCount,
+                statusCode = event.statusCode
+            )
+        )
         is AndroidWarningIssueEvent.NotificationSchedulingWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
             action = event.action.tagValue,
@@ -939,6 +957,7 @@ private fun warningIssueGroupKey(event: AndroidWarningIssueEvent): String? {
         is AndroidWarningIssueEvent.ProgressRepositoryWarning -> event.repositoryAction
         is AndroidWarningIssueEvent.AiRuntimeWarning -> event.name.tagValue
         is AndroidWarningIssueEvent.NotificationSchedulingWarning -> event.diagnostic.notificationKind
+        is AndroidWarningIssueEvent.AnalyticsPipelineWarning -> event.name.tagValue
     }
     return sanitizeSentryTagValue(fieldName = "warningGroup", value = rawGroupKey)
 }
@@ -975,7 +994,14 @@ private data class SentryAndroidObservationContext(
     val progress: SentryProgressContext?,
     val notifications: SentryNotificationSchedulingContext?,
     val feedback: SentryFeedbackContext?,
-    val technicalError: SentryTechnicalErrorContext?
+    val technicalError: SentryTechnicalErrorContext?,
+    val analytics: SentryAnalyticsContext? = null
+)
+
+private data class SentryAnalyticsContext(
+    val analyticsAction: String?,
+    val eventCount: Int?,
+    val statusCode: Int?
 )
 
 private data class SentryHttpContext(

--- a/apps/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/apps/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Keeps the analytics install identity and its queue off cloud backup and device-to-device
+  transfer. A restored `anonymous_id` would appear on a second device, and identity resolution in
+  `analytics.identity_links` is first-link-wins with no repair path, so a shared id merges two
+  people permanently. Everything not listed here is still backed up as before.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude
+            domain="sharedpref"
+            path="flashcards-analytics-identity.xml" />
+        <exclude
+            domain="database"
+            path="flashcards-analytics-queue.db" />
+        <exclude
+            domain="database"
+            path="flashcards-analytics-queue.db-wal" />
+        <exclude
+            domain="database"
+            path="flashcards-analytics-queue.db-shm" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude
+            domain="sharedpref"
+            path="flashcards-analytics-identity.xml" />
+        <exclude
+            domain="database"
+            path="flashcards-analytics-queue.db" />
+        <exclude
+            domain="database"
+            path="flashcards-analytics-queue.db-wal" />
+        <exclude
+            domain="database"
+            path="flashcards-analytics-queue.db-shm" />
+    </device-transfer>
+</data-extraction-rules>

--- a/apps/android/core/observability/build.gradle.kts
+++ b/apps/android/core/observability/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -18,4 +19,18 @@ android {
     kotlin {
         jvmToolchain(17)
     }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.org.jetbrains.kotlinx.coroutines.android)
+
+    // The analytics queue is durable and lives on its own Room database, deliberately separate from
+    // the product data layer in `:data:local`.
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
+    // `OkHttpClient` appears in the public analytics client constructor.
+    api(libs.okhttp)
 }

--- a/apps/android/core/observability/src/main/AndroidManifest.xml
+++ b/apps/android/core/observability/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Read by the analytics client to record the network state of each event at creation time. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
@@ -10,7 +10,8 @@ enum class AndroidObservationFeature(
     AI(tagValue = "ai"),
     PROGRESS(tagValue = "progress"),
     FEEDBACK(tagValue = "feedback"),
-    NOTIFICATIONS(tagValue = "notifications")
+    NOTIFICATIONS(tagValue = "notifications"),
+    ANALYTICS(tagValue = "analytics")
 }
 
 enum class AndroidObservationAction(
@@ -42,7 +43,8 @@ enum class AndroidObservationAction(
     PROGRESS_REPOSITORY_EXCEPTION(tagValue = "progress_repository_exception"),
     FEEDBACK_PROMPT_EXCEPTION(tagValue = "feedback_prompt_exception"),
     NOTIFICATION_SCHEDULING_BREADCRUMB(tagValue = "notification_scheduling_breadcrumb"),
-    NOTIFICATION_SCHEDULING_WARNING(tagValue = "notification_scheduling_warning")
+    NOTIFICATION_SCHEDULING_WARNING(tagValue = "notification_scheduling_warning"),
+    ANALYTICS_PIPELINE_WARNING(tagValue = "analytics_pipeline_warning")
 }
 
 enum class AndroidAiObservationName(
@@ -66,6 +68,31 @@ enum class AndroidAiObservationName(
     RUNTIME_HANDOFF_APPLIED_TO_RUNNING_DRAFT(tagValue = "ai_runtime_handoff_applied_to_running_draft"),
     RUNTIME_HANDOFF_START_FRESH_CONVERSATION(tagValue = "ai_runtime_handoff_start_fresh_conversation"),
     RUNTIME_HANDOFF_APPLIED_TO_EXISTING_SESSION(tagValue = "ai_runtime_handoff_applied_to_existing_session")
+}
+
+/**
+ * Analytics pipeline failures worth reporting from the client.
+ *
+ * Deliberately excluded: per-event rejections, which the server already captures with cross-client
+ * grouping and which `analytics_events_dropped` carries into the data itself, and ordinary offline
+ * or transient network failures, which this repository silences in background capture paths.
+ */
+enum class AndroidAnalyticsObservationName(
+    val tagValue: String
+) {
+    QUEUE_STORE_WRITE_FAILED(tagValue = "analytics_queue_store_write_failed"),
+    QUEUE_STORE_READ_FAILED(tagValue = "analytics_queue_store_read_failed"),
+    QUEUE_OVERFLOW(tagValue = "analytics_queue_overflow"),
+    QUEUE_TTL_EXPIRED(tagValue = "analytics_queue_ttl_expired"),
+
+    /**
+     * Events discarded at an identity boundary. Deliberately not an `analytics_events_dropped`
+     * reason: that enum is frozen, and spending `rejected` on an expected, bounded loss would
+     * poison the one signal that surfaces real server refusals and clock skew.
+     */
+    IDENTITY_BOUNDARY_DISCARDED(tagValue = "analytics_identity_boundary_discarded"),
+    BATCH_CONTRACT_REFUSED(tagValue = "analytics_batch_contract_refused"),
+    SUSTAINED_SERVER_ERRORS(tagValue = "analytics_sustained_server_errors")
 }
 
 enum class AndroidFeedbackPromptAction(
@@ -521,6 +548,28 @@ sealed interface AndroidWarningIssueEvent : AndroidObservationEvent {
             requestId = requestId,
             statusCode = statusCode,
             code = code ?: name.tagValue,
+            appVersion = appVersion,
+            clientVersion = clientVersion,
+            versionCode = versionCode
+        )
+    }
+
+    data class AnalyticsPipelineWarning(
+        val name: AndroidAnalyticsObservationName,
+        val eventCount: Int?,
+        val statusCode: Int?,
+        val appVersion: String?,
+        val clientVersion: String?,
+        val versionCode: Int?
+    ) : AndroidWarningIssueEvent {
+        override val feature: AndroidObservationFeature = AndroidObservationFeature.ANALYTICS
+        override val action: AndroidObservationAction = AndroidObservationAction.ANALYTICS_PIPELINE_WARNING
+        override val tags: AndroidObservationTags = AndroidObservationTags(
+            userId = null,
+            workspaceId = null,
+            requestId = null,
+            statusCode = statusCode,
+            code = name.tagValue,
             appVersion = appVersion,
             clientVersion = clientVersion,
             versionCode = versionCode

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/Analytics.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/Analytics.kt
@@ -1,0 +1,172 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Product analytics entry point.
+ *
+ * A user action must never be blocked, delayed or failed by anything behind this interface:
+ * [track] is fire-and-forget into a local queue and every network path is off the interaction path.
+ */
+interface Analytics {
+    /** Never suspends, never throws, never touches the database on the calling thread. */
+    fun track(event: AnalyticsEvent)
+
+    /** Asks for a delivery attempt. Returns immediately; delivery happens on the IO dispatcher. */
+    fun flush()
+
+    /**
+     * Connectivity came back. Clears a backoff that only an offline stretch produced and asks for a
+     * delivery attempt; a `429`/`5xx` backoff is deliberately left alone.
+     */
+    fun onConnectivityRestored()
+
+    /**
+     * Identity boundary: logout, an account switch, a server change, the credential-recovery erase,
+     * and an account deletion — whether this device asked for it or discovered it as a `410
+     * ACCOUNT_DELETED` answer while syncing.
+     *
+     * Rotates `anonymous_id` so a second person on this install does not inherit the first person's
+     * identity, and **discards** whatever is still queued. Queued events belong to the person who is
+     * leaving, and the server attributes a batch to the credential that carries it, so anything left
+     * behind would land under the next person's account, permanently, on an append-only table. The
+     * discarded count is reported through the platform's error reporter, never as an
+     * `analytics_events_dropped` reason.
+     *
+     * Unlike [track] this may not be dropped, and it may not be deferred either: the durable half of
+     * the boundary — rotating the stored `anonymous_id` — happens synchronously on the calling
+     * thread, so a process death immediately afterwards still finds a rotated id on disk and the
+     * outgoing person's rows unsendable. Only the queue delete and the reporting are asynchronous.
+     *
+     * That synchronous half is a single `SharedPreferences` commit and does no network or database
+     * work, so it never delays a user action; call it off the main thread all the same.
+     */
+    fun reset()
+
+    /** Kill switch, honored immediately. Disabling also drops whatever is still queued. */
+    fun setEnabled(enabled: Boolean)
+}
+
+/**
+ * Whoever holds an open measurement while the person is using a surface — the review session above
+ * all, whose `duration_ms` and `answered_count` are the only numeric measures in the whole catalog.
+ *
+ * A `ViewModel` teardown callback fires for none of the cases that matter here: a call, a
+ * notification, a screen lock and a swipe to another app all leave the view-model store intact, and
+ * a process kill never calls it at all. The process leaving the foreground is the real signal, so it
+ * is the one this interface carries.
+ */
+interface AnalyticsForegroundListener {
+    /** Close whatever is open. Emitted events reach the queue before the background flush. */
+    fun onAnalyticsForegroundLeft()
+
+    /** The person is back. Reopen whatever was closed above if they are still on that surface. */
+    fun onAnalyticsForegroundEntered()
+}
+
+/**
+ * Process foreground transitions, delivered **synchronously on the notifying thread**.
+ *
+ * Synchronous, and deliberately not a flow: the same `ON_STOP` that ends a review session also asks
+ * for the background flush, and the session-end event has to be in the queue before that flush is
+ * requested. An asynchronous hand-off would be ordered after it about as often as before it, and the
+ * event would then wait for the next flush trigger — which on a device that is put down never comes.
+ */
+class AnalyticsForegroundTransitions {
+    private val listeners: CopyOnWriteArrayList<AnalyticsForegroundListener> = CopyOnWriteArrayList()
+
+    fun addListener(listener: AnalyticsForegroundListener) {
+        listeners.addIfAbsent(listener)
+    }
+
+    fun removeListener(listener: AnalyticsForegroundListener) {
+        listeners.remove(listener)
+    }
+
+    fun notifyForegroundLeft() {
+        listeners.forEach { listener -> listener.onAnalyticsForegroundLeft() }
+    }
+
+    fun notifyForegroundEntered() {
+        listeners.forEach { listener -> listener.onAnalyticsForegroundEntered() }
+    }
+}
+
+object NoOpAnalytics : Analytics {
+    override fun track(event: AnalyticsEvent) = Unit
+
+    override fun flush() = Unit
+
+    override fun onConnectivityRestored() = Unit
+
+    override fun reset() = Unit
+
+    override fun setEnabled(enabled: Boolean) = Unit
+}
+
+/**
+ * Emits `sync_failed` at the transition **into** failure rather than once per attempt.
+ *
+ * Sync is retried on a timer, so a per-attempt event would turn an append-only table into a
+ * measurement of poll cadence instead of failure incidence, and an offline device would fill its
+ * 5000-event queue with repeats that evict the real events. A failure already reported in the
+ * current episode is suppressed while it persists, and the next success re-arms everything, so one
+ * failure episode costs one event per distinct way it failed.
+ *
+ * The gate is keyed on the reason **and** the screen, not on the reason alone. `screen` is the only
+ * thing in the frozen catalog that separates a deliberate Settings → *Sync now* from a background
+ * poll, and the poll runs every 15 s on Review and Cards, so a reason-only key would let the poll
+ * consume the episode first and systematically erase the deliberate action — the rarer and more
+ * informative of the two — exactly during the outages where it matters.
+ */
+class AnalyticsSyncFailureReporter(
+    private val analytics: Analytics
+) {
+    /**
+     * Reported failures of the current episode. A set rather than a last-value slot: with a
+     * two-part key, a last-value slot would re-emit the background failure every time a user-driven
+     * one interleaved with it, which is the poll-cadence measurement this gate exists to prevent.
+     */
+    private val reportedFailures: MutableSet<AnalyticsSyncFailureSignature> =
+        ConcurrentHashMap.newKeySet<AnalyticsSyncFailureSignature>()
+
+    fun reportFailure(
+        reason: AnalyticsSyncFailureReason,
+        screen: AnalyticsSurface? = null
+    ) {
+        val signature = AnalyticsSyncFailureSignature(reason = reason, screen = screen)
+        if (reportedFailures.add(signature).not()) {
+            return
+        }
+        analytics.track(event = AnalyticsEvent.SyncFailed(reason = reason, screen = screen))
+    }
+
+    /** Re-arms the next failure of any reason, on any screen. */
+    fun reportSuccess() {
+        reportedFailures.clear()
+    }
+}
+
+private data class AnalyticsSyncFailureSignature(
+    val reason: AnalyticsSyncFailureReason,
+    val screen: AnalyticsSurface?
+)
+
+/**
+ * The endpoint requires a human-authenticated transport and accepts `bearer`, `session` and
+ * `guest`. When no credential exists yet the client keeps events queued rather than sending an
+ * unauthenticated batch; an ordinary sign-up delay costs nothing under the 14-day queue TTL.
+ */
+data class AnalyticsCredential(
+    val apiBaseUrl: String,
+    val authorizationHeader: String
+)
+
+fun interface AnalyticsCredentialProvider {
+    suspend fun currentCredential(): AnalyticsCredential?
+}
+
+fun interface AnalyticsNetworkStateProvider {
+    fun currentNetworkState(): AnalyticsNetworkState
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsClient.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsClient.kt
@@ -1,0 +1,779 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import android.content.Context
+import android.os.Build
+import com.flashcardsopensourceapp.core.observability.AndroidAnalyticsObservationName
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AppObservability
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import java.util.concurrent.atomic.AtomicInteger
+import java.time.ZoneId
+import java.util.Locale
+import kotlin.random.Random
+
+/**
+ * Maximum number of batches one flush pass will deliver before yielding, so a very large backlog
+ * cannot monopolise the worker.
+ */
+private const val analyticsMaxBatchesPerFlush: Int = 10
+
+private sealed interface AnalyticsCommand {
+    data class Enqueue(
+        val event: AnalyticsEvent,
+        val occurredAtMillis: Long,
+        val networkState: AnalyticsNetworkState,
+        /**
+         * The number of identity boundaries requested when this event was created. The worker
+         * refuses any event whose generation is not both the one it has applied and the one
+         * currently requested, which is what makes the boundary independent of the order the
+         * channel happens to deliver in.
+         */
+        val identityGeneration: Int
+    ) : AnalyticsCommand
+
+    data object Flush : AnalyticsCommand
+
+    data object ConnectivityRestored : AnalyticsCommand
+
+    data object Reset : AnalyticsCommand
+
+    data class SetEnabled(val enabled: Boolean) : AnalyticsCommand
+}
+
+/**
+ * Durable, batching product-analytics client.
+ *
+ * Every command is handed to a single consumer coroutine on the IO dispatcher through a bounded
+ * channel, so [track] never blocks, never throws and never touches the database or the network on
+ * the calling thread, while the consumer still sees writes in order.
+ */
+class AnalyticsClient internal constructor(
+    context: Context,
+    private val appScope: CoroutineScope,
+    private val identity: AnalyticsIdentity,
+    private val credentialProvider: AnalyticsCredentialProvider,
+    private val networkStateProvider: AnalyticsNetworkStateProvider,
+    private val observability: AppObservability,
+    private val appVersion: String?,
+    private val versionCode: Int?,
+    private val transport: AnalyticsTransport,
+    private val deviceContextProvider: () -> AnalyticsDeviceContext = ::currentAnalyticsDeviceContext,
+    private val currentTimeMillisProvider: () -> Long = System::currentTimeMillis
+) : Analytics {
+    constructor(
+        context: Context,
+        appScope: CoroutineScope,
+        okHttpClient: OkHttpClient,
+        identity: AnalyticsIdentity,
+        credentialProvider: AnalyticsCredentialProvider,
+        networkStateProvider: AnalyticsNetworkStateProvider,
+        observability: AppObservability,
+        appVersion: String?,
+        versionCode: Int?
+    ) : this(
+        context = context,
+        appScope = appScope,
+        identity = identity,
+        credentialProvider = credentialProvider,
+        networkStateProvider = networkStateProvider,
+        observability = observability,
+        appVersion = appVersion,
+        versionCode = versionCode,
+        transport = OkHttpAnalyticsTransport(okHttpClient = okHttpClient)
+    )
+
+    private val applicationContext: Context = context.applicationContext
+
+    // Lazy on purpose: app start never waits for the queue to open.
+    private val databaseHolder: Lazy<AnalyticsDatabase> = lazy {
+        buildAnalyticsDatabase(context = applicationContext)
+    }
+    private val database: AnalyticsDatabase
+        get() = databaseHolder.value
+
+    private val commands = Channel<AnalyticsCommand>(capacity = 512)
+
+    @Volatile
+    private var enabled: Boolean = true
+
+    private val pendingDropCounts: MutableMap<AnalyticsDroppedReason, Int> = mutableMapOf()
+    private val handoffOverflowCount = AtomicInteger(0)
+
+    /**
+     * Identity boundaries requested so far, bumped synchronously inside [reset].
+     *
+     * This is the **in-process** half of the boundary only; the durable half is the rotation [reset]
+     * performs on the caller's thread. The counter exists because the [AnalyticsCommand.Reset]
+     * hand-off is droppable — a full channel would silently lose it — and because channel ordering
+     * is only guaranteed per calling thread: an event tracked on another thread just before the
+     * boundary carries the old generation and is refused even if its hand-off arrives after it.
+     *
+     * The counter is bumped before the rotation on purpose. The reverse order has a window in which
+     * an event created under the old generation is stored under the new `anonymous_id`, which is
+     * misattribution; this order's window instead stores an event under the old id after the queue
+     * was emptied, and the stored-id filter then discards it. This module prefers undercounting.
+     */
+    private val requestedIdentityGeneration = AtomicInteger(0)
+
+    /** Worker-confined: the generation the queue and `anonymous_id` currently belong to. */
+    private var appliedIdentityGeneration: Int = 0
+    private val reportedObservationNames: MutableSet<AndroidAnalyticsObservationName> = mutableSetOf()
+    private var consecutiveDeliveryFailureCount: Int = 0
+    private var nextDeliveryAttemptAtMillis: Long = 0L
+    private var isDeliveryBackoffFromTransportFailure: Boolean = false
+    private var firstServerErrorAtMillis: Long? = null
+
+    init {
+        startCommandWorker()
+        startPeriodicFlush()
+    }
+
+    override fun track(event: AnalyticsEvent) {
+        if (!enabled) {
+            return
+        }
+
+        val occurredAtMillis: Long = currentTimeMillisProvider()
+        // Both readings belong to the moment the event is created. The worker can be parked inside
+        // a flush for several batches of network I/O, so reading the network state there could
+        // relabel an event created offline as `wifi`, losing the one value the column exists for.
+        val networkState: AnalyticsNetworkState = networkStateProvider.currentNetworkState()
+        val enqueued: Boolean = commands.trySend(
+            AnalyticsCommand.Enqueue(
+                event = event,
+                occurredAtMillis = occurredAtMillis,
+                networkState = networkState,
+                identityGeneration = requestedIdentityGeneration.get()
+            )
+        ).isSuccess
+        if (!enqueued) {
+            // Drop rather than wait: a full hand-off buffer may never delay the caller.
+            recordHandoffOverflow()
+        }
+    }
+
+    override fun flush() {
+        if (!enabled) {
+            return
+        }
+        commands.trySend(AnalyticsCommand.Flush)
+    }
+
+    override fun onConnectivityRestored() {
+        if (!enabled) {
+            return
+        }
+        commands.trySend(AnalyticsCommand.ConnectivityRestored)
+    }
+
+    override fun reset() {
+        // The counter closes the in-process hole; the hand-off below only makes the cleanup prompt.
+        // A boundary command must not be droppable, and `trySend` is: on a full channel the queue
+        // would survive the logout and ship under the next credential.
+        requestedIdentityGeneration.incrementAndGet()
+        // The durable half, synchronously on the caller's thread. An in-process counter says
+        // nothing on disk, so deferring this to the worker leaves a window — the worker can be
+        // parked inside a flush for several batches of network I/O, and force-quitting after
+        // signing out is an ordinary thing to do — in which a process death loses the boundary
+        // entirely: the queue still holds the outgoing person's rows, `anonymous_id` is still
+        // theirs, and the next launch starts at generation zero with nothing to detect. Rotating
+        // here instead makes the boundary hold on its own, because every queued row now carries a
+        // stale `anonymousId` and neither batch selection nor delivery will touch one.
+        //
+        // It is one `SharedPreferences` commit and no network or database work, and all three hook
+        // sites already run inside `CloudIdentityResetCoordinator`'s `withContext(Dispatchers.IO)`,
+        // so nothing on the interaction path waits for it.
+        identity.rotateForLogout()
+        commands.trySend(AnalyticsCommand.Reset)
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        this.enabled = enabled
+        commands.trySend(AnalyticsCommand.SetEnabled(enabled = enabled))
+    }
+
+    /**
+     * Releases the queue's SQLite connection. Call it only once the scope that owns the command
+     * worker has been cancelled. Production never rebuilds the graph, but the instrumentation reset
+     * rule does it several times per test, and without this every run leaks a connection on one
+     * file across the whole suite.
+     */
+    fun close() {
+        commands.close()
+        if (databaseHolder.isInitialized()) {
+            databaseHolder.value.close()
+        }
+    }
+
+    private fun startCommandWorker() {
+        appScope.launch(Dispatchers.IO) {
+            for (command in commands) {
+                try {
+                    // Before anything else, so no command can reach the queue or the network with a
+                    // requested boundary still unapplied.
+                    applyRequestedIdentityBoundary()
+                    when (command) {
+                        is AnalyticsCommand.Enqueue -> handleEnqueue(
+                            event = command.event,
+                            occurredAtMillis = command.occurredAtMillis,
+                            networkState = command.networkState,
+                            identityGeneration = command.identityGeneration
+                        )
+
+                        AnalyticsCommand.Flush -> handleFlush()
+                        AnalyticsCommand.ConnectivityRestored -> handleConnectivityRestored()
+                        // Already applied above; the command only exists to wake the worker.
+                        AnalyticsCommand.Reset -> Unit
+                        is AnalyticsCommand.SetEnabled -> handleSetEnabled(enabled = command.enabled)
+                    }
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Exception) {
+                    reportOnce(
+                        name = when (command) {
+                            is AnalyticsCommand.Enqueue -> AndroidAnalyticsObservationName.QUEUE_STORE_WRITE_FAILED
+                            else -> AndroidAnalyticsObservationName.QUEUE_STORE_READ_FAILED
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun startPeriodicFlush() {
+        appScope.launch(Dispatchers.IO) {
+            while (isActive) {
+                delay(analyticsPeriodicFlushIntervalMillis)
+                flush()
+            }
+        }
+    }
+
+    private suspend fun handleEnqueue(
+        event: AnalyticsEvent,
+        occurredAtMillis: Long,
+        networkState: AnalyticsNetworkState,
+        identityGeneration: Int
+    ) {
+        if (!enabled) {
+            return
+        }
+
+        // Read before the generation checks, never at insert time: `serializeAnalyticsEvent` and
+        // `enforceQueueCaps` suspend on the database in between, and a [reset] landing inside that
+        // window would otherwise store a pre-boundary event under the **next** person's
+        // `anonymous_id` — misattribution, the one direction this module never takes.
+        //
+        // Reading it here makes the boundary hold rather than merely be unlikely, because [reset]
+        // bumps the counter before it rotates: if this read returned the rotated id then the bump
+        // already happened, so the live counter below has moved and the event is refused. If the
+        // checks pass instead, the rotation had not happened yet, this is the outgoing person's id,
+        // and every delivery path filters on the stored id.
+        val anonymousId: String = identity.currentAnonymousId()
+        if (
+            identityGeneration != appliedIdentityGeneration ||
+            identityGeneration != requestedIdentityGeneration.get()
+        ) {
+            // Created on the other side of an identity boundary — one already applied, or one
+            // requested since this command was picked up. Storing it would let it ship under the
+            // next person's credential, which this module never allows: it prefers undercounting to
+            // misattribution.
+            return
+        }
+
+        val dao: AnalyticsQueueDao = database.analyticsQueueDao()
+        val serializedEvent: AnalyticsSerializedEvent = serializeAnalyticsEvent(
+            event = event,
+            eventId = newAnalyticsEventId(epochMillis = occurredAtMillis),
+            occurredAtMillis = occurredAtMillis,
+            networkState = networkState
+        )
+
+        if (serializedEvent.byteSize > analyticsMaxEventBytes) {
+            // The server would refuse it; refusing it here keeps the batch it would have poisoned.
+            recordDropped(reason = AnalyticsDroppedReason.REJECTED, count = 1)
+            reportOnce(name = AndroidAnalyticsObservationName.BATCH_CONTRACT_REFUSED)
+            return
+        }
+
+        enforceQueueCaps(dao = dao, incomingByteSize = serializedEvent.byteSize)
+        dao.insert(
+            entity = AnalyticsQueuedEventEntity(
+                eventId = serializedEvent.eventId,
+                eventName = serializedEvent.eventName,
+                eventJson = serializedEvent.json,
+                byteSize = serializedEvent.byteSize,
+                createdAtMillis = occurredAtMillis,
+                anonymousId = anonymousId,
+                // Read at insert time on purpose, unlike the id above: it advances `last_event_at`,
+                // and an event that was refused must not move the session clock.
+                sessionId = identity.sessionIdForEvent(nowMillis = occurredAtMillis)
+            )
+        )
+
+        if (dao.countEvents() >= analyticsFlushBatchThreshold) {
+            handleFlush()
+        }
+    }
+
+    /**
+     * The asynchronous half of an identity boundary: [reset] has already rotated `anonymous_id` on
+     * disk, so this only empties the queue and advances the applied generation.
+     *
+     * It deliberately does **not** rotate again. The rotation is durable and belongs to the thread
+     * that asked for the boundary; repeating it here would mint a second `anonymous_id` for one
+     * logout, and — because a persistently failing delete leaves the boundary pending — a fresh one
+     * on every subsequent command, each with its own synchronous commit. Rotate once, retry only
+     * the delete.
+     *
+     * The delete is cleanup rather than the boundary itself: from the rotation onwards every queued
+     * row carries a stale `anonymousId`, and neither batch selection nor
+     * [purgeEventsFromPreviousIdentities] will ever hand one to the server, so a delete that never
+     * succeeds costs queue space and nothing else.
+     *
+     * The applied generation advances only once the delete has succeeded. A failure therefore leaves
+     * the boundary pending and retries on the next command, and until then every enqueue is refused
+     * as out of generation, which is the conservative direction.
+     *
+     * Several boundaries in a row coalesce: any number of consecutive boundaries needs exactly one
+     * empty queue, and the enqueue generation check discards whatever was created between them.
+     *
+     * The loss is reported through the platform's error reporter rather than counted into
+     * `analytics_events_dropped`: that `reason` enum is frozen, and `rejected` has to keep meaning
+     * a real server refusal.
+     */
+    private suspend fun applyRequestedIdentityBoundary() {
+        val requestedGeneration: Int = requestedIdentityGeneration.get()
+        if (requestedGeneration == appliedIdentityGeneration) {
+            return
+        }
+
+        val discardedCount: Int = database.analyticsQueueDao().deleteAll()
+        pendingDropCounts.clear()
+        handoffOverflowCount.set(0)
+        appliedIdentityGeneration = requestedGeneration
+        if (discardedCount > 0) {
+            reportOnce(
+                name = AndroidAnalyticsObservationName.IDENTITY_BOUNDARY_DISCARDED,
+                eventCount = discardedCount
+            )
+        }
+    }
+
+    /**
+     * Connectivity is back. An offline stretch must not leave the queue parked behind a backoff
+     * that only a transport failure produced, which is exactly what the connectivity flush trigger
+     * exists to prevent. A `429`/`5xx` backoff is server pressure and is left in place.
+     */
+    private suspend fun handleConnectivityRestored() {
+        if (isDeliveryBackoffFromTransportFailure) {
+            isDeliveryBackoffFromTransportFailure = false
+            nextDeliveryAttemptAtMillis = 0L
+        }
+        handleFlush()
+    }
+
+    private suspend fun handleSetEnabled(enabled: Boolean) {
+        if (enabled) {
+            return
+        }
+        // Nothing captured before the kill switch may leave the device afterwards.
+        database.analyticsQueueDao().deleteAll()
+        pendingDropCounts.clear()
+        handoffOverflowCount.set(0)
+    }
+
+    private suspend fun handleFlush() {
+        if (!enabled) {
+            return
+        }
+
+        val nowMillis: Long = currentTimeMillisProvider()
+        // Every backoff this client schedules is capped at [analyticsMaxRetryDelayMillis], including
+        // a `Retry-After`, so a deadline further out than the cap cannot have been scheduled against
+        // the clock now being read: the wall clock moved backwards after it was set. Waiting for
+        // wall time to catch up would park the queue — and with it the TTL purge below — for the
+        // size of the jump, until the caps started dropping the oldest events.
+        if (nextDeliveryAttemptAtMillis - nowMillis > analyticsMaxRetryDelayMillis) {
+            nextDeliveryAttemptAtMillis = nowMillis
+        }
+        if (nowMillis < nextDeliveryAttemptAtMillis) {
+            return
+        }
+
+        val dao: AnalyticsQueueDao = database.analyticsQueueDao()
+        purgeExpiredEvents(dao = dao, nowMillis = nowMillis)
+        purgeEventsFromPreviousIdentities(dao = dao)
+        materializePendingDrops(dao = dao, nowMillis = nowMillis)
+
+        // Never send an unauthenticated batch: without a credential the events stay queued.
+        val credential: AnalyticsCredential = credentialProvider.currentCredential() ?: return
+        val deviceContext: AnalyticsDeviceContext = deviceContextProvider()
+
+        var deliveredBatchCount = 0
+        while (deliveredBatchCount < analyticsMaxBatchesPerFlush) {
+            // Selection is filtered on the stored `anonymous_id` rather than on whatever row happens
+            // to be oldest, so a delete that failed at a boundary — or one that never ran because
+            // the process died before the worker woke — still cannot put a departed person's events
+            // on the wire. Re-read per batch: a logout may land between two batches of one flush.
+            val currentAnonymousId: String = identity.currentAnonymousId()
+            val oldestEvent: AnalyticsQueuedEventEntity =
+                dao.oldestEventForAnonymousId(anonymousId = currentAnonymousId) ?: return
+            val batch: List<AnalyticsQueuedEventEntity> = takeBatchWithinBodyLimit(
+                events = dao.oldestEventsForIdentity(
+                    anonymousId = currentAnonymousId,
+                    sessionId = oldestEvent.sessionId,
+                    limit = analyticsMaxEventsPerBatch
+                )
+            )
+            if (batch.isEmpty()) {
+                return
+            }
+
+            val delivered: Boolean = deliverBatch(
+                dao = dao,
+                credential = credential,
+                deviceContext = deviceContext,
+                batch = batch
+            )
+            if (!delivered) {
+                return
+            }
+            deliveredBatchCount += 1
+        }
+    }
+
+    /**
+     * Delivers one batch, splitting it on a whole-batch refusal until every part either lands or is
+     * dropped. Splitting terminates and cannot wedge the queue behind a single poison event.
+     */
+    private suspend fun deliverBatch(
+        dao: AnalyticsQueueDao,
+        credential: AnalyticsCredential,
+        deviceContext: AnalyticsDeviceContext,
+        batch: List<AnalyticsQueuedEventEntity>
+    ): Boolean {
+        val pendingChunks: ArrayDeque<List<AnalyticsQueuedEventEntity>> = ArrayDeque()
+        pendingChunks.addLast(batch)
+
+        while (pendingChunks.isNotEmpty()) {
+            val chunk: List<AnalyticsQueuedEventEntity> = pendingChunks.removeFirst()
+            val outcome: AnalyticsBatchOutcome = transport.sendBatch(
+                credential = credential,
+                clientVersion = appVersion,
+                body = renderAnalyticsBatchBody(
+                    // Stamped now, not when the events were created: the server derives
+                    // `occurred_at` from the interval between the two.
+                    clientSentAtMillis = currentTimeMillisProvider(),
+                    anonymousId = chunk.first().anonymousId,
+                    sessionId = chunk.first().sessionId,
+                    deviceContext = deviceContext,
+                    eventJsonPayloads = chunk.map { queuedEvent -> queuedEvent.eventJson }
+                )
+            )
+
+            when (outcome) {
+                is AnalyticsBatchOutcome.Finished -> {
+                    // A 200 finishes the batch. `accepted` is a count only and rejected events are
+                    // permanently refused, so everything that was sent is purged by what was sent.
+                    dao.deleteByIds(eventIds = chunk.map { queuedEvent -> queuedEvent.eventId })
+                    if (outcome.rejectedCount > 0 && !containsOnlyDropEvents(chunk = chunk)) {
+                        recordDropped(
+                            reason = AnalyticsDroppedReason.REJECTED,
+                            count = outcome.rejectedCount
+                        )
+                    }
+                    onDeliverySucceeded()
+                }
+
+                is AnalyticsBatchOutcome.WholeBatchRefused -> {
+                    reportOnce(name = AndroidAnalyticsObservationName.BATCH_CONTRACT_REFUSED)
+                    if (chunk.size > 1) {
+                        val midpoint: Int = chunk.size / 2
+                        pendingChunks.addFirst(chunk.subList(midpoint, chunk.size).toList())
+                        pendingChunks.addFirst(chunk.subList(0, midpoint).toList())
+                    } else {
+                        // Retrying the same bytes fails identically forever.
+                        dao.deleteByIds(eventIds = chunk.map { queuedEvent -> queuedEvent.eventId })
+                        if (!containsOnlyDropEvents(chunk = chunk)) {
+                            recordDropped(
+                                reason = AnalyticsDroppedReason.REJECTED,
+                                count = chunk.size
+                            )
+                        }
+                    }
+                }
+
+                is AnalyticsBatchOutcome.RetryLater -> {
+                    noteServerError(statusCode = outcome.statusCode)
+                    scheduleRetry(retryAfterMillis = outcome.retryAfterMillis)
+                    return false
+                }
+
+                is AnalyticsBatchOutcome.CredentialRefused -> {
+                    // Keep the events queued against a future valid credential; do not spin.
+                    scheduleRetry(retryAfterMillis = null)
+                    return false
+                }
+
+                AnalyticsBatchOutcome.TransportFailure -> {
+                    // Being offline is not server pressure. It must not grow the same backoff
+                    // towards the one-hour cap, or connectivity coming back would find the queue
+                    // parked for an hour behind a window nothing had a reason to open.
+                    scheduleTransportFailureRetry()
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
+    private fun onDeliverySucceeded() {
+        consecutiveDeliveryFailureCount = 0
+        nextDeliveryAttemptAtMillis = 0L
+        isDeliveryBackoffFromTransportFailure = false
+        firstServerErrorAtMillis = null
+    }
+
+    /**
+     * A short fixed pause that keeps an offline device from re-attempting on every enqueued event,
+     * and that [handleConnectivityRestored] can clear outright.
+     */
+    private fun scheduleTransportFailureRetry() {
+        isDeliveryBackoffFromTransportFailure = true
+        nextDeliveryAttemptAtMillis = currentTimeMillisProvider() + analyticsInitialRetryDelayMillis
+    }
+
+    /**
+     * `Retry-After` wins when present, and local exponential backoff with full jitter covers the
+     * answers that never carry it, such as the API Gateway throttle refusal.
+     */
+    private fun scheduleRetry(retryAfterMillis: Long?) {
+        isDeliveryBackoffFromTransportFailure = false
+        consecutiveDeliveryFailureCount += 1
+        val delayMillis: Long = if (retryAfterMillis != null) {
+            retryAfterMillis
+        } else {
+            val exponentialCeilingMillis: Long = analyticsInitialRetryDelayMillis
+                .shl(minOf(consecutiveDeliveryFailureCount - 1, 10))
+                .coerceIn(analyticsInitialRetryDelayMillis, analyticsMaxRetryDelayMillis)
+            Random.nextLong(from = 0L, until = exponentialCeilingMillis + 1L)
+        }
+        nextDeliveryAttemptAtMillis = currentTimeMillisProvider() +
+            delayMillis.coerceIn(0L, analyticsMaxRetryDelayMillis)
+    }
+
+    private fun noteServerError(statusCode: Int) {
+        if (statusCode < 500) {
+            firstServerErrorAtMillis = null
+            return
+        }
+
+        val nowMillis: Long = currentTimeMillisProvider()
+        val firstErrorAtMillis: Long = firstServerErrorAtMillis ?: nowMillis.also {
+            firstServerErrorAtMillis = nowMillis
+        }
+        if (nowMillis - firstErrorAtMillis > analyticsSustainedServerErrorReportAfterMillis) {
+            reportOnce(
+                name = AndroidAnalyticsObservationName.SUSTAINED_SERVER_ERRORS,
+                statusCode = statusCode
+            )
+        }
+    }
+
+    /**
+     * The delivery-side half of the identity boundary. A row whose `anonymousId` is no longer the
+     * current one was created by somebody who has since left this install, and the credential in
+     * hand now belongs to somebody else, so it can never be delivered. Normally
+     * [applyRequestedIdentityBoundary] already emptied the queue and this finds nothing; it is what
+     * makes the boundary hold when that delete failed, or never ran at all because the process died
+     * between [reset]'s rotation and the worker waking up.
+     */
+    private suspend fun purgeEventsFromPreviousIdentities(dao: AnalyticsQueueDao) {
+        val discardedCount: Int = dao.deleteForOtherAnonymousIds(
+            anonymousId = identity.currentAnonymousId()
+        )
+        if (discardedCount > 0) {
+            reportOnce(
+                name = AndroidAnalyticsObservationName.IDENTITY_BOUNDARY_DISCARDED,
+                eventCount = discardedCount
+            )
+        }
+    }
+
+    private suspend fun purgeExpiredEvents(
+        dao: AnalyticsQueueDao,
+        nowMillis: Long
+    ) {
+        val expiredCount: Int = dao.deleteExpired(cutoffMillis = nowMillis - analyticsQueueTtlMillis)
+        if (expiredCount > 0) {
+            recordDropped(reason = AnalyticsDroppedReason.TTL_EXPIRED, count = expiredCount)
+            reportOnce(
+                name = AndroidAnalyticsObservationName.QUEUE_TTL_EXPIRED,
+                eventCount = expiredCount
+            )
+        }
+    }
+
+    private suspend fun enforceQueueCaps(
+        dao: AnalyticsQueueDao,
+        incomingByteSize: Int
+    ) {
+        var overflowCount = 0
+
+        val queuedEventCount: Int = dao.countEvents()
+        if (queuedEventCount + 1 > analyticsMaxQueuedEvents) {
+            overflowCount += dao.deleteOldest(limit = queuedEventCount + 1 - analyticsMaxQueuedEvents)
+        }
+
+        while (dao.totalByteSize() + incomingByteSize > analyticsMaxQueuedBytes) {
+            val removedCount: Int = dao.deleteOldest(limit = analyticsMaxEventsPerBatch)
+            if (removedCount <= 0) {
+                break
+            }
+            overflowCount += removedCount
+        }
+
+        if (overflowCount > 0) {
+            recordDropped(reason = AnalyticsDroppedReason.QUEUE_OVERFLOW, count = overflowCount)
+            reportOnce(
+                name = AndroidAnalyticsObservationName.QUEUE_OVERFLOW,
+                eventCount = overflowCount
+            )
+        }
+    }
+
+    /**
+     * Turns the accumulated loss counters into `analytics_events_dropped` events so the loss shows
+     * up in the data itself and not only in server-side telemetry. Counters are aggregated rather
+     * than emitted one per drop, which also keeps a drop from causing another drop.
+     */
+    private suspend fun materializePendingDrops(
+        dao: AnalyticsQueueDao,
+        nowMillis: Long
+    ) {
+        val handoffOverflow: Int = handoffOverflowCount.getAndSet(0)
+        if (handoffOverflow > 0) {
+            recordDropped(reason = AnalyticsDroppedReason.QUEUE_OVERFLOW, count = handoffOverflow)
+            reportOnce(
+                name = AndroidAnalyticsObservationName.QUEUE_OVERFLOW,
+                eventCount = handoffOverflow
+            )
+        }
+
+        if (pendingDropCounts.isEmpty()) {
+            return
+        }
+
+        val drops: Map<AnalyticsDroppedReason, Int> = pendingDropCounts.toMap()
+        pendingDropCounts.clear()
+        drops.forEach { (reason, count) ->
+            if (count <= 0) {
+                return@forEach
+            }
+            val serializedEvent: AnalyticsSerializedEvent = serializeAnalyticsEvent(
+                event = AnalyticsEvent.AnalyticsEventsDropped(reason = reason, count = count),
+                eventId = newAnalyticsEventId(epochMillis = nowMillis),
+                occurredAtMillis = nowMillis,
+                networkState = networkStateProvider.currentNetworkState()
+            )
+            dao.insert(
+                entity = AnalyticsQueuedEventEntity(
+                    eventId = serializedEvent.eventId,
+                    eventName = serializedEvent.eventName,
+                    eventJson = serializedEvent.json,
+                    byteSize = serializedEvent.byteSize,
+                    createdAtMillis = nowMillis,
+                    anonymousId = identity.currentAnonymousId(),
+                    sessionId = identity.sessionIdForEvent(nowMillis = nowMillis)
+                )
+            )
+        }
+    }
+
+    private fun recordDropped(
+        reason: AnalyticsDroppedReason,
+        count: Int
+    ) {
+        if (count <= 0) {
+            return
+        }
+        pendingDropCounts[reason] = (pendingDropCounts[reason] ?: 0) + count
+    }
+
+    /** Reached from any thread, so the loss is only counted here and accounted for on the worker. */
+    private fun recordHandoffOverflow() {
+        handoffOverflowCount.incrementAndGet()
+    }
+
+    private fun reportOnce(
+        name: AndroidAnalyticsObservationName,
+        eventCount: Int? = null,
+        statusCode: Int? = null
+    ) {
+        if (!reportedObservationNames.add(name)) {
+            return
+        }
+        observability.captureWarning(
+            event = AndroidWarningIssueEvent.AnalyticsPipelineWarning(
+                name = name,
+                eventCount = eventCount,
+                statusCode = statusCode,
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
+    }
+}
+
+/**
+ * A rejection is itself a loss, and a loss emits `analytics_events_dropped`. When the refused batch
+ * held nothing but drop events, counting the refusal would emit another drop event that is refused
+ * for the same reason: net queue change zero and a device posting forever, which one install can
+ * use to consume the endpoint's whole per-method throttle. Discard those instead.
+ */
+private fun containsOnlyDropEvents(chunk: List<AnalyticsQueuedEventEntity>): Boolean {
+    return chunk.all { queuedEvent -> queuedEvent.eventName == analyticsEventsDroppedEventName }
+}
+
+/**
+ * Trims a batch so the serialized body cannot exceed the request-body limit. Fifty events at the
+ * per-event limit already fit, so this only matters if either server limit ever moves.
+ */
+private fun takeBatchWithinBodyLimit(
+    events: List<AnalyticsQueuedEventEntity>
+): List<AnalyticsQueuedEventEntity> {
+    val bodyBudgetBytes: Int = analyticsMaxRequestBodyBytes - analyticsBatchEnvelopeHeadroomBytes
+    var usedBytes = 0
+    val batch = mutableListOf<AnalyticsQueuedEventEntity>()
+    for (event in events) {
+        val nextUsedBytes: Int = usedBytes + event.byteSize + 1
+        if (batch.isNotEmpty() && nextUsedBytes > bodyBudgetBytes) {
+            break
+        }
+        batch += event
+        usedBytes = nextUsedBytes
+    }
+    return batch
+}
+
+private const val analyticsBatchEnvelopeHeadroomBytes: Int = 2_048
+
+/** Describes the device at flush time; every field is capped at 200 characters server-side. */
+fun currentAnalyticsDeviceContext(): AnalyticsDeviceContext {
+    return AnalyticsDeviceContext(
+        osVersion = Build.VERSION.RELEASE,
+        deviceModel = "${Build.MANUFACTURER} ${Build.MODEL}",
+        deviceLocale = Locale.getDefault().toLanguageTag(),
+        timezone = ZoneId.systemDefault().id
+    )
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsEvent.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsEvent.kt
@@ -1,0 +1,251 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+/**
+ * Hand-written mirror of the frozen backend product-analytics catalog.
+ *
+ * The server keeps a closed allowlist of event names, property names and property values, so this
+ * file is deliberately type-strict: there is no `track(name, properties)` anywhere. Every event is
+ * its own data class whose constructor arguments are exactly the properties the server declares,
+ * which means an event that cannot satisfy the contract does not compile.
+ *
+ * `guest_upgrade_completed` and `catalog_deck_installed` are server-derived. A client batch that
+ * contains either is rejected, so they are absent here on purpose.
+ */
+
+/** Named because the delivery path has to recognise a batch that carries nothing else. */
+internal const val analyticsEventsDroppedEventName: String = "analytics_events_dropped"
+
+/** Shared cross-platform surface enum for the top-level `screen` field. */
+enum class AnalyticsSurface(val wireValue: String) {
+    REVIEW(wireValue = "review"),
+    CATALOG(wireValue = "catalog"),
+    DECK_DETAIL(wireValue = "deck_detail"),
+    ONBOARDING(wireValue = "onboarding"),
+    CARD_EDITOR(wireValue = "card_editor"),
+    CARDS(wireValue = "cards"),
+    PROGRESS(wireValue = "progress"),
+    SETTINGS(wireValue = "settings"),
+    AI(wireValue = "ai")
+}
+
+/** Captured when the event is created, never when the batch is flushed. */
+enum class AnalyticsNetworkState(val wireValue: String) {
+    WIFI(wireValue = "wifi"),
+    CELLULAR(wireValue = "cellular"),
+    OFFLINE(wireValue = "offline"),
+    UNKNOWN(wireValue = "unknown")
+}
+
+enum class AnalyticsLaunchType(val wireValue: String) {
+    COLD(wireValue = "cold"),
+    WARM(wireValue = "warm")
+}
+
+enum class AnalyticsOnboardingStep(val wireValue: String) {
+    LANGUAGE(wireValue = "language"),
+    GOAL(wireValue = "goal"),
+    NOTIFICATIONS(wireValue = "notifications"),
+    FIRST_DECK(wireValue = "first_deck"),
+    FIRST_REVIEW(wireValue = "first_review"),
+    SIGNIN(wireValue = "signin")
+}
+
+enum class AnalyticsOnboardingOutcome(val wireValue: String) {
+    COMPLETED(wireValue = "completed"),
+    SKIPPED(wireValue = "skipped")
+}
+
+enum class AnalyticsSignInFailureReason(val wireValue: String) {
+    INVALID_CODE(wireValue = "invalid_code"),
+    EXPIRED_CODE(wireValue = "expired_code"),
+    RATE_LIMITED(wireValue = "rate_limited"),
+    OFFLINE(wireValue = "offline"),
+    SERVER_ERROR(wireValue = "server_error"),
+    CANCELLED(wireValue = "cancelled")
+}
+
+enum class AnalyticsDeckScope(val wireValue: String) {
+    ALL(wireValue = "all"),
+    DECK(wireValue = "deck"),
+    FILTER(wireValue = "filter")
+}
+
+enum class AnalyticsReviewEndReason(val wireValue: String) {
+    COMPLETED(wireValue = "completed"),
+    ABANDONED(wireValue = "abandoned"),
+    INTERRUPTED(wireValue = "interrupted")
+}
+
+enum class AnalyticsReviewAnswerFailureReason(val wireValue: String) {
+    OFFLINE(wireValue = "offline"),
+    TIMEOUT(wireValue = "timeout"),
+    SYNC_CONFLICT(wireValue = "sync_conflict"),
+    SERVER_ERROR(wireValue = "server_error")
+}
+
+enum class AnalyticsCardCreateEntryPoint(val wireValue: String) {
+    CARDS(wireValue = "cards"),
+    DECK_DETAIL(wireValue = "deck_detail"),
+    REVIEW(wireValue = "review"),
+    AI(wireValue = "ai"),
+    QUICK_ACTION(wireValue = "quick_action")
+}
+
+enum class AnalyticsSyncFailureReason(val wireValue: String) {
+    OFFLINE(wireValue = "offline"),
+    TIMEOUT(wireValue = "timeout"),
+    CONFLICT(wireValue = "conflict"),
+    UNAUTHORIZED(wireValue = "unauthorized"),
+    SERVER_ERROR(wireValue = "server_error"),
+    STORAGE_FULL(wireValue = "storage_full")
+}
+
+enum class AnalyticsDroppedReason(val wireValue: String) {
+    QUEUE_OVERFLOW(wireValue = "queue_overflow"),
+    TTL_EXPIRED(wireValue = "ttl_expired"),
+    REJECTED(wireValue = "rejected")
+}
+
+/**
+ * The two property value kinds the server catalog accepts from this client: an exact allowlisted
+ * string, and an integer greater than or equal to zero.
+ */
+sealed interface AnalyticsPropertyValue {
+    data class Text(val value: String) : AnalyticsPropertyValue
+
+    data class Count(val value: Int) : AnalyticsPropertyValue
+}
+
+sealed interface AnalyticsEvent {
+    val eventName: String
+
+    /** Top-level event field, never a property. Legal on every event, required on `screen_viewed`. */
+    val screen: AnalyticsSurface?
+
+    val properties: Map<String, AnalyticsPropertyValue>
+
+    data class AppOpened(
+        val launchType: AnalyticsLaunchType,
+        override val screen: AnalyticsSurface? = null
+    ) : AnalyticsEvent {
+        override val eventName: String = "app_opened"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "launch_type" to AnalyticsPropertyValue.Text(value = launchType.wireValue)
+        )
+    }
+
+    /** `screen` is non-null here on purpose: the server rejects `screen_viewed` without it. */
+    data class ScreenViewed(
+        override val screen: AnalyticsSurface
+    ) : AnalyticsEvent {
+        override val eventName: String = "screen_viewed"
+        override val properties: Map<String, AnalyticsPropertyValue> = emptyMap()
+    }
+
+    data class OnboardingStepCompleted(
+        val step: AnalyticsOnboardingStep,
+        val outcome: AnalyticsOnboardingOutcome,
+        override val screen: AnalyticsSurface? = AnalyticsSurface.ONBOARDING
+    ) : AnalyticsEvent {
+        override val eventName: String = "onboarding_step_completed"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "step" to AnalyticsPropertyValue.Text(value = step.wireValue),
+            "outcome" to AnalyticsPropertyValue.Text(value = outcome.wireValue)
+        )
+    }
+
+    data class SignInFailed(
+        val reason: AnalyticsSignInFailureReason,
+        override val screen: AnalyticsSurface? = null
+    ) : AnalyticsEvent {
+        override val eventName: String = "signin_failed"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "reason" to AnalyticsPropertyValue.Text(value = reason.wireValue)
+        )
+    }
+
+    data class ReviewSessionStarted(
+        val deckScope: AnalyticsDeckScope,
+        override val screen: AnalyticsSurface? = AnalyticsSurface.REVIEW
+    ) : AnalyticsEvent {
+        override val eventName: String = "review_session_started"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "deck_scope" to AnalyticsPropertyValue.Text(value = deckScope.wireValue)
+        )
+    }
+
+    data class ReviewSessionEnded(
+        val endReason: AnalyticsReviewEndReason,
+        val answeredCount: Int,
+        val durationMs: Long,
+        override val screen: AnalyticsSurface? = AnalyticsSurface.REVIEW
+    ) : AnalyticsEvent {
+        override val eventName: String = "review_session_ended"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "end_reason" to AnalyticsPropertyValue.Text(value = endReason.wireValue),
+            "answered_count" to AnalyticsPropertyValue.Count(value = nonNegativeAnalyticsCount(value = answeredCount.toLong())),
+            "duration_ms" to AnalyticsPropertyValue.Count(value = nonNegativeAnalyticsCount(value = durationMs))
+        )
+    }
+
+    data class ReviewAnswerFailed(
+        val reason: AnalyticsReviewAnswerFailureReason,
+        override val screen: AnalyticsSurface? = AnalyticsSurface.REVIEW
+    ) : AnalyticsEvent {
+        override val eventName: String = "review_answer_failed"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "reason" to AnalyticsPropertyValue.Text(value = reason.wireValue)
+        )
+    }
+
+    data class CardCreateStarted(
+        val entryPoint: AnalyticsCardCreateEntryPoint,
+        override val screen: AnalyticsSurface? = null
+    ) : AnalyticsEvent {
+        override val eventName: String = "card_create_started"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "entry_point" to AnalyticsPropertyValue.Text(value = entryPoint.wireValue)
+        )
+    }
+
+    data class SyncFailed(
+        val reason: AnalyticsSyncFailureReason,
+        override val screen: AnalyticsSurface? = null
+    ) : AnalyticsEvent {
+        override val eventName: String = "sync_failed"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "reason" to AnalyticsPropertyValue.Text(value = reason.wireValue)
+        )
+    }
+
+    data class CatalogDeckInstallStarted(
+        val packageSlug: String,
+        override val screen: AnalyticsSurface? = AnalyticsSurface.CATALOG
+    ) : AnalyticsEvent {
+        override val eventName: String = "catalog_deck_install_started"
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "package_slug" to AnalyticsPropertyValue.Text(value = packageSlug)
+        )
+    }
+
+    data class AnalyticsEventsDropped(
+        val reason: AnalyticsDroppedReason,
+        val count: Int,
+        override val screen: AnalyticsSurface? = null
+    ) : AnalyticsEvent {
+        override val eventName: String = analyticsEventsDroppedEventName
+        override val properties: Map<String, AnalyticsPropertyValue> = mapOf(
+            "reason" to AnalyticsPropertyValue.Text(value = reason.wireValue),
+            "count" to AnalyticsPropertyValue.Count(value = nonNegativeAnalyticsCount(value = count.toLong()))
+        )
+    }
+}
+
+/**
+ * The server rejects negatives and anything outside the integer range, and a rejected event is
+ * reported back only as the generic `invalid_event`. Clamping here keeps a bad caller-side count
+ * from silently costing the event.
+ */
+private fun nonNegativeAnalyticsCount(value: Long): Int {
+    return value.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsIdentity.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsIdentity.kt
@@ -1,0 +1,101 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+/**
+ * Storage name for the analytics identity. It is excluded from Android auto-backup and from
+ * device-to-device transfer in `apps/android/app/src/main/res/xml/data_extraction_rules.xml`, the
+ * document the application element points at with `android:dataExtractionRules`.
+ *
+ * That exclusion is load-bearing, not hygiene: a restored `anonymous_id` would appear on a second
+ * device, and identity resolution in `analytics.identity_links` is first-link-wins with no repair
+ * path, so a shared id merges two people permanently.
+ */
+const val analyticsIdentityPreferencesName: String = "flashcards-analytics-identity"
+
+private const val anonymousIdKey: String = "anonymous_id"
+private const val sessionIdKey: String = "session_id"
+private const val lastEventAtMillisKey: String = "last_event_at_millis"
+
+/**
+ * `anonymous_id` and `session_id` lifecycle.
+ *
+ * The sync installation id is deliberately not reused: it must stay stable across users, while
+ * `anonymous_id` must reset on logout so a second person on a shared device does not inherit the
+ * first person's identity.
+ */
+class AnalyticsIdentity(
+    context: Context
+) {
+    private val preferences: SharedPreferences = context.applicationContext.getSharedPreferences(
+        analyticsIdentityPreferencesName,
+        Context.MODE_PRIVATE
+    )
+
+    /** One lowercase UUID per install, rotated only on explicit logout. */
+    @Synchronized
+    fun currentAnonymousId(): String {
+        val storedAnonymousId: String? = preferences.getString(anonymousIdKey, null)
+        if (!storedAnonymousId.isNullOrBlank()) {
+            return storedAnonymousId
+        }
+
+        val createdAnonymousId: String = newAnalyticsUuid()
+        preferences.edit(commit = true) {
+            putString(anonymousIdKey, createdAnonymousId)
+        }
+        return createdAnonymousId
+    }
+
+    /**
+     * A UUID that rotates after 30 minutes with no emitted analytics event, foreground or
+     * background alike. Inactivity rather than backgrounding is deliberate and identical on the
+     * web and iOS clients; rotating on backgrounding here would make session counts incomparable
+     * while looking like the same constant.
+     *
+     * The expiry test is **signed**, never an absolute difference, and there is deliberately no
+     * `nowMillis < lastEventAtMillis` branch. A session is a statement about user activity, not
+     * about the device clock, so neither of the two ways `nowMillis` can land below the stored
+     * timestamp may mint a new one:
+     *
+     *  - a clock correction backwards, after which an absolute test would rotate on *every* event
+     *    until wall time catches up, producing one session per event for the size of the jump;
+     *  - an event that reaches this method after a later one, which needs no clock movement at all.
+     *    [AnalyticsClient.track] stamps `occurredAtMillis` on the caller's thread and hands the
+     *    event off through a channel whose ordering only holds per sender thread, and events are
+     *    tracked from the main thread and from a WorkManager thread alike; the flush-time
+     *    `analytics_events_dropped` rows are stamped later still.
+     *
+     * For the same reason the stored timestamp is clamped forward: a reordered arrival must not
+     * rewind `last_event_at` for everything that follows it.
+     */
+    @Synchronized
+    fun sessionIdForEvent(nowMillis: Long): String {
+        val storedSessionId: String? = preferences.getString(sessionIdKey, null)
+        val lastEventAtMillis: Long = preferences.getLong(lastEventAtMillisKey, 0L)
+        val isExpired: Boolean = storedSessionId.isNullOrBlank() ||
+            lastEventAtMillis <= 0L ||
+            nowMillis - lastEventAtMillis >= analyticsSessionTimeoutMillis
+
+        val sessionId: String = if (isExpired) newAnalyticsUuid() else storedSessionId.orEmpty()
+        // Asynchronous on purpose: this runs once per emitted event, and the only cost of losing
+        // the last write to a crash is one extra session rotation.
+        preferences.edit(commit = false) {
+            putString(sessionIdKey, sessionId)
+            putLong(lastEventAtMillisKey, maxOf(lastEventAtMillis, nowMillis))
+        }
+        return sessionId
+    }
+
+    /** Explicit logout: a new person on this install must not inherit the previous identity. */
+    @Synchronized
+    fun rotateForLogout() {
+        preferences.edit(commit = true) {
+            putString(anonymousIdKey, newAnalyticsUuid())
+            remove(sessionIdKey)
+            remove(lastEventAtMillisKey)
+        }
+    }
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsNetworkMonitor.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsNetworkMonitor.kt
@@ -1,0 +1,173 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * How stale a cached reading may get while the callback is unavailable. Only the fallback path uses
+ * it; a registered callback keeps the cache current for free.
+ */
+private const val analyticsNetworkStateRefreshIntervalMillis: Long = 30_000L
+
+/**
+ * Reads the network state when an event is created, and reports connectivity coming back so the
+ * queue can drain.
+ *
+ * The reading has to happen at creation time: an offline-first client can only ever flush while
+ * online, so a flush-time reading could never record `offline`, which is the one value the column
+ * exists for.
+ */
+class AnalyticsNetworkMonitor(
+    context: Context,
+    private val scope: CoroutineScope
+) : AnalyticsNetworkStateProvider {
+    private val connectivityManager: ConnectivityManager? =
+        context.applicationContext.getSystemService(ConnectivityManager::class.java)
+
+    @Volatile
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    @Volatile
+    private var observedNetworkState: AnalyticsNetworkState = AnalyticsNetworkState.UNKNOWN
+
+    private val isRefreshInFlight = AtomicBoolean(false)
+
+    /**
+     * `null` until a reading has actually been taken. A zero sentinel would collide with the first
+     * [analyticsNetworkStateRefreshIntervalMillis] of uptime, where `elapsedRealtime` is itself
+     * still below the interval, and swallow the only reading an offline launch ever gets.
+     */
+    @Volatile
+    private var lastRefreshAtElapsedMillis: Long? = null
+
+    /**
+     * Answers from the cache and never from the binder. Most call sites are on the main thread, and
+     * `ConnectivityManager.activeNetwork` plus `getNetworkCapabilities` are two binder round trips —
+     * exactly the blocking of a tap this module forbids — so registration failing must not turn
+     * every `track` into them. It refreshes the cache off this thread instead.
+     *
+     * Until a reading has landed the answer is `unknown`, which is legal and honest. `offline` is
+     * never synthesised from a state that was not observed: it is the one value the per-event field
+     * exists to carry, and a false one poisons exactly the analysis it was added for.
+     */
+    override fun currentNetworkState(): AnalyticsNetworkState {
+        if (networkCallback == null) {
+            requestNetworkStateRefresh()
+        }
+        return observedNetworkState
+    }
+
+    /**
+     * Reads the state on the IO dispatcher, at most once per
+     * [analyticsNetworkStateRefreshIntervalMillis] and never twice at a time, so a burst of events
+     * costs the caller one atomic compare and nothing else. `elapsedRealtime` rather than wall time:
+     * a clock correction must not stall the refresh for the size of the jump. The throttle never
+     * suppresses the first read, whenever in the device's uptime it is asked for.
+     */
+    private fun requestNetworkStateRefresh() {
+        val nowElapsedMillis: Long = SystemClock.elapsedRealtime()
+        val lastRefreshMillis: Long? = lastRefreshAtElapsedMillis
+        if (
+            lastRefreshMillis != null &&
+            nowElapsedMillis - lastRefreshMillis < analyticsNetworkStateRefreshIntervalMillis
+        ) {
+            return
+        }
+        if (isRefreshInFlight.compareAndSet(false, true).not()) {
+            return
+        }
+
+        scope.launch(Dispatchers.IO) {
+            try {
+                observedNetworkState = readNetworkState()
+                lastRefreshAtElapsedMillis = SystemClock.elapsedRealtime()
+            } finally {
+                isRefreshInFlight.set(false)
+            }
+        }
+    }
+
+    private fun readNetworkState(): AnalyticsNetworkState {
+        val manager: ConnectivityManager = connectivityManager ?: return AnalyticsNetworkState.UNKNOWN
+        return try {
+            val activeNetwork: Network = manager.activeNetwork ?: return AnalyticsNetworkState.OFFLINE
+            val capabilities: NetworkCapabilities = manager.getNetworkCapabilities(activeNetwork)
+                ?: return AnalyticsNetworkState.OFFLINE
+            networkStateFor(capabilities = capabilities)
+        } catch (_: SecurityException) {
+            AnalyticsNetworkState.UNKNOWN
+        }
+    }
+
+    fun startObservingConnectivityRestored(onConnectivityRestored: () -> Unit) {
+        val manager: ConnectivityManager = connectivityManager ?: return
+        if (networkCallback != null) {
+            return
+        }
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                observedNetworkState = readNetworkState()
+                onConnectivityRestored()
+            }
+
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities
+            ) {
+                observedNetworkState = networkStateFor(capabilities = networkCapabilities)
+            }
+
+            override fun onLost(network: Network) {
+                observedNetworkState = readNetworkState()
+            }
+
+            override fun onUnavailable() {
+                observedNetworkState = AnalyticsNetworkState.OFFLINE
+            }
+        }
+        try {
+            manager.registerDefaultNetworkCallback(callback)
+            networkCallback = callback
+        } catch (_: SecurityException) {
+            // Without the network-state permission the queue still drains on its periodic timer,
+            // and `currentNetworkState` falls back to its own throttled background refresh.
+        } catch (_: IllegalArgumentException) {
+            // Nothing to observe on this device; the periodic timer remains the flush trigger.
+        }
+
+        // Seeded off this thread — registration happens during graph construction on the main
+        // thread. Registration alone is not enough: it replays the current default network
+        // asynchronously, but replays nothing at all when there is no network, so an app launched
+        // offline would report `unknown` instead of the `offline` it can actually observe.
+        requestNetworkStateRefresh()
+    }
+
+    fun stopObservingConnectivityRestored() {
+        val manager: ConnectivityManager = connectivityManager ?: return
+        val callback: ConnectivityManager.NetworkCallback = networkCallback ?: return
+        networkCallback = null
+        try {
+            manager.unregisterNetworkCallback(callback)
+        } catch (_: IllegalArgumentException) {
+            // Already unregistered.
+        }
+    }
+}
+
+private fun networkStateFor(capabilities: NetworkCapabilities): AnalyticsNetworkState {
+    return when {
+        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET).not() ->
+            AnalyticsNetworkState.OFFLINE
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> AnalyticsNetworkState.WIFI
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> AnalyticsNetworkState.CELLULAR
+        else -> AnalyticsNetworkState.UNKNOWN
+    }
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsQueue.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsQueue.kt
@@ -1,0 +1,116 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import android.content.Context
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+/**
+ * Durable analytics queue on its own Room database.
+ *
+ * It deliberately does not share `:data:local`: analytics writes must never sit behind the same
+ * locks as product sync, because emitting an event may not block, delay or fail a user action.
+ */
+const val analyticsQueueDatabaseName: String = "flashcards-analytics-queue.db"
+
+@Entity(tableName = "analytics_queued_event")
+internal data class AnalyticsQueuedEventEntity(
+    @PrimaryKey val eventId: String,
+    val eventName: String,
+    val eventJson: String,
+    val byteSize: Int,
+    val createdAtMillis: Long,
+    val anonymousId: String,
+    val sessionId: String
+)
+
+@Dao
+internal interface AnalyticsQueueDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(entity: AnalyticsQueuedEventEntity)
+
+    @Query("SELECT COUNT(*) FROM analytics_queued_event")
+    suspend fun countEvents(): Int
+
+    @Query("SELECT COALESCE(SUM(byteSize), 0) FROM analytics_queued_event")
+    suspend fun totalByteSize(): Long
+
+    /**
+     * The oldest row belonging to the current identity. Selection is scoped to `anonymousId` rather
+     * than taking the globally oldest row so that a boundary whose delete failed — or that a process
+     * death interrupted before the worker ran — cannot put a departed person's events on the wire:
+     * the rotation alone is enough to make them unselectable.
+     */
+    @Query(
+        "SELECT * FROM analytics_queued_event WHERE anonymousId = :anonymousId " +
+            "ORDER BY createdAtMillis ASC, eventId ASC LIMIT 1"
+    )
+    suspend fun oldestEventForAnonymousId(anonymousId: String): AnalyticsQueuedEventEntity?
+
+    /**
+     * A batch carries one `anonymousId` and one `sessionId` for every event in it, so a batch may
+     * only ever contain events created under the same pair.
+     */
+    @Query(
+        "SELECT * FROM analytics_queued_event " +
+            "WHERE anonymousId = :anonymousId AND sessionId = :sessionId " +
+            "ORDER BY createdAtMillis ASC, eventId ASC LIMIT :limit"
+    )
+    suspend fun oldestEventsForIdentity(
+        anonymousId: String,
+        sessionId: String,
+        limit: Int
+    ): List<AnalyticsQueuedEventEntity>
+
+    @Query("DELETE FROM analytics_queued_event WHERE eventId IN (:eventIds)")
+    suspend fun deleteByIds(eventIds: List<String>)
+
+    /**
+     * Enforces the identity boundary. `anonymousId` rotates atomically on logout, so a row that no
+     * longer matches the current one was created by somebody else and can never be delivered: the
+     * server attributes a batch to the credential carrying it, not to the id inside it.
+     */
+    @Query("DELETE FROM analytics_queued_event WHERE anonymousId <> :anonymousId")
+    suspend fun deleteForOtherAnonymousIds(anonymousId: String): Int
+
+    @Query("DELETE FROM analytics_queued_event WHERE createdAtMillis < :cutoffMillis")
+    suspend fun deleteExpired(cutoffMillis: Long): Int
+
+    @Query(
+        "DELETE FROM analytics_queued_event WHERE eventId IN (" +
+            "SELECT eventId FROM analytics_queued_event ORDER BY createdAtMillis ASC, eventId ASC LIMIT :limit" +
+            ")"
+    )
+    suspend fun deleteOldest(limit: Int): Int
+
+    /** Returns how many rows were removed, so a discard at an identity boundary can be reported. */
+    @Query("DELETE FROM analytics_queued_event")
+    suspend fun deleteAll(): Int
+}
+
+@Database(
+    entities = [AnalyticsQueuedEventEntity::class],
+    version = 1,
+    exportSchema = false
+)
+internal abstract class AnalyticsDatabase : RoomDatabase() {
+    abstract fun analyticsQueueDao(): AnalyticsQueueDao
+}
+
+internal fun buildAnalyticsDatabase(context: Context): AnalyticsDatabase {
+    return Room.databaseBuilder(
+        context = context.applicationContext,
+        klass = AnalyticsDatabase::class.java,
+        name = analyticsQueueDatabaseName
+    )
+        // Analytics is disposable telemetry, never product data: an unreadable or outdated store
+        // is recreated instead of blocking the app or failing a write.
+        .fallbackToDestructiveMigration(dropAllTables = true)
+        .build()
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsTransport.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsTransport.kt
@@ -1,0 +1,100 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+private val analyticsJsonMediaType = "application/json".toMediaType()
+
+private val analyticsClientVersionPattern = Regex("""^\d{1,4}(?:\.\d{1,4}){0,2}""")
+
+internal interface AnalyticsTransport {
+    suspend fun sendBatch(
+        credential: AnalyticsCredential,
+        clientVersion: String?,
+        body: String
+    ): AnalyticsBatchOutcome
+}
+
+/**
+ * `platform` and `app_version` are populated only from `X-Client-Platform` and `X-Client-Version`,
+ * never from the body, and `product_events` is append-only, so a batch shipped without them is
+ * unattributable forever. This client sets these headers nowhere else, so they are set here
+ * deliberately rather than inherited from a shared request helper.
+ */
+internal class OkHttpAnalyticsTransport(
+    okHttpClient: OkHttpClient
+) : AnalyticsTransport {
+    private val httpClient: OkHttpClient = okHttpClient.newBuilder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    override suspend fun sendBatch(
+        credential: AnalyticsCredential,
+        clientVersion: String?,
+        body: String
+    ): AnalyticsBatchOutcome {
+        val requestBuilder = Request.Builder()
+            .url(analyticsEndpointUrl(apiBaseUrl = credential.apiBaseUrl))
+            .post(body.toRequestBody(analyticsJsonMediaType))
+            .header("Content-Type", "application/json")
+            .header("Authorization", credential.authorizationHeader)
+            .header("X-Client-Platform", analyticsPlatformHeaderValue)
+
+        val normalizedClientVersion: String? = normalizeAnalyticsClientVersion(value = clientVersion)
+        if (normalizedClientVersion != null) {
+            requestBuilder.header("X-Client-Version", normalizedClientVersion)
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                    readAnalyticsOutcome(response = response)
+                }
+            } catch (_: IOException) {
+                // Offline and other transport failures stay silent on purpose; the batch is kept.
+                AnalyticsBatchOutcome.TransportFailure
+            }
+        }
+    }
+}
+
+private fun readAnalyticsOutcome(response: Response): AnalyticsBatchOutcome {
+    val statusCode: Int = response.code
+    return when {
+        statusCode == 200 -> parseAnalyticsSuccessBody(responseBody = response.body.string())
+        statusCode == 400 || statusCode == 413 -> AnalyticsBatchOutcome.WholeBatchRefused(statusCode = statusCode)
+        statusCode == 401 || statusCode == 403 || statusCode == 410 ->
+            AnalyticsBatchOutcome.CredentialRefused(statusCode = statusCode)
+        else -> AnalyticsBatchOutcome.RetryLater(
+            statusCode = statusCode,
+            retryAfterMillis = parseAnalyticsRetryAfterMillis(headerValue = response.header("Retry-After"))
+        )
+    }
+}
+
+/**
+ * `POST /v1/analytics/events/` answers `404` on purpose and also misses the endpoint's own
+ * throttle and alarms, so a base-URL join that normalises to a trailing slash would lose every
+ * event silently. The path constant carries no trailing slash and the base URL is trimmed.
+ */
+internal fun analyticsEndpointUrl(apiBaseUrl: String): String {
+    return apiBaseUrl.trim().trimEnd('/') + analyticsEventsPath
+}
+
+/** `MAJOR[.MINOR[.PATCH]]`, each part 1-4 digits. Anything else is stored as NULL forever. */
+internal fun normalizeAnalyticsClientVersion(value: String?): String? {
+    val trimmedValue: String = value?.trim().orEmpty()
+    if (trimmedValue.isEmpty()) {
+        return null
+    }
+    return analyticsClientVersionPattern.find(trimmedValue)?.value
+}

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsWire.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsWire.kt
@@ -1,0 +1,235 @@
+package com.flashcardsopensourceapp.core.observability.analytics
+
+import org.json.JSONException
+import org.json.JSONObject
+import java.security.SecureRandom
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+/**
+ * Wire format for `POST /v1/analytics/events`.
+ *
+ * The shared behavioural constants below are identical on the web and iOS clients by contract; the
+ * three clients only stay comparable in the data while they hold the same values.
+ */
+
+/** Appended to the configured API base URL. No trailing slash: the server 404s the slashed form. */
+internal const val analyticsEventsPath: String = "/analytics/events"
+
+internal const val analyticsPlatformHeaderValue: String = "android"
+
+/** Server limits. */
+internal const val analyticsMaxEventsPerBatch: Int = 50
+internal const val analyticsMaxEventBytes: Int = 4096
+internal const val analyticsMaxRequestBodyBytes: Int = 262_144
+internal const val analyticsMaxContextFieldLength: Int = 200
+
+/** Shared behavioural constants. */
+internal const val analyticsFlushBatchThreshold: Int = 20
+internal const val analyticsMaxQueuedEvents: Int = 5_000
+internal const val analyticsMaxQueuedBytes: Long = 5L * 1024L * 1024L
+internal const val analyticsQueueTtlMillis: Long = 14L * 24L * 60L * 60L * 1000L
+internal const val analyticsSessionTimeoutMillis: Long = 30L * 60L * 1000L
+internal const val analyticsInitialRetryDelayMillis: Long = 30L * 1000L
+internal const val analyticsMaxRetryDelayMillis: Long = 60L * 60L * 1000L
+internal const val analyticsPeriodicFlushIntervalMillis: Long = 5L * 60L * 1000L
+internal const val analyticsSustainedServerErrorReportAfterMillis: Long = 60L * 60L * 1000L
+
+/**
+ * UTC with a literal `Z`. `OffsetDateTime` readily renders `+02:00` instead, which the server
+ * rejects outright: a bad `clientSentAt` 400s the whole batch and a bad `clientOccurredAt` costs
+ * that event. The formatter is pinned to [ZoneOffset.UTC] with a quoted `Z` so no device time zone
+ * can leak an offset into the payload.
+ */
+private val analyticsTimestampFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+
+internal fun formatAnalyticsTimestamp(epochMillis: Long): String {
+    return analyticsTimestampFormatter.format(Instant.ofEpochMilli(epochMillis))
+}
+
+private val analyticsRandom: SecureRandom = SecureRandom()
+
+/**
+ * UUID **version 7**. `UUID.randomUUID()` produces version 4, which the endpoint refuses because
+ * `event_id` is the primary key of an append-only table that depends on time-ordered inserts. The
+ * refusal arrives as the generic `invalid_event`, so getting this wrong is silent on the client.
+ *
+ * Layout: 48-bit big-endian millisecond timestamp, 4-bit version `7`, 12 random bits, 2-bit
+ * variant `0b10`, 62 random bits.
+ */
+internal fun newAnalyticsEventId(epochMillis: Long): String {
+    val timestamp: Long = epochMillis.coerceAtLeast(0L) and 0x0000_FFFF_FFFF_FFFFL
+    val randomA: Long = analyticsRandom.nextInt(0x1000).toLong()
+    val mostSignificantBits: Long = (timestamp shl 16) or (0x7L shl 12) or randomA
+    val leastSignificantBits: Long = (analyticsRandom.nextLong() and 0x3FFF_FFFF_FFFF_FFFFL) or Long.MIN_VALUE
+    return UUID(mostSignificantBits, leastSignificantBits).toString()
+}
+
+/** A lowercase UUID with no version requirement, used for `anonymousId` and `sessionId`. */
+internal fun newAnalyticsUuid(): String {
+    return UUID.randomUUID().toString()
+}
+
+/** Describes the device at flush time and is sent once per batch. */
+data class AnalyticsDeviceContext(
+    val osVersion: String?,
+    val deviceModel: String?,
+    val deviceLocale: String?,
+    val timezone: String?
+)
+
+internal data class AnalyticsSerializedEvent(
+    val eventId: String,
+    val eventName: String,
+    val json: String,
+    val byteSize: Int
+)
+
+/**
+ * Renders one event object. Every optional key is written explicitly, with a real JSON null where
+ * there is no value, so all three clients produce identical wire output.
+ */
+internal fun serializeAnalyticsEvent(
+    event: AnalyticsEvent,
+    eventId: String,
+    occurredAtMillis: Long,
+    networkState: AnalyticsNetworkState?
+): AnalyticsSerializedEvent {
+    val properties = JSONObject()
+    event.properties.forEach { (propertyName, propertyValue) ->
+        when (propertyValue) {
+            is AnalyticsPropertyValue.Text -> properties.put(propertyName, propertyValue.value)
+            is AnalyticsPropertyValue.Count -> properties.put(propertyName, propertyValue.value)
+        }
+    }
+
+    val eventJson = JSONObject()
+        .put("eventId", eventId)
+        .put("eventName", event.eventName)
+        .put("clientOccurredAt", formatAnalyticsTimestamp(epochMillis = occurredAtMillis))
+        .put("networkState", networkState?.wireValue ?: JSONObject.NULL)
+        .put("screen", event.screen?.wireValue ?: JSONObject.NULL)
+        // An event with no declared properties still sends an object: a strict object with no
+        // members accepts `{}` unambiguously.
+        .put("properties", properties)
+        // The product has no experiment system yet; the field is always an explicit null.
+        .put("experimentAssignments", JSONObject.NULL)
+        .toString()
+
+    return AnalyticsSerializedEvent(
+        eventId = eventId,
+        eventName = event.eventName,
+        json = eventJson,
+        byteSize = eventJson.toByteArray(Charsets.UTF_8).size
+    )
+}
+
+/**
+ * Builds the batch envelope. `clientSentAt` is stamped at request time, never at event creation
+ * time: the server derives `occurred_at` from the interval between the two, so a stale
+ * `clientSentAt` silently corrupts every timestamp in the batch.
+ */
+internal fun renderAnalyticsBatchBody(
+    clientSentAtMillis: Long,
+    anonymousId: String?,
+    sessionId: String?,
+    deviceContext: AnalyticsDeviceContext?,
+    eventJsonPayloads: List<String>
+): String {
+    val body = StringBuilder()
+    body.append("{\"clientSentAt\":")
+    body.append(JSONObject.quote(formatAnalyticsTimestamp(epochMillis = clientSentAtMillis)))
+    body.append(",\"anonymousId\":")
+    body.append(anonymousId?.let { value -> JSONObject.quote(value) } ?: "null")
+    body.append(",\"sessionId\":")
+    body.append(sessionId?.let { value -> JSONObject.quote(value) } ?: "null")
+    body.append(",\"context\":")
+    body.append(renderAnalyticsContextJson(deviceContext = deviceContext))
+    body.append(",\"events\":[")
+    eventJsonPayloads.forEachIndexed { index, eventJson ->
+        if (index > 0) {
+            body.append(',')
+        }
+        body.append(eventJson)
+    }
+    body.append("]}")
+    return body.toString()
+}
+
+private fun renderAnalyticsContextJson(deviceContext: AnalyticsDeviceContext?): String {
+    if (deviceContext == null) {
+        return "null"
+    }
+
+    return JSONObject()
+        .put("osVersion", clampAnalyticsContextField(value = deviceContext.osVersion))
+        .put("deviceModel", clampAnalyticsContextField(value = deviceContext.deviceModel))
+        .put("deviceLocale", clampAnalyticsContextField(value = deviceContext.deviceLocale))
+        .put("timezone", clampAnalyticsContextField(value = deviceContext.timezone))
+        .toString()
+}
+
+private fun clampAnalyticsContextField(value: String?): Any {
+    val trimmedValue: String = value?.trim().orEmpty()
+    if (trimmedValue.isEmpty()) {
+        return JSONObject.NULL
+    }
+    return trimmedValue.take(analyticsMaxContextFieldLength)
+}
+
+/** What the client must do with the answer, per the response rules of the wire contract. */
+internal sealed interface AnalyticsBatchOutcome {
+    /** `200`. The batch is finished: every event sent is purged, rejected or not. */
+    data class Finished(val acceptedCount: Int, val rejectedCount: Int) : AnalyticsBatchOutcome
+
+    /** `400` / `413`. Whole-batch refusal with no per-event report; the same bytes never succeed. */
+    data class WholeBatchRefused(val statusCode: Int) : AnalyticsBatchOutcome
+
+    /** `429` / `5xx`. Keep everything and retry later. */
+    data class RetryLater(val statusCode: Int, val retryAfterMillis: Long?) : AnalyticsBatchOutcome
+
+    /** `401` / `403` / `410`. Keep the events queued against a future valid credential. */
+    data class CredentialRefused(val statusCode: Int) : AnalyticsBatchOutcome
+
+    /** Offline or another transport failure. Deliberately silent; keep everything. */
+    data object TransportFailure : AnalyticsBatchOutcome
+}
+
+internal fun parseAnalyticsSuccessBody(responseBody: String?): AnalyticsBatchOutcome.Finished {
+    if (responseBody.isNullOrBlank()) {
+        return AnalyticsBatchOutcome.Finished(acceptedCount = 0, rejectedCount = 0)
+    }
+
+    return try {
+        val json = JSONObject(responseBody)
+        AnalyticsBatchOutcome.Finished(
+            acceptedCount = json.optInt("accepted", 0),
+            rejectedCount = json.optJSONArray("rejected")?.length() ?: 0
+        )
+    } catch (_: JSONException) {
+        // A 200 finishes the batch even when the body cannot be read; the events are still purged.
+        AnalyticsBatchOutcome.Finished(acceptedCount = 0, rejectedCount = 0)
+    }
+}
+
+/**
+ * `Retry-After` is an optimisation, never a precondition: only the analytics writer's own
+ * saturation refusal sets it, while a gateway throttle refusal never does. When it is absent the
+ * caller falls back to local exponential backoff with full jitter.
+ */
+internal fun parseAnalyticsRetryAfterMillis(headerValue: String?): Long? {
+    val trimmedValue: String = headerValue?.trim().orEmpty()
+    if (trimmedValue.isEmpty()) {
+        return null
+    }
+
+    val seconds: Long? = trimmedValue.toLongOrNull()
+    if (seconds != null) {
+        return (seconds * 1000L).coerceIn(0L, analyticsMaxRetryDelayMillis)
+    }
+
+    return null
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/CloudIdentityResetCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/CloudIdentityResetCoordinator.kt
@@ -101,26 +101,63 @@ class CloudIdentityResetCoordinator(
      * the installation identity. Use this for recoverable reconciliation
      * failures where we want an explicit disconnected state instead of a full
      * local reset.
+     *
+     * This is deliberately **not** an identity boundary and does not run
+     * [onCloudIdentityReset]: in every caller the same person stays on this
+     * install. Either they are recovering from a locally inconsistent state and
+     * signing back into the same account, or their guest session was invalidated
+     * server-side (`GUEST_AUTH_INVALID`, from
+     * `CloudGuestSessionCoordinator.clearStoredGuestCloudSessionLocalState`) —
+     * losing a session, not handing the device to somebody else. When the remote
+     * account itself is gone, use
+     * [disconnectDeletedCloudIdentityPreservingLocalState] instead.
      */
     suspend fun disconnectCloudIdentityPreservingLocalState() {
         withContext(Dispatchers.IO) {
             resetMutex.withLock {
-                cloudPreferencesStore.clearCredentials()
-                cloudPreferencesStore.clearAccountPreferences()
-                database.syncStateDao().clearBlockedSyncState()
-                val activeWorkspaceId = ensureLocalWorkspaceShell(
-                    database = database,
-                    currentTimeMillis = System.currentTimeMillis()
-                ).workspaceId
-                cloudPreferencesStore.updateCloudSettings(
-                    cloudState = CloudAccountState.DISCONNECTED,
-                    linkedUserId = null,
-                    linkedWorkspaceId = null,
-                    linkedEmail = null,
-                    activeWorkspaceId = activeWorkspaceId
-                )
-                cloudPreferencesStore.clearAccountDeletionState()
+                disconnectCloudIdentityPreservingLocalStateLocked()
             }
         }
+    }
+
+    /**
+     * The same local disconnect, for the one case where the server account is
+     * gone rather than the local state being inconsistent: a `410
+     * ACCOUNT_DELETED` answer, produced when the account is deleted from
+     * another device or the web while this install syncs.
+     *
+     * Local data is still preserved, but the person who owned the cleared
+     * credential is not coming back, so this **is** an identity boundary and
+     * has to run [onCloudIdentityReset] like every other one. Without it,
+     * anything an account-scoped listener still holds — queued analytics events
+     * above all — would survive into the next credential this install obtains,
+     * and the server derives identity from the credential that carries a
+     * request, not from what the payload claims.
+     */
+    suspend fun disconnectDeletedCloudIdentityPreservingLocalState() {
+        withContext(Dispatchers.IO) {
+            resetMutex.withLock {
+                disconnectCloudIdentityPreservingLocalStateLocked()
+                onCloudIdentityReset()
+            }
+        }
+    }
+
+    private suspend fun disconnectCloudIdentityPreservingLocalStateLocked() {
+        cloudPreferencesStore.clearCredentials()
+        cloudPreferencesStore.clearAccountPreferences()
+        database.syncStateDao().clearBlockedSyncState()
+        val activeWorkspaceId = ensureLocalWorkspaceShell(
+            database = database,
+            currentTimeMillis = System.currentTimeMillis()
+        ).workspaceId
+        cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.DISCONNECTED,
+            linkedUserId = null,
+            linkedWorkspaceId = null,
+            linkedEmail = null,
+            activeWorkspaceId = activeWorkspaceId
+        )
+        cloudPreferencesStore.clearAccountDeletionState()
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepository.kt
@@ -207,7 +207,10 @@ class LocalSyncRepository(
                 throw error
             } catch (error: Exception) {
                 if (isRemoteAccountDeletedError(error = error)) {
-                    resetCoordinator.disconnectCloudIdentityPreservingLocalState()
+                    // The server account is gone, so this is an identity boundary and not a local
+                    // inconsistency: local data is still preserved, but every account-scoped
+                    // listener has to see the boundary before the next credential is obtained.
+                    resetCoordinator.disconnectDeletedCloudIdentityPreservingLocalState()
                     syncStatusState.value = SyncStatusSnapshot(
                         status = SyncStatus.Idle,
                         lastSuccessfulSyncAtMillis = syncStatusState.value.lastSuccessfulSyncAtMillis,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -11,6 +11,14 @@ import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreenRepository
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
+import com.flashcardsopensourceapp.core.observability.analytics.Analytics
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsDeckScope
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsEvent
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsForegroundListener
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsForegroundTransitions
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsReviewAnswerFailureReason
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsReviewEndReason
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
@@ -29,6 +37,7 @@ import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncOutcome
 import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncRequest
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
 import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
+import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,11 +45,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
+import java.net.SocketTimeoutException
+
+private const val maxAnalyticsReviewFailureCauseDepth: Int = 8
 
 private fun hasEnoughReviewHistoryForNotificationPrompt(reviewCount: Int): Boolean {
     return reviewCount >= reviewNotificationPermissionPromptThreshold
@@ -61,6 +75,8 @@ class ReviewViewModel(
     private val onAutomaticFeedbackPromptCandidate: () -> Unit,
     private val onNotificationPermissionGranted: () -> Unit,
     private val reviewPreferencesStore: ReviewPreferencesStore,
+    private val analytics: Analytics,
+    private val analyticsForegroundTransitions: AnalyticsForegroundTransitions,
     visibleAppScreenRepository: VisibleAppScreenRepository,
     workspaceRepository: WorkspaceRepository,
     private val textProvider: ReviewTextProvider
@@ -164,11 +180,60 @@ class ReviewViewModel(
         initialValue = initialReviewUiState(textProvider = textProvider)
     )
 
+    private var analyticsReviewSessionDeckScope: AnalyticsDeckScope? = null
+    private var analyticsReviewSessionStartedAtMillis: Long = 0L
+    private var analyticsReviewSessionAnsweredCount: Int = 0
+
+    /**
+     * Set when the process left the foreground with a session open, so returning to a still-visible
+     * review screen reopens one instead of leaving the rest of the sitting unmeasured.
+     */
+    private var wasAnalyticsReviewSessionInterruptedByBackground: Boolean = false
+
+    /**
+     * Closes the session when the process actually leaves the foreground — a call, a notification, a
+     * screen lock, a swipe to another app — because none of those clear a `ViewModelStore` or change
+     * the nav route, and `duration_ms` is wall-clock from start to end. Delivered synchronously and
+     * ahead of the background flush, so the session-end event goes out with it.
+     */
+    private val analyticsForegroundListener = object : AnalyticsForegroundListener {
+        override fun onAnalyticsForegroundLeft() {
+            if (analyticsReviewSessionDeckScope == null) {
+                return
+            }
+            endAnalyticsReviewSession(endReason = AnalyticsReviewEndReason.INTERRUPTED)
+            wasAnalyticsReviewSessionInterruptedByBackground = true
+        }
+
+        override fun onAnalyticsForegroundEntered() {
+            if (wasAnalyticsReviewSessionInterruptedByBackground.not()) {
+                return
+            }
+            wasAnalyticsReviewSessionInterruptedByBackground = false
+            if (visibleAppScreenState.value != VisibleAppScreen.REVIEW) {
+                return
+            }
+            startAnalyticsReviewSession(startedAtMillis = System.currentTimeMillis())
+        }
+    }
+
     init {
         observeWorkspaceChanges()
         observeResolvedFilterChanges()
         observePresentedCardChanges()
         observeAutoSyncDrivenReviewChanges()
+        observeAnalyticsReviewSessionEnd()
+        analyticsForegroundTransitions.addListener(listener = analyticsForegroundListener)
+    }
+
+    override fun onCleared() {
+        analyticsForegroundTransitions.removeListener(listener = analyticsForegroundListener)
+        // Covers only what this callback actually covers: the review graph leaving the back stack
+        // and the view-model store being cleared. It does **not** fire on backgrounding, on a tab
+        // switch (the top-level destinations save and restore their state) or on a process kill —
+        // leaving the foreground is handled by [analyticsForegroundListener] instead.
+        endAnalyticsReviewSession(endReason = AnalyticsReviewEndReason.INTERRUPTED)
+        super.onCleared()
     }
 
     fun selectFilter(reviewFilter: ReviewFilter) {
@@ -181,6 +246,7 @@ class ReviewViewModel(
             return
         }
 
+        endAnalyticsReviewSession(endReason = AnalyticsReviewEndReason.ABANDONED)
         reviewFilterGeneration = nextReviewFilterGeneration
         lastObservedReviewSessionSignature = null
         ownedReviewSubmissions = emptyMap()
@@ -388,6 +454,8 @@ class ReviewViewModel(
             )
         }
 
+        startAnalyticsReviewSessionIfNeeded(reviewedAtMillis = reviewedAtMillis)
+
         viewModelScope.launch {
             try {
                 reviewRepository.recordReview(
@@ -395,6 +463,12 @@ class ReviewViewModel(
                     rating = rating,
                     reviewedAtMillis = reviewedAtMillis
                 )
+                // Counted after the local write is confirmed, on purpose. An answer still in flight
+                // when the session closes — the process leaves the foreground mid-write — belongs to
+                // no session and is not counted into `answered_count`. Counting it optimistically
+                // before the write would overcount answers that then failed and rolled back, and the
+                // web client independently settled on the same rule, so the two stay comparable.
+                analyticsReviewSessionAnsweredCount += 1
                 if (operationWorkspaceGeneration != workspaceGeneration) {
                     return@launch
                 }
@@ -460,6 +534,11 @@ class ReviewViewModel(
                         errorMessage = textProvider.reviewCouldNotBeSaved
                     )
                 }
+                analytics.track(
+                    event = AnalyticsEvent.ReviewAnswerFailed(
+                        reason = analyticsReviewAnswerFailureReason(error = error)
+                    )
+                )
                 technicalErrorController.showTechnicalError(
                     error = makeAppTechnicalError(
                         title = textProvider.technicalErrorTitle,
@@ -641,6 +720,7 @@ class ReviewViewModel(
                     return@collect
                 }
 
+                endAnalyticsReviewSession(endReason = AnalyticsReviewEndReason.ABANDONED)
                 activeWorkspaceId = workspaceId
                 workspaceGeneration += 1L
                 reviewFilterGeneration += 1L
@@ -837,6 +917,120 @@ class ReviewViewModel(
         lastVisibleAutoSyncChangeSignature = nextVisibleChangeSignature
         messageController.showMessage(message = textProvider.reviewUpdatedOnAnotherDeviceMessage)
     }
+
+    /**
+     * A review session opens on the first answered card of the current scope, which keeps
+     * `answered_count` and `duration_ms` meaningful and avoids emitting a session every time the
+     * Review tab is merely glanced at.
+     */
+    private fun startAnalyticsReviewSessionIfNeeded(reviewedAtMillis: Long) {
+        if (analyticsReviewSessionDeckScope != null) {
+            return
+        }
+        startAnalyticsReviewSession(startedAtMillis = reviewedAtMillis)
+    }
+
+    private fun startAnalyticsReviewSession(startedAtMillis: Long) {
+        val deckScope: AnalyticsDeckScope = analyticsDeckScope(
+            reviewFilter = draftState.value.requestedFilter
+        )
+        analyticsReviewSessionDeckScope = deckScope
+        analyticsReviewSessionStartedAtMillis = startedAtMillis
+        analyticsReviewSessionAnsweredCount = 0
+        analytics.track(event = AnalyticsEvent.ReviewSessionStarted(deckScope = deckScope))
+    }
+
+    private fun endAnalyticsReviewSession(endReason: AnalyticsReviewEndReason) {
+        if (analyticsReviewSessionDeckScope == null) {
+            return
+        }
+
+        val answeredCount: Int = analyticsReviewSessionAnsweredCount
+        // Wall clock on both ends, because the session start is the answer's own `reviewedAtMillis`.
+        // A correction backwards mid-session would otherwise make this negative, and the catalog
+        // declares `duration_ms` as an integer >= 0: the server would refuse the whole event rather
+        // than record a short session.
+        val durationMs: Long = (System.currentTimeMillis() - analyticsReviewSessionStartedAtMillis)
+            .coerceAtLeast(0L)
+        // Any other reason for ending — the deck scope changed, the queue emptied, the person left
+        // the review screen — retires the pending reopen along with the session.
+        wasAnalyticsReviewSessionInterruptedByBackground = false
+        analyticsReviewSessionDeckScope = null
+        analyticsReviewSessionStartedAtMillis = 0L
+        analyticsReviewSessionAnsweredCount = 0
+        analytics.track(
+            event = AnalyticsEvent.ReviewSessionEnded(
+                endReason = endReason,
+                answeredCount = answeredCount,
+                durationMs = durationMs
+            )
+        )
+    }
+
+    private fun observeAnalyticsReviewSessionEnd() {
+        viewModelScope.launch {
+            reviewSessionState
+                .map { observedState ->
+                    observedState.sessionSnapshot.isLoading.not() &&
+                        observedState.sessionSnapshot.remainingCount == 0
+                }
+                .distinctUntilChanged()
+                .collect { isQueueExhausted ->
+                    if (isQueueExhausted) {
+                        endAnalyticsReviewSession(endReason = AnalyticsReviewEndReason.COMPLETED)
+                    }
+                }
+        }
+        viewModelScope.launch {
+            visibleAppScreenState
+                .map { visibleScreen -> visibleScreen == VisibleAppScreen.REVIEW }
+                .distinctUntilChanged()
+                .collect { isReviewVisible ->
+                    if (isReviewVisible.not()) {
+                        endAnalyticsReviewSession(endReason = AnalyticsReviewEndReason.ABANDONED)
+                    }
+                }
+        }
+    }
+}
+
+private fun analyticsDeckScope(reviewFilter: ReviewFilter): AnalyticsDeckScope {
+    return when (reviewFilter) {
+        is ReviewFilter.AllCards -> AnalyticsDeckScope.ALL
+        is ReviewFilter.Deck -> AnalyticsDeckScope.DECK
+        is ReviewFilter.Tags -> AnalyticsDeckScope.FILTER
+    }
+}
+
+/** Maps a failed review submission onto the closed reason set the server catalog declares. */
+private fun analyticsReviewAnswerFailureReason(error: Throwable): AnalyticsReviewAnswerFailureReason {
+    var currentError: Throwable? = error
+    var depth = 0
+    while (currentError != null && depth < maxAnalyticsReviewFailureCauseDepth) {
+        val inspectedError: Throwable = currentError
+        when (inspectedError) {
+            is SyncBlockedException -> return AnalyticsReviewAnswerFailureReason.SYNC_CONFLICT
+            is SocketTimeoutException -> return AnalyticsReviewAnswerFailureReason.TIMEOUT
+            is IOException -> return AnalyticsReviewAnswerFailureReason.OFFLINE
+            is CloudRemoteException -> {
+                if (
+                    inspectedError.syncConflict != null ||
+                    inspectedError.errorCode?.trim()?.uppercase() == "SYNC_WORKSPACE_FORK_REQUIRED"
+                ) {
+                    return AnalyticsReviewAnswerFailureReason.SYNC_CONFLICT
+                }
+                return when (inspectedError.statusCode) {
+                    408, 504 -> AnalyticsReviewAnswerFailureReason.TIMEOUT
+                    409 -> AnalyticsReviewAnswerFailureReason.SYNC_CONFLICT
+                    else -> AnalyticsReviewAnswerFailureReason.SERVER_ERROR
+                }
+            }
+            else -> Unit
+        }
+        currentError = inspectedError.cause
+        depth += 1
+    }
+    return AnalyticsReviewAnswerFailureReason.SERVER_ERROR
 }
 
 fun createReviewViewModelFactory(
@@ -853,6 +1047,8 @@ fun createReviewViewModelFactory(
     onAutomaticFeedbackPromptCandidate: () -> Unit,
     onNotificationPermissionGranted: () -> Unit,
     reviewPreferencesStore: ReviewPreferencesStore,
+    analytics: Analytics,
+    analyticsForegroundTransitions: AnalyticsForegroundTransitions,
     visibleAppScreenRepository: VisibleAppScreenRepository,
     workspaceRepository: WorkspaceRepository
 ): ViewModelProvider.Factory {
@@ -873,6 +1069,8 @@ fun createReviewViewModelFactory(
                 onAutomaticFeedbackPromptCandidate = onAutomaticFeedbackPromptCandidate,
                 onNotificationPermissionGranted = onNotificationPermissionGranted,
                 reviewPreferencesStore = reviewPreferencesStore,
+                analytics = analytics,
+                analyticsForegroundTransitions = analyticsForegroundTransitions,
                 visibleAppScreenRepository = visibleAppScreenRepository,
                 workspaceRepository = workspaceRepository,
                 textProvider = reviewTextProvider(context = application)

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusViewModel.kt
@@ -9,6 +9,10 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSyncFailureReason
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSyncFailureReporter
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
@@ -32,6 +36,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import java.io.IOException
+import java.net.SocketTimeoutException
 
 private data class AccountStatusDraftState(
     val errorMessage: String,
@@ -44,6 +50,7 @@ class AccountStatusViewModel(
     private val syncRepository: SyncRepository,
     private val messageController: TransientMessageController,
     private val technicalErrorController: AppTechnicalErrorController,
+    private val syncFailureReporter: AnalyticsSyncFailureReporter,
     workspaceRepository: WorkspaceRepository,
     private val strings: SettingsStringResolver
 ) : ViewModel() {
@@ -155,10 +162,12 @@ class AccountStatusViewModel(
 
         try {
             syncRepository.syncNow()
+            syncFailureReporter.reportSuccess()
             draftState.update { state -> state.copy(isSubmitting = false, errorMessage = "") }
         } catch (error: CancellationException) {
             throw error
         } catch (error: SyncBlockedException) {
+            trackSyncFailed(error = error)
             draftState.update { state ->
                 state.copy(
                     isSubmitting = false,
@@ -166,6 +175,7 @@ class AccountStatusViewModel(
                 )
             }
         } catch (error: Exception) {
+            trackSyncFailed(error = error)
             val syncBlockedMessage = uiState.value.syncBlockedMessage
             if (syncBlockedMessage.isNullOrBlank().not()) {
                 draftState.update { state ->
@@ -204,6 +214,10 @@ class AccountStatusViewModel(
             )
         }
         try {
+            // No analytics call belongs here. There is deliberately no flush-before-logout trigger:
+            // an asynchronous flush started from this path is ordered after the credential is
+            // cleared and achieves nothing. The identity boundary is handled where logout actually
+            // clears the account, in `AppGraph`'s `onCloudIdentityReset` hook.
             cloudAccountRepository.logout()
             draftState.update { state -> state.copy(isSubmitting = false, errorMessage = "") }
             messageController.showMessage(
@@ -230,6 +244,47 @@ class AccountStatusViewModel(
             )
         }
     }
+
+    private fun trackSyncFailed(error: Throwable) {
+        syncFailureReporter.reportFailure(
+            reason = analyticsSettingsSyncFailureReason(error = error),
+            screen = AnalyticsSurface.SETTINGS
+        )
+    }
+}
+
+private const val maxAnalyticsSyncFailureCauseDepth: Int = 8
+
+/** Maps a manual sync failure onto the closed reason set the server catalog declares. */
+private fun analyticsSettingsSyncFailureReason(error: Throwable): AnalyticsSyncFailureReason {
+    var currentError: Throwable? = error
+    var depth = 0
+    while (currentError != null && depth < maxAnalyticsSyncFailureCauseDepth) {
+        val inspectedError: Throwable = currentError
+        when (inspectedError) {
+            is SyncBlockedException -> return AnalyticsSyncFailureReason.CONFLICT
+            is SocketTimeoutException -> return AnalyticsSyncFailureReason.TIMEOUT
+            is IOException -> return AnalyticsSyncFailureReason.OFFLINE
+            is CloudRemoteException -> {
+                if (
+                    inspectedError.syncConflict != null ||
+                    inspectedError.errorCode?.trim()?.uppercase() == "SYNC_WORKSPACE_FORK_REQUIRED"
+                ) {
+                    return AnalyticsSyncFailureReason.CONFLICT
+                }
+                return when (inspectedError.statusCode) {
+                    401, 403 -> AnalyticsSyncFailureReason.UNAUTHORIZED
+                    408, 504 -> AnalyticsSyncFailureReason.TIMEOUT
+                    409 -> AnalyticsSyncFailureReason.CONFLICT
+                    else -> AnalyticsSyncFailureReason.SERVER_ERROR
+                }
+            }
+            else -> Unit
+        }
+        currentError = inspectedError.cause
+        depth += 1
+    }
+    return AnalyticsSyncFailureReason.SERVER_ERROR
 }
 
 private fun accountStatusPrimaryActionAttentionCount(
@@ -249,6 +304,7 @@ fun createAccountStatusViewModelFactory(
     syncRepository: SyncRepository,
     messageController: TransientMessageController,
     technicalErrorController: AppTechnicalErrorController,
+    syncFailureReporter: AnalyticsSyncFailureReporter,
     applicationContext: Context
 ): ViewModelProvider.Factory {
     return viewModelFactory {
@@ -258,6 +314,7 @@ fun createAccountStatusViewModelFactory(
                 syncRepository = syncRepository,
                 messageController = messageController,
                 technicalErrorController = technicalErrorController,
+                syncFailureReporter = syncFailureReporter,
                 workspaceRepository = workspaceRepository,
                 strings = createSettingsStringResolver(context = applicationContext)
             )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.ViewModelProvider
+import com.flashcardsopensourceapp.core.observability.analytics.Analytics
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
@@ -187,12 +188,14 @@ fun createCloudSignInViewModelFactory(
     cloudAccountRepository: CloudAccountRepository,
     syncRepository: SyncRepository,
     messageController: TransientMessageController,
+    analytics: Analytics,
     applicationContext: Context
 ): ViewModelProvider.Factory {
     return com.flashcardsopensourceapp.feature.settings.cloud.signIn.createCloudSignInViewModelFactory(
         cloudAccountRepository = cloudAccountRepository,
         syncRepository = syncRepository,
         messageController = messageController,
+        analytics = analytics,
         applicationContext = applicationContext
     )
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -42,6 +42,11 @@ import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.prepareCloudP
 import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.requiresCloudGuestUpgrade
 import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.resolveCloudPostAuthFailureAction
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
+import com.flashcardsopensourceapp.core.observability.analytics.Analytics
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsEvent
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSignInFailureReason
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
+import java.net.SocketTimeoutException
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -71,6 +76,7 @@ class CloudSignInViewModel(
     private val cloudAccountRepository: CloudAccountRepository,
     private val syncRepository: SyncRepository,
     private val messageController: TransientMessageController,
+    private val analytics: Analytics,
     private val strings: SettingsStringResolver
 ) : ViewModel() {
     private val draftState = MutableStateFlow(
@@ -293,6 +299,7 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return CloudSendCodeNavigationOutcome.NoNavigation
             }
+            trackSignInFailed(reason = analyticsSignInFailureReason(error = error))
             val errorPresentation = createSendCodeErrorPresentation(
                 error = error,
                 strings = strings
@@ -348,6 +355,7 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return false
             }
+            trackSignInFailed(reason = analyticsSignInFailureReason(error = error))
             val errorPresentation = createVerifyCodeErrorPresentation(
                 error = error,
                 strings = strings
@@ -461,6 +469,9 @@ class CloudSignInViewModel(
             }
 
             CloudPostAuthFailureAction.LOGOUT -> {
+                // No analytics call belongs here. There is deliberately no flush-before-logout
+                // trigger, and the identity boundary is handled where logout actually clears the
+                // account, in `AppGraph`'s `onCloudIdentityReset` hook.
                 cloudAccountRepository.logout()
                 clearPostAuthState()
                 messageController.showMessage(
@@ -470,8 +481,35 @@ class CloudSignInViewModel(
         }
     }
 
+    /**
+     * The person deliberately backed out of a sign-in they had started. This is the only path that
+     * records `signin_failed(cancelled)`, so `cancelled` keeps meaning an abandonment.
+     */
     fun cancelSignIn() {
+        trackSignInFailed(reason = AnalyticsSignInFailureReason.CANCELLED)
         clearPostAuthState()
+    }
+
+    /**
+     * Clears the sign-in draft without recording an abandonment.
+     *
+     * Entering a surface that hosts sign-in, starting the flow and finishing a local erase all need
+     * a clean draft, and none of them is a person giving up: a composition entered on every
+     * configuration change and every process start, a tap on *Sign in*, and a completed erase would
+     * otherwise fill the `cancelled` bucket on an append-only table with rows that mean the
+     * opposite of what they say.
+     */
+    fun resetSignInState() {
+        clearPostAuthState()
+    }
+
+    private fun trackSignInFailed(reason: AnalyticsSignInFailureReason) {
+        analytics.track(
+            event = AnalyticsEvent.SignInFailed(
+                reason = reason,
+                screen = AnalyticsSurface.SETTINGS
+            )
+        )
     }
 
     fun acknowledgePostAuthCompletion() {
@@ -892,6 +930,7 @@ fun createCloudSignInViewModelFactory(
     cloudAccountRepository: CloudAccountRepository,
     syncRepository: SyncRepository,
     messageController: TransientMessageController,
+    analytics: Analytics,
     applicationContext: Context
 ): ViewModelProvider.Factory {
     return viewModelFactory {
@@ -900,9 +939,43 @@ fun createCloudSignInViewModelFactory(
                 cloudAccountRepository = cloudAccountRepository,
                 syncRepository = syncRepository,
                 messageController = messageController,
+                analytics = analytics,
                 strings = createSettingsStringResolver(context = applicationContext)
             )
         }
+    }
+}
+
+private const val maxAnalyticsSignInFailureCauseDepth: Int = 8
+
+/** Maps a sign-in failure onto the closed reason set the server catalog declares. */
+private fun analyticsSignInFailureReason(error: Throwable): AnalyticsSignInFailureReason {
+    var currentError: Throwable? = error
+    var depth = 0
+    while (currentError != null && depth < maxAnalyticsSignInFailureCauseDepth) {
+        val inspectedError: Throwable = currentError
+        when (inspectedError) {
+            is SocketTimeoutException -> return AnalyticsSignInFailureReason.OFFLINE
+            is IOException -> return AnalyticsSignInFailureReason.OFFLINE
+            is CloudRemoteException -> return analyticsCloudSignInFailureReason(error = inspectedError)
+            else -> Unit
+        }
+        currentError = inspectedError.cause
+        depth += 1
+    }
+    return AnalyticsSignInFailureReason.SERVER_ERROR
+}
+
+private fun analyticsCloudSignInFailureReason(error: CloudRemoteException): AnalyticsSignInFailureReason {
+    if (error.statusCode == 429) {
+        return AnalyticsSignInFailureReason.RATE_LIMITED
+    }
+
+    return when (error.errorCode?.trim()?.uppercase()) {
+        "OTP_CODE_INVALID", "OTP_VERIFY_FAILED", "INVALID_EMAIL" -> AnalyticsSignInFailureReason.INVALID_CODE
+        "OTP_SESSION_EXPIRED", "OTP_CHALLENGE_CONSUMED" -> AnalyticsSignInFailureReason.EXPIRED_CODE
+        "OTP_TOO_MANY_ATTEMPTS", "RATE_LIMITED" -> AnalyticsSignInFailureReason.RATE_LIMITED
+        else -> AnalyticsSignInFailureReason.SERVER_ERROR
     }
 }
 

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.settings
 
+import com.flashcardsopensourceapp.core.observability.analytics.NoOpAnalytics
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
@@ -48,6 +49,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -114,6 +116,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -157,6 +160,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = syncRepository,
             messageController = TransientMessageController { message -> messages += message },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -238,6 +242,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = syncRepository,
             messageController = TransientMessageController { message -> messages += message },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -303,6 +308,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -350,6 +356,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { message -> messages.add(message) },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -399,6 +406,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = syncRepository,
             messageController = TransientMessageController { message -> messages += message },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -447,6 +455,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -497,6 +506,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -547,6 +557,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = syncRepository,
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -594,6 +605,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -646,6 +658,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = syncRepository,
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -698,6 +711,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -738,6 +752,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -771,6 +786,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -813,6 +829,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -849,6 +866,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -887,6 +905,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -940,6 +959,7 @@ class CloudSignInViewModelTest {
             cloudAccountRepository = repository,
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
+            analytics = NoOpAnalytics,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ sentryAndroidGradlePlugin = "6.19.0"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
The third of three clients. The module lives in `:core:observability` with its own Room database, so a flush never contends with the product database, and `track()` never suspends, never throws, and drops rather than waits when its hand-off buffer is full.

Events are a `sealed interface` mirroring the backend's frozen catalog — a typo or an undeclared property does not compile, and `ScreenViewed` overrides `screen` as non-null so the one event that requires it cannot omit it. Nine of the eleven client events have call sites; the app has no onboarding flow and no catalog feature, so `onboarding_step_completed` and `catalog_deck_install_started` have nothing to fire from. Both omissions were verified against the code, not assumed.

## Queued events never cross an identity boundary

A row is deliverable only while its stored `anonymous_id` equals the current one. `reset()` rotates the id **synchronously on the calling thread**, batch selection filters on the stored value, and rows belonging to other identities are purged before every selection — so a failed delete, a killed worker or a process death cannot let one person's events ship under the next person's credential. The server derives `user_id` from whichever credential carried the batch, `product_events` is append-only, and `analytics.identity_links` resolves first-link-wins with no repair path, so that failure is unrepairable rather than merely wrong.

`reset()` now reaches every path that ends an identity. The `410 ACCOUNT_DELETED` sync response — reached when the account is deleted from another device while this install syncs — previously cleared credentials without crossing the boundary. The guest→account upgrade deliberately does *not* rotate, because the `anonymous_id` has to carry through for `identity_links` to join the guest to the account.

## Timestamps are treated as untrustworthy

The session clock compares signed and its marker only moves forward, so neither a backwards correction nor an event arriving out of order can mint a session. `duration_ms` is clamped non-negative: the catalog declares it as an integer, so a backwards jump mid-session would otherwise make the server refuse the whole event rather than record a short one. And a delivery deadline further out than the maximum retry delay is treated as a clock artifact — every backoff this client schedules is capped, so such a deadline is provably impossible to have scheduled legitimately, and leaving it would park the TTL purge behind it while the caps kept evicting real events.

## Verification

Five review rounds, each by a reviewer that had not written or fixed the patch; the fifth returned no findings at any severity and independently re-derived the happens-before argument for the identity check. No unit tests, per this repository's testing philosophy. The `CloudSignInViewModelTest` change only adds the new constructor argument to existing call sites.

An emulator run confirmed the wire format directly out of the app's own queue database — every `eventId` with `7` at string index 14, every timestamp ending in `Z`, `screen` top-level and `null` where absent, `properties` `{}` for a no-property event. Probing the deployed endpoint with the app's own serialised batch returned `401` for `/v1/analytics/events` (the route resolves; only auth was missing) and `404 ANALYTICS_ROUTE_NOT_FOUND` for the trailing-slash variant.

**Not verified, and worth two minutes before release:** a `200` with an **empty** `rejected` array end to end. Reaching it needs a credential, which means accepting the AI consent dialog or creating an account — not something to do on your behalf. To finish it: install the debug build, open the AI tab and accept the consent dialog to mint a guest session, send a short message, then press Home to trigger a flush. Confirm in `analytics.product_events` that rows arrived with `platform = 'android'`. A drained local queue is not sufficient proof, because a fully rejected batch also answers `200`.

While you are there, answer the last due card in a review and read the emitted `review_session_ended`: `answered_count` should include that last answer. Static reading says it does, but the ordering against the optimistic queue update could not be proven from the code.

## Accepted residuals

- A 50-event batch refused at the envelope level binary-splits into up to ~99 requests inside one drain step. Convergent and lossless — a gateway `429` returns early with the undelivered chunks still in the database — but the per-flush cap counts batches rather than requests, where the web client counts requests.
- A future navigation destination under an unmapped route prefix will silently stop producing `screen_viewed` until the surface mapper is extended. Every currently registered destination maps.
- An install that never signs in and never opens AI chat has no credential at all, so its events age out at the 14-day TTL. The client is behaving correctly — it must not send unauthenticated — but Android has no equivalent of the web guest session, and whether to mint one is a product decision.
- `signin_failed(cancelled)` fires only from the credential-recovery escape hatch; the ordinary Settings sign-in flow has no cancel hook. Left deliberately: no client currently produces that reason, and wiring only Android would make it the only one with data there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)