### PR TITLE
Send product analytics from the iOS app

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsClient.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsClient.swift
@@ -1,0 +1,1109 @@
+import Foundation
+
+/// Everything the module needs to post a batch, read without touching the network.
+struct AnalyticsCredentials: Sendable, Equatable {
+    let apiBaseUrl: String
+    let authorizationHeaderValue: String
+}
+
+/// Resolved on the main actor because the cloud session lives there. It must never refresh a token or
+/// create a session: analytics is off the interaction path and must not drive cloud work of its own.
+typealias AnalyticsCredentialsProvider = @MainActor @Sendable () -> AnalyticsCredentials?
+
+/**
+ * The product analytics client.
+ *
+ * A user action must never be blocked, delayed or failed by anything in here. `track` is synchronous,
+ * returns `Void`, is not `async` and never throws: it stamps the event and hands it to a background
+ * actor, and every network path runs off the interaction path.
+ */
+enum Analytics {
+    static let enabledState: AnalyticsEnabledState = AnalyticsEnabledState(isEnabled: true)
+    static let foregroundState: AnalyticsForegroundState = AnalyticsForegroundState()
+    static let networkMonitor: AnalyticsNetworkMonitor = AnalyticsNetworkMonitor()
+    /// Shared with the runtime rather than owned by it, because the identity boundary has to be marked
+    /// synchronously on the caller's thread while the queue work it guards runs on the actor.
+    static let identity: AnalyticsIdentity = AnalyticsIdentity(userDefaults: .standard)
+    static let runtime: AnalyticsRuntime = AnalyticsRuntime(
+        queue: AnalyticsQueue(),
+        identity: Analytics.identity
+    )
+    static let surfaceTracker: AnalyticsSurfaceTracker = AnalyticsSurfaceTracker()
+    static let reviewSessionTracker: AnalyticsReviewSessionTracker = AnalyticsReviewSessionTracker()
+    /// One reporter for the whole process, so a failure episode costs one event per reason no matter
+    /// which sync surface noticed it.
+    static let syncFailureReporter: AnalyticsSyncFailureReporter = AnalyticsSyncFailureReporter()
+
+    /// Wires in credential resolution and starts the connectivity-restored flush trigger. Safe to call
+    /// once at app start; it opens no store and performs no I/O of its own.
+    static func configure(credentialsProvider: @escaping AnalyticsCredentialsProvider) {
+        self.networkMonitor.start {
+            Analytics.flush()
+        }
+        Task.detached(priority: .utility) {
+            await self.runtime.setCredentialsProvider(credentialsProvider)
+            await self.runtime.flush()
+        }
+        Task.detached(priority: .utility) {
+            // Periodic flush trigger. The other three — queue threshold, app backgrounded and
+            // connectivity restored — are event driven; this one is what drains a queue that is below
+            // the batch threshold and stays there.
+            while Task.isCancelled == false {
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(analyticsPeriodicFlushIntervalSeconds * 1_000_000_000))
+                } catch {
+                    return
+                }
+                await self.runtime.flush()
+            }
+        }
+    }
+
+    /**
+     * Records one event. `screen` is the surface the user was on; it is a top-level wire field and is
+     * ignored for `screen_viewed`, which carries its own.
+     */
+    static func track(_ event: AnalyticsEvent, screen: AnalyticsSurface? = nil) {
+        guard let pendingEvent = self.makePendingEvent(event: event, screen: screen) else {
+            return
+        }
+
+        Task.detached(priority: .utility) {
+            await self.runtime.enqueue(pendingEvent)
+        }
+    }
+
+    /// The process has been in the background. Recorded rather than acted on, because it is the
+    /// precondition for the next foreground transition being a genuine return.
+    static func recordAppBackgrounded() {
+        self.foregroundState.recordBackgrounded()
+    }
+
+    /**
+     * The warm `app_opened`, emitted on a real background → foreground transition and nothing else.
+     *
+     * `ScenePhase` is not usable as the signal: it drops to `.inactive` for the app switcher, Control
+     * Center, the notification shade and system permission alerts — this app triggers one of those
+     * itself with the notification pre-prompt — and returning from any of them would count as an app
+     * open, permanently inflating an append-only table and making iOS incomparable with the web and
+     * Android clients.
+     *
+     * A foreground transition is only a *return* if the process was in the background first, which is
+     * what the recorded flag establishes. That is also what keeps a launch that begins in the
+     * background — where `FlashcardsApp.init` emits the cold open — from having its first foreground
+     * transition counted a second time. Whether iOS prewarming produces exactly that shape, and
+     * whether it posts a background notification of its own along the way, is not established from
+     * this repository and belongs in a device-level check.
+     */
+    static func trackAppForegrounded() {
+        guard self.foregroundState.consumeBackgroundedReturn() else {
+            return
+        }
+
+        self.track(.appOpened(launchType: .warm))
+    }
+
+    /// Awaitable `track`, for a caller that must know the event reached the queue before it flushes.
+    /// `track` hands the write to an independently scheduled job, which gives no ordering at all
+    /// against a flush started beside it.
+    static func trackAndWait(_ event: AnalyticsEvent, screen: AnalyticsSurface? = nil) async {
+        guard let pendingEvent = self.makePendingEvent(event: event, screen: screen) else {
+            return
+        }
+
+        await self.runtime.enqueue(pendingEvent)
+    }
+
+    /// Everything an event carries is captured here, synchronously, on the caller's thread.
+    private static func makePendingEvent(
+        event: AnalyticsEvent,
+        screen: AnalyticsSurface?
+    ) -> AnalyticsPendingEvent? {
+        guard self.enabledState.isEnabled() else {
+            return nil
+        }
+        // A value the type system cannot pin down and the server would certainly reject. Spending a
+        // queue slot and a batch on it would only turn a caller bug into lost neighbouring events.
+        guard event.satisfiesCatalogValueConstraints else {
+            return nil
+        }
+
+        return AnalyticsPendingEvent(
+            event: event,
+            screen: event.declaredScreen ?? screen,
+            networkState: self.networkMonitor.currentState(),
+            occurredAt: Date(),
+            // Read now rather than at the queue write, so an event created before a logout cannot be
+            // stamped with the next person's identity merely because its write is scheduled after
+            // the reset.
+            anonymousId: self.identity.currentAnonymousId()
+        )
+    }
+
+    static func flush() {
+        guard self.enabledState.isEnabled() else {
+            return
+        }
+
+        Task.detached(priority: .utility) {
+            await self.runtime.flush()
+        }
+    }
+
+    /// Awaitable flush, for the one caller that has to keep the process alive until the batch is
+    /// actually sent: the app going to the background.
+    static func flushAndWait() async {
+        guard self.enabledState.isEnabled() else {
+            return
+        }
+
+        await self.runtime.flush()
+    }
+
+    /**
+     * Explicit logout or account switch.
+     *
+     * Queued events belong to the person who is leaving, so they are discarded here rather than
+     * carried across the boundary: delivered later they would go out under whatever credential
+     * exists then, and the server derives `user_id` from that credential onto an append-only table
+     * with no repair path. There is deliberately no flush-before-logout trigger to rescue them —
+     * an asynchronous flush started from this synchronous path is ordered after the credential is
+     * cleared and delivers nothing. `anonymous_id` rotates here and nowhere else.
+     *
+     * The rotation, not the queue wipe, is what makes the boundary hold. It is persisted in
+     * `UserDefaults` synchronously on the caller's thread before the wipe is even scheduled, and every
+     * queued row carries the id it was written under, so a row from before this line is recognisable
+     * as pre-boundary by comparing two persisted facts. A wipe refused by a full or failing disk, and
+     * a process killed between the rotation and the wipe, both leave rows that the send path deletes
+     * instead of posting.
+     */
+    static func reset() {
+        self.identity.reset()
+        // Suppression state belongs to the person who is leaving as much as the queue does: a reason
+        // reported under the outgoing identity must not silence the first `sync_failed` of the next
+        // one.
+        self.syncFailureReporter.rearm()
+        Task.detached(priority: .utility) {
+            await self.runtime.resetIdentity()
+        }
+    }
+
+    /// Kill switch, honoured immediately: a disabled client records nothing and sends nothing.
+    static func setEnabled(_ enabled: Bool) {
+        self.enabledState.setEnabled(enabled)
+        guard enabled == false else {
+            return
+        }
+
+        Task.detached(priority: .utility) {
+            await self.runtime.discardQueue()
+        }
+    }
+}
+
+/// Read on the interaction path by `track`, so it is a lock rather than actor state.
+final class AnalyticsEnabledState: @unchecked Sendable {
+    private let lock: NSLock
+    private var enabled: Bool
+
+    init(isEnabled: Bool) {
+        self.lock = NSLock()
+        self.enabled = isEnabled
+    }
+
+    func isEnabled() -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.enabled
+    }
+
+    func setEnabled(_ isEnabled: Bool) {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        self.enabled = isEnabled
+    }
+}
+
+/**
+ * Whether the process has been in the background since the last warm open was recorded.
+ *
+ * One instance per process, read and written from the app lifecycle notifications, which is why it is
+ * a lock rather than actor state: the notification arrives synchronously and must not schedule work to
+ * decide whether an event happened. Consuming the flag also makes a repeated foreground notification
+ * idempotent.
+ */
+final class AnalyticsForegroundState: @unchecked Sendable {
+    private let lock: NSLock
+    private var hasEnteredBackground: Bool
+
+    init() {
+        self.lock = NSLock()
+        self.hasEnteredBackground = false
+    }
+
+    func recordBackgrounded() {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        self.hasEnteredBackground = true
+    }
+
+    func consumeBackgroundedReturn() -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        guard self.hasEnteredBackground else {
+            return false
+        }
+
+        self.hasEnteredBackground = false
+        return true
+    }
+}
+
+/**
+ * One event with everything captured at creation time: the surface, the network state a flush-time
+ * reading could never report as `offline`, and the `anonymous_id` that was in effect.
+ *
+ * The id is the identity boundary stamp. It is a persisted value rather than an in-memory counter, so
+ * an event that reaches the queue after a logout — or after a relaunch that followed one — is still
+ * recognisable as belonging to the person who left, and is discarded instead of stamped with the
+ * identity of whoever comes next.
+ */
+struct AnalyticsPendingEvent: Sendable, Equatable {
+    let event: AnalyticsEvent
+    let screen: AnalyticsSurface?
+    let networkState: AnalyticsNetworkState
+    let occurredAt: Date
+    let anonymousId: String
+}
+
+private enum AnalyticsFlushDeferral: Sendable, Equatable {
+    /// 429 and 5xx: keep everything and retry later.
+    case retryAfter(TimeInterval?)
+    /// 401, 403 and 410: keep the events queued against a future valid credential and do not spin.
+    case credentialUnusable
+}
+
+/// The one store-failure stage that is never rate limited: it is the difference between the outgoing
+/// person's queue being discarded and it being posted under the next person's credential.
+private let analyticsIdentityResetFailureStage: String = "identity_reset"
+
+private struct AnalyticsDeliveryResult: Sendable {
+    var settledEventIds: [String] = []
+    var rejectedCount: Int = 0
+    var invalidBatchCount: Int = 0
+    var serverErrorCount: Int = 0
+    var deferral: AnalyticsFlushDeferral?
+}
+
+actor AnalyticsRuntime {
+    private let queue: AnalyticsQueue
+    private let identity: AnalyticsIdentity
+    private let session: URLSession
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private var credentialsProvider: AnalyticsCredentialsProvider?
+    private var flushTask: Task<Void, Never>?
+    private var pendingDropCounts: [AnalyticsDroppedReason: Int]
+    private var consecutiveDeferralCount: Int
+    private var nextAttemptAt: Date?
+    private var consecutiveInvalidBatchCount: Int
+    private var firstServerErrorAt: Date?
+    private var reportedOverflowThisSession: Bool
+    private var reportedExpiryThisSession: Bool
+    private var reportedStoreFailureStages: Set<String>
+    private var reportedInvalidBatchThisSession: Bool
+    private var reportedSustainedServerErrorThisSession: Bool
+    private var identityBoundaryDiscardedCount: Int
+
+    init(queue: AnalyticsQueue, identity: AnalyticsIdentity, session: URLSession? = nil) {
+        self.queue = queue
+        self.identity = identity
+        if let session {
+            self.session = session
+        } else {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.timeoutIntervalForRequest = 20
+            configuration.waitsForConnectivity = false
+            self.session = URLSession(configuration: configuration)
+        }
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+        self.credentialsProvider = nil
+        self.flushTask = nil
+        self.pendingDropCounts = [:]
+        self.consecutiveDeferralCount = 0
+        self.nextAttemptAt = nil
+        self.consecutiveInvalidBatchCount = 0
+        self.firstServerErrorAt = nil
+        self.reportedOverflowThisSession = false
+        self.reportedExpiryThisSession = false
+        self.reportedStoreFailureStages = []
+        self.reportedInvalidBatchThisSession = false
+        self.reportedSustainedServerErrorThisSession = false
+        self.identityBoundaryDiscardedCount = 0
+    }
+
+    func setCredentialsProvider(_ provider: @escaping AnalyticsCredentialsProvider) {
+        self.credentialsProvider = provider
+    }
+
+    func enqueue(_ pendingEvent: AnalyticsPendingEvent) async {
+        let queuedEventCount = self.store(pendingEvent: pendingEvent)
+        guard let queuedEventCount, queuedEventCount >= analyticsFlushBatchThreshold else {
+            return
+        }
+
+        await self.flush()
+    }
+
+    func flush() async {
+        if let flushTask = self.flushTask {
+            await flushTask.value
+            return
+        }
+
+        let flushTask: Task<Void, Never> = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            await self.runFlush()
+            // Cleared from inside the task, so the handle is already gone once its value becomes
+            // available. Clearing it in the first waiter instead leaves a window in which a second
+            // caller awaits an already finished task and returns having flushed nothing — which the
+            // backgrounded app's `flushAndWait` would silently spend its background window on.
+            await self.clearFlushTask()
+        }
+        self.flushTask = flushTask
+        await flushTask.value
+    }
+
+    private func clearFlushTask() {
+        self.flushTask = nil
+    }
+
+    /**
+     * The identity boundary's cleanup. Contract §6: queued events must never be carried across it, and
+     * the discard is reported through the app's own observability rather than as an
+     * `analytics_events_dropped` reason — `rejected` has to keep meaning a real server refusal.
+     *
+     * `Analytics.reset()` has already rotated `anonymous_id`, so this is a best-effort sweep of rows
+     * the new id no longer owns rather than the boundary itself. If it throws, or never runs because
+     * the process died, the same sweep runs again before the next batch is selected and those rows are
+     * deleted there instead of sent.
+     */
+    func resetIdentity() {
+        let anonymousId = self.identity.currentAnonymousId()
+        do {
+            let discardedEventCount = try self.queueRemoveEvents(notOwnedByAnonymousId: anonymousId)
+            self.identityBoundaryDiscardedCount += discardedEventCount
+        } catch {
+            self.reportStoreFailure(error: error, stage: analyticsIdentityResetFailureStage)
+        }
+        // Losses counted for the outgoing identity would otherwise be emitted as the next identity's
+        // `analytics_events_dropped`. Clearing all of them can undercount a drop that happened in the
+        // gap between the rotation and this sweep, which is the direction this system prefers.
+        self.pendingDropCounts = [:]
+        self.reportIdentityBoundaryDiscardIfNeeded()
+    }
+
+    private func reportIdentityBoundaryDiscardIfNeeded() {
+        let discardedCount = self.identityBoundaryDiscardedCount
+        guard discardedCount > 0 else {
+            return
+        }
+
+        self.identityBoundaryDiscardedCount = 0
+        self.reportWarning(action: "analytics_identity_boundary_discarded", count: discardedCount)
+    }
+
+    func discardQueue() {
+        do {
+            try self.queueRemoveAll()
+        } catch {
+            self.reportStoreFailure(error: error, stage: "discard")
+        }
+        self.pendingDropCounts = [:]
+    }
+
+    // MARK: - Queue writes
+
+    @discardableResult
+    private func store(pendingEvent: AnalyticsPendingEvent) -> Int? {
+        let occurredAt = pendingEvent.occurredAt
+        // The identity boundary, checked against the id the event was created under. A mismatch means
+        // the event was created before a logout and is only reaching the queue after it, so it belongs
+        // to the person who left and is discarded with the rest of their queue.
+        guard let identitySnapshot = self.identity.identityForEmittedEvent(
+            now: occurredAt,
+            requiredAnonymousId: pendingEvent.anonymousId
+        ) else {
+            self.identityBoundaryDiscardedCount += 1
+            return nil
+        }
+
+        let payload = AnalyticsEventPayload(
+            eventId: makeAnalyticsEventId(now: occurredAt),
+            eventName: pendingEvent.event.eventName,
+            clientOccurredAt: analyticsTimestampString(date: occurredAt),
+            networkState: pendingEvent.networkState.rawValue,
+            screen: pendingEvent.screen?.rawValue,
+            properties: pendingEvent.event.properties,
+            // The product has no experiment system yet, and the field is a flat string map when it
+            // does. Sending null is the whole contract for it today.
+            experimentAssignments: nil
+        )
+
+        do {
+            let outcome = try self.queueAppend(
+                event: AnalyticsQueuedEvent(
+                    anonymousId: identitySnapshot.anonymousId,
+                    sessionId: identitySnapshot.sessionId,
+                    payload: payload
+                ),
+                now: occurredAt
+            )
+            self.recordDrops(
+                reason: .queueOverflow,
+                count: outcome.overflowDroppedCount,
+                owningAnonymousId: identitySnapshot.anonymousId
+            )
+            self.recordDrops(
+                reason: .ttlExpired,
+                count: outcome.expiredDroppedCount,
+                owningAnonymousId: identitySnapshot.anonymousId
+            )
+            return outcome.queuedEventCount
+        } catch {
+            self.reportStoreFailure(error: error, stage: "append")
+            return nil
+        }
+    }
+
+    private func recordDrops(reason: AnalyticsDroppedReason, count: Int, owningAnonymousId: String) {
+        guard count > 0 else {
+            return
+        }
+        // A loss belongs to the identity that suffered it. `deliver` suspends, so an identity boundary
+        // can land while a batch is in flight; the rejection count that comes back then describes the
+        // previous person's loss, and re-accumulating it here would drain it into an
+        // `analytics_events_dropped` stamped with the next person's identity.
+        guard owningAnonymousId == self.identity.currentAnonymousId() else {
+            return
+        }
+
+        self.pendingDropCounts[reason, default: 0] += count
+        switch reason {
+        case .queueOverflow:
+            guard self.reportedOverflowThisSession == false else {
+                return
+            }
+            self.reportedOverflowThisSession = true
+            self.reportWarning(action: "analytics_queue_overflow", count: count)
+        case .ttlExpired:
+            guard self.reportedExpiryThisSession == false else {
+                return
+            }
+            self.reportedExpiryThisSession = true
+            self.reportWarning(action: "analytics_queue_ttl_expired", count: count)
+        case .rejected:
+            // Per-event rejections are not reported from the client: the server already captures
+            // contract violations with cross-client grouping, and the counted loss travels in the
+            // data itself as analytics_events_dropped.
+            return
+        }
+    }
+
+    /// Turns accumulated losses into real events so the loss is visible in the data rather than only
+    /// in server-side telemetry. `occurred_at_out_of_window` rejections are deliberately excluded from
+    /// server-side Sentry reporting, so this is the only place they are ever counted.
+    private func drainPendingDropEvents(now: Date, anonymousId: String) {
+        let pendingDropCounts = self.pendingDropCounts
+        guard pendingDropCounts.isEmpty == false else {
+            return
+        }
+
+        self.pendingDropCounts = [:]
+        for (reason, count) in pendingDropCounts where count > 0 {
+            self.store(
+                pendingEvent: AnalyticsPendingEvent(
+                    event: .analyticsEventsDropped(reason: reason, count: count),
+                    screen: nil,
+                    networkState: Analytics.networkMonitor.currentState(),
+                    occurredAt: now,
+                    anonymousId: anonymousId
+                )
+            )
+        }
+    }
+
+    // MARK: - Flush
+
+    private func runFlush() async {
+        guard Analytics.enabledState.isEnabled() else {
+            return
+        }
+        if let nextAttemptAt = self.nextAttemptAt, Date() < nextAttemptAt {
+            return
+        }
+        self.nextAttemptAt = nil
+        self.reportIdentityBoundaryDiscardIfNeeded()
+
+        do {
+            // The boundary sweep runs before the TTL sweep so a row that outlived a failed or
+            // never-run identity wipe is counted as a boundary discard rather than as this identity's
+            // TTL loss. The TTL count is kept, not thrown away: this is the sweep a real expiry lands
+            // on, because the launch flush runs before any `track` and would otherwise clear a queue
+            // that aged out during a long offline or unauthenticated stretch in complete silence.
+            let boundaryAnonymousId = self.identity.currentAnonymousId()
+            self.identityBoundaryDiscardedCount += try self.queueRemoveEvents(
+                notOwnedByAnonymousId: boundaryAnonymousId
+            )
+            let expiredEventCount = try self.queueRemoveExpired(now: Date())
+            self.recordDrops(
+                reason: .ttlExpired,
+                count: expiredEventCount,
+                owningAnonymousId: boundaryAnonymousId
+            )
+        } catch {
+            self.reportStoreFailure(error: error, stage: "expire")
+        }
+
+        // The drain is bounded. A batch refused at the envelope level is dropped and reported as
+        // `analytics_events_dropped`, and that report can be refused in turn, so an unbounded loop
+        // is one POST per iteration forever on a single device — enough to consume the endpoint's
+        // whole 20 rps method throttle for every other client. Whatever the cap leaves behind is
+        // picked up by the next trigger.
+        var drainIterationCount = 0
+        while Task.isCancelled == false, drainIterationCount < analyticsMaximumDrainIterationsPerFlush {
+            drainIterationCount += 1
+            let anonymousIdBeforeCredentials = self.identity.currentAnonymousId()
+            self.drainPendingDropEvents(now: Date(), anonymousId: anonymousIdBeforeCredentials)
+
+            guard let credentials = await self.currentCredentials() else {
+                // Never send unauthenticated. The events wait under the queue TTL and the server's
+                // 30-day window, so an ordinary sign-up delay costs nothing.
+                return
+            }
+
+            // The credential read suspends, so an identity boundary can land between it and the batch
+            // load. Only a matched pair may be sent: otherwise the outgoing credential carries the next
+            // person's events, or the next credential carries the outgoing person's. Both halves are
+            // persisted values, so this holds across a relaunch as well as across a suspension.
+            let anonymousId = self.identity.currentAnonymousId()
+            guard anonymousId == anonymousIdBeforeCredentials else {
+                continue
+            }
+
+            let batchLoad: AnalyticsQueueBatchLoad
+            do {
+                // Selecting a batch also deletes every row the current `anonymous_id` does not own, so
+                // a batch can only ever be composed of rows that are still on this side of the
+                // boundary.
+                batchLoad = try self.queueLoadNextBatch(
+                    limit: analyticsMaximumEventsPerBatch,
+                    anonymousId: anonymousId
+                )
+            } catch {
+                self.reportStoreFailure(error: error, stage: "read")
+                return
+            }
+            self.identityBoundaryDiscardedCount += batchLoad.boundaryDiscardedCount
+            guard let batch = batchLoad.batch else {
+                return
+            }
+
+            let result = await self.deliver(
+                anonymousId: batch.anonymousId,
+                sessionId: batch.sessionId,
+                payloads: batch.payloads,
+                credentials: credentials
+            )
+
+            do {
+                // On a 200 every event in the batch is finished, accepted or rejected alike: rejected
+                // events are permanently refused and resending them changes nothing. Purge by what was
+                // sent, because a rejection may carry a null event id.
+                try self.queueDelete(eventIds: result.settledEventIds)
+            } catch {
+                self.reportStoreFailure(error: error, stage: "delete")
+                return
+            }
+
+            self.recordDrops(
+                reason: .rejected,
+                count: result.rejectedCount,
+                owningAnonymousId: batch.anonymousId
+            )
+            self.updateInvalidBatchReporting(invalidBatchCount: result.invalidBatchCount)
+            self.updateServerErrorReporting(serverErrorCount: result.serverErrorCount, now: Date())
+
+            if let deferral = result.deferral {
+                self.applyDeferral(deferral, now: Date())
+                return
+            }
+
+            self.consecutiveDeferralCount = 0
+            guard result.settledEventIds.isEmpty == false else {
+                return
+            }
+        }
+    }
+
+    private func currentCredentials() async -> AnalyticsCredentials? {
+        guard let credentialsProvider = self.credentialsProvider else {
+            return nil
+        }
+
+        return await credentialsProvider()
+    }
+
+    /**
+     * Posts one request and, on a whole-batch refusal, halves and retries. `400` and `413` carry no
+     * per-event report and retrying the same bytes fails identically forever, so the same convergent
+     * rule serves both: split a multi-event batch, drop a single-event batch and count it. That
+     * terminates and cannot wedge the queue behind a poison event.
+     */
+    private func deliver(
+        anonymousId: String,
+        sessionId: String,
+        payloads: [AnalyticsEventPayload],
+        credentials: AnalyticsCredentials
+    ) async -> AnalyticsDeliveryResult {
+        guard payloads.isEmpty == false else {
+            return AnalyticsDeliveryResult()
+        }
+
+        let outcome = await self.send(
+            anonymousId: anonymousId,
+            sessionId: sessionId,
+            payloads: payloads,
+            credentials: credentials
+        )
+
+        // A refused `analytics_events_dropped` must never produce a replacement: the replacement is
+        // refused for the same reason, which counts as another drop, and the net queue change is
+        // zero while the device keeps posting. Capping the reported rejections at the number of
+        // ordinary events in the batch makes every drop event terminal, and can only ever undercount
+        // — the trade this system prefers over misattribution.
+        let reportableRejectionLimit = payloads.filter { payload in
+            payload.eventName != analyticsEventsDroppedEventName
+        }.count
+
+        switch outcome {
+        case .completed(let rejectedCount):
+            var result = AnalyticsDeliveryResult()
+            result.settledEventIds = payloads.map { payload in
+                payload.eventId
+            }
+            result.rejectedCount = min(rejectedCount, reportableRejectionLimit)
+            return result
+        case .wholeBatchRefused:
+            var result = AnalyticsDeliveryResult()
+            result.invalidBatchCount = 1
+            guard payloads.count > 1 else {
+                result.settledEventIds = payloads.map { payload in
+                    payload.eventId
+                }
+                result.rejectedCount = min(1, reportableRejectionLimit)
+                return result
+            }
+
+            let midpoint = payloads.count / 2
+            let firstResult = await self.deliver(
+                anonymousId: anonymousId,
+                sessionId: sessionId,
+                payloads: Array(payloads[0..<midpoint]),
+                credentials: credentials
+            )
+            result = self.combine(result, firstResult)
+            guard result.deferral == nil else {
+                return result
+            }
+
+            let secondResult = await self.deliver(
+                anonymousId: anonymousId,
+                sessionId: sessionId,
+                payloads: Array(payloads[midpoint...]),
+                credentials: credentials
+            )
+            return self.combine(result, secondResult)
+        case .retryLater(let retryAfterSeconds, let isServerError):
+            var result = AnalyticsDeliveryResult()
+            result.deferral = .retryAfter(retryAfterSeconds)
+            result.serverErrorCount = isServerError ? 1 : 0
+            return result
+        case .credentialUnusable:
+            var result = AnalyticsDeliveryResult()
+            result.deferral = .credentialUnusable
+            return result
+        }
+    }
+
+    private func combine(
+        _ lhs: AnalyticsDeliveryResult,
+        _ rhs: AnalyticsDeliveryResult
+    ) -> AnalyticsDeliveryResult {
+        var combined = AnalyticsDeliveryResult()
+        combined.settledEventIds = lhs.settledEventIds + rhs.settledEventIds
+        combined.rejectedCount = lhs.rejectedCount + rhs.rejectedCount
+        combined.invalidBatchCount = lhs.invalidBatchCount + rhs.invalidBatchCount
+        combined.serverErrorCount = lhs.serverErrorCount + rhs.serverErrorCount
+        combined.deferral = lhs.deferral ?? rhs.deferral
+        return combined
+    }
+
+    private func send(
+        anonymousId: String,
+        sessionId: String,
+        payloads: [AnalyticsEventPayload],
+        credentials: AnalyticsCredentials
+    ) async -> AnalyticsSendOutcome {
+        // clientSentAt is stamped here, at the moment of the request, because the server derives
+        // occurred_at from the interval between it and clientOccurredAt.
+        let batch = AnalyticsBatchPayload(
+            clientSentAt: analyticsTimestampString(date: Date()),
+            anonymousId: anonymousId,
+            sessionId: sessionId,
+            context: analyticsClientContextPayload(),
+            events: payloads
+        )
+
+        let request: URLRequest
+        let body: Data
+        do {
+            body = try self.encoder.encode(batch)
+            request = try makeAnalyticsIngestRequest(
+                credentials: credentials,
+                body: body
+            )
+        } catch {
+            self.reportStoreFailure(error: error, stage: "encode")
+            return .retryLater(retryAfterSeconds: nil, isServerError: false)
+        }
+
+        logAnalyticsOutgoingRequestIfEnabled(request: request, body: body)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await self.session.data(for: request)
+        } catch {
+            // Ordinary offline and transient transport failures are deliberately not reported: this
+            // repository already silences them in every background capture path.
+            return .retryLater(retryAfterSeconds: nil, isServerError: false)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return .retryLater(retryAfterSeconds: nil, isServerError: false)
+        }
+
+        let retryAfterSeconds = analyticsRetryAfterSeconds(
+            value: httpResponse.value(forHTTPHeaderField: "Retry-After")
+        )
+        logAnalyticsResponseIfEnabled(httpResponse: httpResponse, data: data)
+
+        switch httpResponse.statusCode {
+        case 200:
+            guard let ingestResponse = try? self.decoder.decode(AnalyticsIngestResponse.self, from: data) else {
+                // The batch was accepted even if the envelope could not be read, and redelivery is
+                // safe but pointless, so the events are still finished.
+                return .completed(rejectedCount: 0)
+            }
+            return .completed(rejectedCount: ingestResponse.rejected.count)
+        case 400, 413:
+            return .wholeBatchRefused
+        case 401, 403, 410:
+            return .credentialUnusable
+        default:
+            return .retryLater(
+                retryAfterSeconds: retryAfterSeconds,
+                isServerError: httpResponse.statusCode >= 500
+            )
+        }
+    }
+
+    // MARK: - Backoff and reporting
+
+    private func applyDeferral(_ deferral: AnalyticsFlushDeferral, now: Date) {
+        let retryAfterSeconds: TimeInterval?
+        switch deferral {
+        case .credentialUnusable:
+            // 401, 403 and 410 are paced like every other refusal, because the contract says do not
+            // spin: unpaced, a queue sitting at the batch threshold issues one refused POST per
+            // tracked event, which is what a deleted account answering 410 does on every single user
+            // interaction, indefinitely. The events stay queued against a future valid credential.
+            retryAfterSeconds = nil
+        case .retryAfter(let seconds):
+            // Retry-After is an optimisation, never a precondition: only the analytics writer's own
+            // saturation refusal carries it, and the API Gateway throttle never does.
+            retryAfterSeconds = seconds
+        }
+
+        self.consecutiveDeferralCount += 1
+        let delaySeconds = retryAfterSeconds ?? analyticsBackoffDelaySeconds(
+            attempt: self.consecutiveDeferralCount
+        )
+        self.nextAttemptAt = now.addingTimeInterval(delaySeconds)
+    }
+
+    private func updateInvalidBatchReporting(invalidBatchCount: Int) {
+        guard invalidBatchCount > 0 else {
+            self.consecutiveInvalidBatchCount = 0
+            return
+        }
+
+        self.consecutiveInvalidBatchCount += invalidBatchCount
+        guard self.consecutiveInvalidBatchCount >= 3, self.reportedInvalidBatchThisSession == false else {
+            return
+        }
+
+        // A repeated whole-batch 400 means this client is off contract in a way that costs every event
+        // it sends, which is worth exactly one report.
+        self.reportedInvalidBatchThisSession = true
+        self.reportWarning(action: "analytics_invalid_batch_repeated", count: self.consecutiveInvalidBatchCount)
+    }
+
+    private func updateServerErrorReporting(serverErrorCount: Int, now: Date) {
+        guard serverErrorCount > 0 else {
+            self.firstServerErrorAt = nil
+            return
+        }
+
+        let firstServerErrorAt = self.firstServerErrorAt ?? now
+        self.firstServerErrorAt = firstServerErrorAt
+        guard now.timeIntervalSince(firstServerErrorAt) > 3_600,
+              self.reportedSustainedServerErrorThisSession == false else {
+            return
+        }
+
+        self.reportedSustainedServerErrorThisSession = true
+        self.reportWarning(action: "analytics_sustained_server_error", count: serverErrorCount)
+    }
+
+    /**
+     * The local store failing to open, write or read is the one failure nothing else can see, so it is
+     * the one this module reports itself.
+     *
+     * Reported once per stage rather than once per session. A single session-wide flag let one earlier
+     * benign append failure swallow the report for a failed identity-boundary sweep, which is the
+     * failure that decides whether the previous person's events can still be posted; the boundary
+     * stage is not rate limited at all, because it can only happen once per logout.
+     */
+    private func reportStoreFailure(error: Error, stage: String) {
+        if stage != analyticsIdentityResetFailureStage {
+            guard self.reportedStoreFailureStages.contains(stage) == false else {
+                return
+            }
+        }
+
+        self.reportedStoreFailureStages.insert(stage)
+        FlashcardsObservability.captureSilentFailure(
+            error: error,
+            scope: analyticsObservationScope(),
+            action: "analytics_queue_store_failed",
+            stage: stage,
+            statusCode: nil,
+            backendCode: nil,
+            requestId: nil
+        )
+    }
+
+    private func reportWarning(action: String, count: Int) {
+        FlashcardsObservability.captureSilentFailure(
+            error: AnalyticsConditionReport(action: action, count: count),
+            scope: analyticsObservationScope(),
+            action: action,
+            stage: String(count),
+            statusCode: nil,
+            backendCode: nil,
+            requestId: nil
+        )
+    }
+
+    // MARK: - Queue bridge
+
+    private func queueAppend(event: AnalyticsQueuedEvent, now: Date) throws -> AnalyticsQueueAppendOutcome {
+        try self.queue.append(event: event, now: now)
+    }
+
+    private func queueRemoveExpired(now: Date) throws -> Int {
+        try self.queue.removeExpired(now: now)
+    }
+
+    private func queueLoadNextBatch(limit: Int, anonymousId: String) throws -> AnalyticsQueueBatchLoad {
+        try self.queue.loadNextBatch(limit: limit, anonymousId: anonymousId)
+    }
+
+    private func queueRemoveEvents(notOwnedByAnonymousId anonymousId: String) throws -> Int {
+        try self.queue.removeEvents(notOwnedByAnonymousId: anonymousId)
+    }
+
+    private func queueDelete(eventIds: [String]) throws {
+        try self.queue.delete(eventIds: eventIds)
+    }
+
+    @discardableResult
+    private func queueRemoveAll() throws -> Int {
+        try self.queue.removeAll()
+    }
+}
+
+/// A condition worth exactly one report through the existing observability layer, carried as an error
+/// because that is the shape `captureSilentFailure` takes.
+struct AnalyticsConditionReport: LocalizedError, Equatable {
+    let action: String
+    let count: Int
+
+    var errorDescription: String? {
+        "\(self.action) count=\(self.count)"
+    }
+}
+
+enum AnalyticsRequestError: LocalizedError, Equatable {
+    case invalidIngestUrl(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidIngestUrl(let apiBaseUrl):
+            return "Analytics ingest URL could not be built from \(apiBaseUrl)"
+        }
+    }
+}
+
+private enum AnalyticsSendOutcome: Sendable {
+    case completed(rejectedCount: Int)
+    case wholeBatchRefused
+    case retryLater(retryAfterSeconds: TimeInterval?, isServerError: Bool)
+    case credentialUnusable
+}
+
+/// Exponential backoff with full jitter, capped at one hour.
+func analyticsBackoffDelaySeconds(attempt: Int) -> TimeInterval {
+    let exponent = min(max(0, attempt - 1), 16)
+    let ceiling = min(
+        analyticsRetryMaximumDelaySeconds,
+        analyticsRetryBaseDelaySeconds * pow(2, Double(exponent))
+    )
+    return Double.random(in: 0...ceiling)
+}
+
+func analyticsRetryAfterSeconds(value: String?) -> TimeInterval? {
+    guard let nanoseconds = cloudRetryAfterDelayNanoseconds(value: value) else {
+        return nil
+    }
+
+    return min(analyticsRetryMaximumDelaySeconds, Double(nanoseconds) / 1_000_000_000)
+}
+
+func analyticsObservationScope() -> IOSObservationScope {
+    IOSObservationScope(
+        feature: .analytics,
+        userId: nil,
+        workspaceId: nil,
+        requestId: nil,
+        clientRequestId: nil,
+        sessionId: nil,
+        runId: nil,
+        cloudState: nil,
+        configurationMode: nil
+    )
+}
+
+/**
+ * Builds the ingest request. The path is asserted rather than joined loosely: `POST
+ * /v1/analytics/events/` answers 404 on purpose and also misses the endpoint's tighter throttle and
+ * all three of its alarms, so a base URL that normalises to a trailing slash would lose every event
+ * silently. `X-Client-Platform` and `X-Client-Version` are set per endpoint in this repository, and
+ * `product_events` is append-only, so a batch shipped without them is unattributable forever.
+ */
+func makeAnalyticsIngestRequest(credentials: AnalyticsCredentials, body: Data) throws -> URLRequest {
+    let trimmedBaseUrl = credentials.apiBaseUrl.hasSuffix("/")
+        ? String(credentials.apiBaseUrl.dropLast())
+        : credentials.apiBaseUrl
+    guard let url = URL(string: "\(trimmedBaseUrl)\(analyticsEventsPath)"),
+          url.path.hasSuffix("/") == false,
+          url.path.hasSuffix(analyticsEventsPath) else {
+        throw AnalyticsRequestError.invalidIngestUrl(credentials.apiBaseUrl)
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+    request.setValue(analyticsClientPlatformHeaderValue, forHTTPHeaderField: "X-Client-Platform")
+    request.setValue(appMarketingVersion(), forHTTPHeaderField: "X-Client-Version")
+    request.httpBody = body
+    return request
+}
+
+/// Device context, describing the device at flush time.
+func analyticsClientContextPayload() -> AnalyticsContextPayload {
+    let operatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    return AnalyticsContextPayload(
+        osVersion: "\(operatingSystemVersion.majorVersion).\(operatingSystemVersion.minorVersion).\(operatingSystemVersion.patchVersion)",
+        deviceModel: analyticsDeviceModelIdentifier(),
+        deviceLocale: Locale.current.identifier(.bcp47),
+        timezone: TimeZone.current.identifier
+    )
+}
+
+func analyticsDeviceModelIdentifier() -> String? {
+    if let simulatorModel = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] {
+        return simulatorModel
+    }
+
+    var systemInfo = utsname()
+    guard uname(&systemInfo) == 0 else {
+        return nil
+    }
+
+    let machine = systemInfo.machine
+    let identifier = withUnsafePointer(to: machine) { pointer in
+        pointer.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: machine)) { characters in
+            String(cString: characters)
+        }
+    }
+    return identifier.isEmpty ? nil : identifier
+}
+
+let analyticsRequestDebugLogEnvironmentKey: String = "FLASHCARDS_ANALYTICS_LOG_REQUEST"
+
+/**
+ * Prints the exact outgoing batch when the launch environment asks for it. This is how the wire format
+ * is checked against a live endpoint — the path, both `X-Client-*` headers, the `Z` timestamps and the
+ * version nibble of every `eventId` — rather than by reading the code that produced them. Off unless
+ * the variable is set, and the catalog admits no free-text property, so the body carries no user data.
+ */
+func logAnalyticsOutgoingRequestIfEnabled(request: URLRequest, body: Data) {
+    guard ProcessInfo.processInfo.environment[analyticsRequestDebugLogEnvironmentKey] != nil else {
+        return
+    }
+
+    let headers = request.allHTTPHeaderFields ?? [:]
+    let redactedHeaders = headers.map { key, value in
+        "\(key)=\(key.lowercased() == "authorization" ? "<redacted>" : value)"
+    }.sorted().joined(separator: " ")
+    fputs("analytics_request url=\(request.url?.absoluteString ?? "-") \(redactedHeaders)\n", stderr)
+    fputs("analytics_request_body \(String(decoding: body, as: UTF8.self))\n", stderr)
+}
+
+func logAnalyticsResponseIfEnabled(httpResponse: HTTPURLResponse, data: Data) {
+    guard ProcessInfo.processInfo.environment[analyticsRequestDebugLogEnvironmentKey] != nil else {
+        return
+    }
+
+    let requestId = httpResponse.value(forHTTPHeaderField: "X-Request-Id") ?? "-"
+    fputs(
+        "analytics_response status=\(httpResponse.statusCode) requestId=\(requestId) body=\(String(decoding: data, as: UTF8.self))\n",
+        stderr
+    )
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,292 @@
+import Foundation
+
+/**
+ * Hand-written mirror of the frozen backend product analytics catalog in
+ * `apps/backend/src/productAnalytics/catalog.ts`. The server rejects anything it does not declare,
+ * so the client API is type-strict per event: every case carries exactly the properties the catalog
+ * declares and there is deliberately no `track(name:properties:)` anywhere. A typo or an undeclared
+ * property does not compile instead of becoming a silent server-side rejection.
+ *
+ * `guest_upgrade_completed` and `catalog_deck_installed` are server-derived and are absent here on
+ * purpose: a client batch that carries one is rejected `server_only_event`.
+ */
+enum AnalyticsEvent: Sendable, Equatable {
+    case appOpened(launchType: AnalyticsLaunchType)
+    case screenViewed(screen: AnalyticsSurface)
+    case onboardingStepCompleted(step: AnalyticsOnboardingStep, outcome: AnalyticsOnboardingOutcome)
+    case signInFailed(reason: AnalyticsSignInFailureReason)
+    case reviewSessionStarted(deckScope: AnalyticsReviewDeckScope)
+    case reviewSessionEnded(
+        endReason: AnalyticsReviewSessionEndReason,
+        answeredCount: Int,
+        durationMilliseconds: Int
+    )
+    case reviewAnswerFailed(reason: AnalyticsReviewAnswerFailureReason)
+    case cardCreateStarted(entryPoint: AnalyticsCardCreateEntryPoint)
+    /// Emit only through `Analytics.reportSyncFailure(reason:)`. Sync is retried on a timer, so a
+    /// direct `track` measures poll cadence instead of failure incidence.
+    case syncFailed(reason: AnalyticsSyncFailureReason)
+    case catalogDeckInstallStarted(packageSlug: String)
+    case analyticsEventsDropped(reason: AnalyticsDroppedReason, count: Int)
+}
+
+/**
+ * Platform-independent surfaces from the backend catalog. Native screens are mapped onto these and a
+ * native screen name is never sent, because cross-client funnel comparison is the only reason the
+ * surface list is shared at all.
+ */
+enum AnalyticsSurface: String, Sendable, Equatable, CaseIterable {
+    case review
+    case catalog
+    case deckDetail = "deck_detail"
+    case onboarding
+    case cardEditor = "card_editor"
+    case cards
+    case progress
+    case settings
+    case ai
+}
+
+/**
+ * Captured when the event is created rather than when the batch flushes. A queued batch can only
+ * ever be sent while online, so a flush-time reading could never record `offline`, which is the one
+ * value the column exists for.
+ */
+enum AnalyticsNetworkState: String, Sendable, Equatable {
+    case wifi
+    case cellular
+    case offline
+    case unknown
+}
+
+enum AnalyticsLaunchType: String, Sendable, Equatable {
+    case cold
+    case warm
+}
+
+enum AnalyticsOnboardingStep: String, Sendable, Equatable {
+    case language
+    case goal
+    case notifications
+    case firstDeck = "first_deck"
+    case firstReview = "first_review"
+    case signin
+}
+
+enum AnalyticsOnboardingOutcome: String, Sendable, Equatable {
+    case completed
+    case skipped
+}
+
+enum AnalyticsSignInFailureReason: String, Sendable, Equatable {
+    case invalidCode = "invalid_code"
+    case expiredCode = "expired_code"
+    case rateLimited = "rate_limited"
+    case offline
+    case serverError = "server_error"
+    case cancelled
+}
+
+enum AnalyticsReviewDeckScope: String, Sendable, Equatable {
+    case all
+    case deck
+    case filter
+}
+
+enum AnalyticsReviewSessionEndReason: String, Sendable, Equatable {
+    case completed
+    case abandoned
+    case interrupted
+}
+
+enum AnalyticsReviewAnswerFailureReason: String, Sendable, Equatable {
+    case offline
+    case timeout
+    case syncConflict = "sync_conflict"
+    case serverError = "server_error"
+}
+
+enum AnalyticsCardCreateEntryPoint: String, Sendable, Equatable {
+    case cards
+    case deckDetail = "deck_detail"
+    case review
+    case ai
+    case quickAction = "quick_action"
+}
+
+enum AnalyticsSyncFailureReason: String, Sendable, Equatable {
+    case offline
+    case timeout
+    case conflict
+    case unauthorized
+    case serverError = "server_error"
+    case storageFull = "storage_full"
+}
+
+/**
+ * The catalog name of the loss-reporting event, needed by the delivery path: a refused
+ * `analytics_events_dropped` must never be counted into a replacement, or the replacement is refused
+ * for the same reason and the client posts forever without the queue ever changing.
+ */
+let analyticsEventsDroppedEventName: String = "analytics_events_dropped"
+
+enum AnalyticsDroppedReason: String, Sendable, Equatable {
+    case queueOverflow = "queue_overflow"
+    case ttlExpired = "ttl_expired"
+    case rejected
+}
+
+/// The only two property value kinds the catalog admits. Nested objects and arrays are rejected.
+enum AnalyticsPropertyValue: Sendable, Equatable, Codable {
+    case string(String)
+    case integer(Int)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let integer = try? container.decode(Int.self) {
+            self = .integer(integer)
+            return
+        }
+
+        self = .string(try container.decode(String.self))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .integer(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+extension AnalyticsEvent {
+    var eventName: String {
+        switch self {
+        case .appOpened:
+            return "app_opened"
+        case .screenViewed:
+            return "screen_viewed"
+        case .onboardingStepCompleted:
+            return "onboarding_step_completed"
+        case .signInFailed:
+            return "signin_failed"
+        case .reviewSessionStarted:
+            return "review_session_started"
+        case .reviewSessionEnded:
+            return "review_session_ended"
+        case .reviewAnswerFailed:
+            return "review_answer_failed"
+        case .cardCreateStarted:
+            return "card_create_started"
+        case .syncFailed:
+            return "sync_failed"
+        case .catalogDeckInstallStarted:
+            return "catalog_deck_install_started"
+        case .analyticsEventsDropped:
+            return analyticsEventsDroppedEventName
+        }
+    }
+
+    /**
+     * `screen` is a top-level event field on the wire, never a property: a surface placed inside
+     * `properties` is rejected `unknown_property`. Only `screen_viewed` carries one of its own; every
+     * other event takes the surface the caller was on, if any.
+     */
+    var declaredScreen: AnalyticsSurface? {
+        switch self {
+        case .screenViewed(let screen):
+            return screen
+        default:
+            return nil
+        }
+    }
+
+    /**
+     * Every declared property is required — the server builds a strict object with no optional
+     * members — so each case fills in all of its own. Counters are clamped at zero because the
+     * catalog admits no negative value and the table they land in is append-only.
+     */
+    var properties: [String: AnalyticsPropertyValue] {
+        switch self {
+        case .appOpened(let launchType):
+            return ["launch_type": .string(launchType.rawValue)]
+        case .screenViewed:
+            return [:]
+        case .onboardingStepCompleted(let step, let outcome):
+            return [
+                "step": .string(step.rawValue),
+                "outcome": .string(outcome.rawValue)
+            ]
+        case .signInFailed(let reason):
+            return ["reason": .string(reason.rawValue)]
+        case .reviewSessionStarted(let deckScope):
+            return ["deck_scope": .string(deckScope.rawValue)]
+        case .reviewSessionEnded(let endReason, let answeredCount, let durationMilliseconds):
+            return [
+                "end_reason": .string(endReason.rawValue),
+                "answered_count": .integer(max(0, answeredCount)),
+                "duration_ms": .integer(max(0, durationMilliseconds))
+            ]
+        case .reviewAnswerFailed(let reason):
+            return ["reason": .string(reason.rawValue)]
+        case .cardCreateStarted(let entryPoint):
+            return ["entry_point": .string(entryPoint.rawValue)]
+        case .syncFailed(let reason):
+            return ["reason": .string(reason.rawValue)]
+        case .catalogDeckInstallStarted(let packageSlug):
+            return ["package_slug": .string(packageSlug)]
+        case .analyticsEventsDropped(let reason, let count):
+            return [
+                "reason": .string(reason.rawValue),
+                "count": .integer(max(0, count))
+            ]
+        }
+    }
+
+    /**
+     * The one property the type system cannot pin down. A catalog package slug arrives from the
+     * backend already in slug shape, so a value that fails the pattern is a caller bug; enqueuing it
+     * would spend a queue slot on an event the server is guaranteed to reject.
+     */
+    var satisfiesCatalogValueConstraints: Bool {
+        switch self {
+        case .catalogDeckInstallStarted(let packageSlug):
+            return isAnalyticsCatalogSlug(value: packageSlug)
+        default:
+            return true
+        }
+    }
+}
+
+/// Mirrors `productAnalyticsSlugPattern`: `^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$`.
+func isAnalyticsCatalogSlug(value: String) -> Bool {
+    let characters = Array(value.utf8)
+    guard characters.count >= 1 && characters.count <= 120 else {
+        return false
+    }
+
+    func isLowercaseAlphanumeric(_ byte: UInt8) -> Bool {
+        (byte >= 97 && byte <= 122) || (byte >= 48 && byte <= 57)
+    }
+
+    guard isLowercaseAlphanumeric(characters[0]) else {
+        return false
+    }
+    guard characters.count > 1 else {
+        return true
+    }
+    guard isLowercaseAlphanumeric(characters[characters.count - 1]) else {
+        return false
+    }
+
+    for byte in characters[1..<(characters.count - 1)] {
+        guard isLowercaseAlphanumeric(byte) || byte == 45 else {
+            return false
+        }
+    }
+
+    return true
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsIdentity.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsIdentity.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+let analyticsAnonymousIdUserDefaultsKey: String = "analytics-anonymous-id"
+let analyticsSessionIdUserDefaultsKey: String = "analytics-session-id"
+let analyticsSessionLastEventAtUserDefaultsKey: String = "analytics-session-last-event-at"
+
+struct AnalyticsIdentitySnapshot: Sendable, Equatable {
+    let anonymousId: String
+    let sessionId: String
+}
+
+/**
+ * `anonymous_id` and `session_id` lifecycle.
+ *
+ * `anonymous_id` lives in `UserDefaults` and deliberately not in the Keychain: the Keychain would
+ * carry it across a reinstall, and identity resolution in `analytics.identity_links` is
+ * first-link-wins with no repair path, so a resurrected id would silently merge two people forever.
+ * For the same reason it is not the sync installation id, which must stay stable across users while
+ * this must reset so a second person on a shared device does not inherit the first person's identity.
+ *
+ * It is also the **durable marker of the identity boundary**. Every queued row is stamped with the id
+ * it was written under, and rotating this value is the first thing `reset()` does, so a row created
+ * before a boundary is recognisable as such by comparing two persisted facts. Nothing in memory has
+ * to survive for that comparison to hold.
+ *
+ * `session_id` is a UUID that rotates after 30 minutes with no emitted analytics event, foreground
+ * and background alike. The rule is stated as inactivity rather than backgrounding on purpose, so
+ * session counts stay comparable with web and Android.
+ *
+ * Read on the interaction path by `track` and again on the analytics actor, so the read-modify-write
+ * pairs are held under a lock rather than left to `UserDefaults` key-at-a-time atomicity.
+ */
+final class AnalyticsIdentity: @unchecked Sendable {
+    private let lock: NSLock
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults) {
+        self.lock = NSLock()
+        self.userDefaults = userDefaults
+    }
+
+    /// The persisted `anonymous_id` on its own, without touching the session. This is the value every
+    /// queued row carries and the value a batch is checked against before it is sent.
+    func currentAnonymousId() -> String {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.loadOrCreateAnonymousIdLocked()
+    }
+
+    /**
+     * Resolves the identity for an event that is being emitted now, rotating the session first when it
+     * has gone stale, and then recording this emission as the session's latest activity.
+     *
+     * `requiredAnonymousId` is the id read when the event was created. Checking it here, under the same
+     * lock that reads the persisted value, is what keeps an event created before an identity boundary
+     * from being stamped with the identity of whoever comes next merely because its queue write was
+     * scheduled after the boundary. A mismatch returns `nil` and the event is discarded.
+     */
+    func identityForEmittedEvent(now: Date, requiredAnonymousId: String) -> AnalyticsIdentitySnapshot? {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        let anonymousId = self.loadOrCreateAnonymousIdLocked()
+        guard anonymousId == requiredAnonymousId else {
+            return nil
+        }
+
+        let lastEventAt = self.userDefaults.object(
+            forKey: analyticsSessionLastEventAtUserDefaultsKey
+        ) as? Double
+        let sessionId = self.loadOrCreateSessionIdLocked(now: now, lastEventAt: lastEventAt)
+        // Clamped forward. `track` hands every event to an independently scheduled job, so two events
+        // created microseconds apart can arrive here in reverse creation order, and letting the earlier
+        // one rewind the marker would shorten the inactivity window for everything after it.
+        self.userDefaults.set(
+            max(now.timeIntervalSince1970, lastEventAt ?? now.timeIntervalSince1970),
+            forKey: analyticsSessionLastEventAtUserDefaultsKey
+        )
+        return AnalyticsIdentitySnapshot(anonymousId: anonymousId, sessionId: sessionId)
+    }
+
+    /**
+     * Explicit logout. The anonymous id rotates here and nowhere else.
+     *
+     * This rotation **is** the identity boundary. It runs synchronously on the caller's thread, before
+     * any queue work is scheduled, and it lands in `UserDefaults` — a different store with a different
+     * failure mode from the queue's SQLite file. Everything downstream compares a row's stored id with
+     * this one, so neither a failed queue wipe nor a process death between the two can leave a
+     * pre-boundary row that looks current. `synchronize()` is called deliberately rather than left to
+     * the periodic flush: the marker has to be on disk before a kill that the rows it guards outlive.
+     */
+    func reset() {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        self.userDefaults.set(makeAnalyticsAnonymousId(), forKey: analyticsAnonymousIdUserDefaultsKey)
+        self.userDefaults.removeObject(forKey: analyticsSessionIdUserDefaultsKey)
+        self.userDefaults.removeObject(forKey: analyticsSessionLastEventAtUserDefaultsKey)
+        _ = self.userDefaults.synchronize()
+    }
+
+    private func loadOrCreateAnonymousIdLocked() -> String {
+        if let storedAnonymousId = self.userDefaults.string(forKey: analyticsAnonymousIdUserDefaultsKey),
+           isAnalyticsUuidString(value: storedAnonymousId) {
+            return storedAnonymousId
+        }
+
+        let anonymousId = makeAnalyticsAnonymousId()
+        self.userDefaults.set(anonymousId, forKey: analyticsAnonymousIdUserDefaultsKey)
+        return anonymousId
+    }
+
+    private func loadOrCreateSessionIdLocked(now: Date, lastEventAt: Double?) -> String {
+        let storedSessionId = self.userDefaults.string(forKey: analyticsSessionIdUserDefaultsKey)
+
+        if let storedSessionId,
+           isAnalyticsUuidString(value: storedSessionId),
+           let lastEventAt,
+           // Signed, not absolute, and the contract settles it this way for all three clients. A
+           // session is a statement about user activity, so only real inactivity — the marker falling
+           // more than the timeout *behind* now — may rotate it. Any `now` at or before the marker
+           // keeps the session, which covers both cases that produce one: `track` gives no ordering
+           // between events, so an event created microseconds earlier can arrive after a later one;
+           // and a backwards clock correction must not mint sessions at all. An `abs()` here would
+           // rotate on every event after a >30-minute backwards jump, because the forward clamp the
+           // caller applies pins the marker to the stale future value until wall time catches up —
+           // one session per event for the size of the jump.
+           now.timeIntervalSince1970 - lastEventAt < analyticsSessionTimeoutSeconds {
+            return storedSessionId
+        }
+
+        let sessionId = makeAnalyticsSessionId()
+        self.userDefaults.set(sessionId, forKey: analyticsSessionIdUserDefaultsKey)
+        return sessionId
+    }
+}
+
+/// `anonymousId` and `sessionId` carry no UUID version requirement; only `eventId` does.
+func makeAnalyticsAnonymousId() -> String {
+    UUID().uuidString.lowercased()
+}
+
+func makeAnalyticsSessionId() -> String {
+    UUID().uuidString.lowercased()
+}
+
+/**
+ * `eventId` must be a UUID **version 7**. `UUID()` produces version 4, and the endpoint reports a
+ * version 4 id as the generic `invalid_event`, indistinguishable from a malformed event, so getting
+ * this wrong is silent on the client. Version 7 is generated explicitly here: a 48-bit big-endian
+ * millisecond timestamp, the version nibble, the RFC 9562 variant bits, and random elsewhere.
+ */
+func makeAnalyticsEventId(now: Date = Date()) -> String {
+    var randomBytes = [UInt8](repeating: 0, count: 10)
+    for index in randomBytes.indices {
+        randomBytes[index] = UInt8.random(in: UInt8.min...UInt8.max)
+    }
+
+    let eventId = makeAnalyticsUuidV7(
+        millisecondsSince1970: epochMillis(date: now),
+        randomBytes: randomBytes
+    )
+    // The rule the server actually applies, checked against the produced string rather than against
+    // the code that produced it. A version 4 id comes back as the generic `invalid_event`, so a
+    // regression here would silently cost every event the client sends; debug builds trap instead,
+    // which includes the simulator smoke run.
+    assert(isAnalyticsUuidV7(value: eventId), "Analytics event ids must be UUID version 7")
+    return eventId
+}
+
+func makeAnalyticsUuidV7(millisecondsSince1970: Int64, randomBytes: [UInt8]) -> String {
+    precondition(randomBytes.count >= 10, "UUIDv7 needs 10 random bytes")
+
+    let timestamp = UInt64(max(0, millisecondsSince1970)) & 0x0000_FFFF_FFFF_FFFF
+    var bytes = [UInt8](repeating: 0, count: 16)
+    bytes[0] = UInt8((timestamp >> 40) & 0xFF)
+    bytes[1] = UInt8((timestamp >> 32) & 0xFF)
+    bytes[2] = UInt8((timestamp >> 24) & 0xFF)
+    bytes[3] = UInt8((timestamp >> 16) & 0xFF)
+    bytes[4] = UInt8((timestamp >> 8) & 0xFF)
+    bytes[5] = UInt8(timestamp & 0xFF)
+    // High nibble of byte 6 is the version, and it is character 14 of the canonical string, which is
+    // exactly what the server checks.
+    bytes[6] = 0x70 | (randomBytes[0] & 0x0F)
+    bytes[7] = randomBytes[1]
+    // Two high bits of byte 8 are the variant.
+    bytes[8] = 0x80 | (randomBytes[2] & 0x3F)
+    for index in 0..<7 {
+        bytes[9 + index] = randomBytes[3 + index]
+    }
+
+    return canonicalAnalyticsUuidString(bytes: bytes)
+}
+
+func isAnalyticsUuidV7(value: String) -> Bool {
+    guard isAnalyticsUuidString(value: value) else {
+        return false
+    }
+
+    return Array(value)[14] == "7"
+}
+
+func isAnalyticsUuidString(value: String) -> Bool {
+    let characters = Array(value.utf8)
+    guard characters.count == 36 else {
+        return false
+    }
+
+    let hyphenIndexes: Set<Int> = [8, 13, 18, 23]
+    for (index, byte) in characters.enumerated() {
+        if hyphenIndexes.contains(index) {
+            guard byte == 45 else {
+                return false
+            }
+            continue
+        }
+
+        let isDigit = byte >= 48 && byte <= 57
+        let isLowercaseHex = byte >= 97 && byte <= 102
+        guard isDigit || isLowercaseHex else {
+            return false
+        }
+    }
+
+    return true
+}
+
+private func canonicalAnalyticsUuidString(bytes: [UInt8]) -> String {
+    let hexDigits = Array("0123456789abcdef")
+    var characters: [Character] = []
+    characters.reserveCapacity(36)
+    for (index, byte) in bytes.enumerated() {
+        if index == 4 || index == 6 || index == 8 || index == 10 {
+            characters.append("-")
+        }
+        characters.append(hexDigits[Int(byte >> 4)])
+        characters.append(hexDigits[Int(byte & 0x0F)])
+    }
+
+    return String(characters)
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsNetworkMonitor.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsNetworkMonitor.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Network
+
+/**
+ * Latest connectivity reading, kept so `track` can stamp `networkState` on the event synchronously at
+ * the moment it happens. The value has to be readable without awaiting anything: it is captured on
+ * the interaction path, and the contract makes it a per-event field precisely so an event created
+ * while offline still says so once the queue drains.
+ *
+ * Path changes also drive the connectivity-restored flush trigger.
+ */
+final class AnalyticsNetworkMonitor: @unchecked Sendable {
+    private let lock: NSLock
+    private let monitor: NWPathMonitor
+    private let monitorQueue: DispatchQueue
+    private var state: AnalyticsNetworkState
+    /// Only the start-once claim. Deliberately not named for the monitor being *running*: it is set
+    /// before `monitor.start` so two concurrent calls cannot both start the monitor, which means it is
+    /// never an observation of connectivity and nothing outside `start` may read it as one.
+    private var hasRequestedStart: Bool
+
+    init() {
+        self.lock = NSLock()
+        self.monitor = NWPathMonitor()
+        self.monitorQueue = DispatchQueue(label: "com.flashcards.analytics.network-monitor")
+        self.state = .unknown
+        self.hasRequestedStart = false
+    }
+
+    func start(onConnectivityRestored: @escaping @Sendable () -> Void) {
+        self.lock.lock()
+        let hadRequestedStart = self.hasRequestedStart
+        self.hasRequestedStart = true
+        self.lock.unlock()
+        guard hadRequestedStart == false else {
+            return
+        }
+
+        self.monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else {
+                return
+            }
+
+            let nextState = analyticsNetworkState(path: path)
+            self.lock.lock()
+            let previousState = self.state
+            self.state = nextState
+            self.lock.unlock()
+
+            if previousState == .offline && nextState != .offline {
+                onConnectivityRestored()
+            }
+        }
+        self.monitor.start(queue: self.monitorQueue)
+    }
+
+    /**
+     * The last state `pathUpdateHandler` actually delivered, and `unknown` until the first one does.
+     *
+     * Nothing is read from the monitor to fill that gap. `Network.framework` publishes no synchronous
+     * path accessor: the first update is delivered asynchronously on `monitorQueue`, and the Swift
+     * overlay's `currentPath` is a cached snapshot holding its pre-update default until then — an
+     * unsatisfied path, which maps to `offline`. The gap is guaranteed rather than theoretical,
+     * because `FlashcardsApp.init` starts this monitor and emits the cold `app_opened` on the next
+     * statement of the same main-thread `init`, ahead of any queue hop. Seeding from `currentPath`
+     * would therefore stamp `offline` on the two highest-volume events of every online device,
+     * permanently, on an append-only table.
+     *
+     * The contract forbids exactly that: never synthesise `offline` from a state that was not
+     * observed. `unknown` is a legal value and an honest gap; `offline` is the one value the field
+     * exists to carry, and a false one poisons the analysis the field was added for.
+     */
+    func currentState() -> AnalyticsNetworkState {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.state
+    }
+}
+
+private func analyticsNetworkState(path: NWPath) -> AnalyticsNetworkState {
+    guard path.status == .satisfied else {
+        return .offline
+    }
+    if path.usesInterfaceType(.wifi) || path.usesInterfaceType(.wiredEthernet) {
+        return .wifi
+    }
+    if path.usesInterfaceType(.cellular) {
+        return .cellular
+    }
+
+    return .unknown
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsQueue.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsQueue.swift
@@ -1,0 +1,469 @@
+import Foundation
+import SQLite3
+
+/// One queued event with the identity it was emitted under. Identity is stored per event rather than
+/// read at flush time so a batch never claims a session or an anonymous id the event did not belong
+/// to — the queue survives relaunches, session rotation and logout.
+///
+/// The stored `anonymousId` is also what makes the identity boundary durable: it is compared with the
+/// persisted current id before anything is sent, so a row written before a logout is recognisable as
+/// such no matter what happened to the process or to the wipe that was supposed to remove it.
+struct AnalyticsQueuedEvent: Sendable, Equatable {
+    let anonymousId: String
+    let sessionId: String
+    let payload: AnalyticsEventPayload
+}
+
+/// A batch is always drawn from a single `(anonymousId, sessionId)` pair, because both are batch-level
+/// fields on the wire.
+struct AnalyticsQueueBatch: Sendable, Equatable {
+    let anonymousId: String
+    let sessionId: String
+    let payloads: [AnalyticsEventPayload]
+
+    var eventIds: [String] {
+        self.payloads.map { payload in
+            payload.eventId
+        }
+    }
+}
+
+struct AnalyticsQueueAppendOutcome: Sendable, Equatable {
+    let queuedEventCount: Int
+    let overflowDroppedCount: Int
+    let expiredDroppedCount: Int
+}
+
+/// A batch and the identity-boundary purge that had to happen before it could be selected. The two are
+/// returned together so a batch can never be produced without the purge having run.
+struct AnalyticsQueueBatchLoad: Sendable, Equatable {
+    let batch: AnalyticsQueueBatch?
+    let boundaryDiscardedCount: Int
+}
+
+enum AnalyticsQueueError: LocalizedError, Equatable {
+    case open(String)
+    case write(String)
+    case read(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .open(let message):
+            return "Analytics queue could not be opened: \(message)"
+        case .write(let message):
+            return "Analytics queue write failed: \(message)"
+        case .read(let message):
+            return "Analytics queue read failed: \(message)"
+        }
+    }
+}
+
+/**
+ * Durable event queue in its own SQLite file, deliberately separate from the product database under
+ * `Database/`. A separate file rather than a separate table: one SQLite file means one write lock, so
+ * analytics writes would contend with product sync writes, which is exactly what the no-blocking rule
+ * forbids. This queue is best effort and has a TTL; the sync outbox is strict and preserves product
+ * data. They must not be mixed.
+ *
+ * The store is opened lazily, so app launch never waits for it.
+ *
+ * `@unchecked Sendable` because `AnalyticsRuntime` owns the only reference and every call already
+ * runs on that actor's executor, which keeps the SQLite work off the main actor without paying for a
+ * second hop on every queue write.
+ */
+final class AnalyticsQueue: @unchecked Sendable {
+    private let databaseURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private var connection: OpaquePointer?
+
+    init(databaseURL: URL? = nil) {
+        self.databaseURL = databaseURL ?? AnalyticsQueue.defaultDatabaseURL()
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+        self.connection = nil
+    }
+
+    deinit {
+        if let connection = self.connection {
+            sqlite3_close_v2(connection)
+        }
+    }
+
+    static func defaultDatabaseURL() -> URL {
+        let applicationSupportDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+        let directory = (applicationSupportDirectory ?? URL(fileURLWithPath: NSTemporaryDirectory()))
+            .appendingPathComponent("Flashcards", isDirectory: true)
+        return directory.appendingPathComponent("analytics.sqlite", isDirectory: false)
+    }
+
+    func append(event: AnalyticsQueuedEvent, now: Date) throws -> AnalyticsQueueAppendOutcome {
+        let connection = try self.openedConnection()
+        let payloadJson = try self.encodePayload(payload: event.payload)
+        let payloadBytes = payloadJson.utf8.count
+        guard payloadBytes <= analyticsMaximumEventByteCount else {
+            throw AnalyticsQueueError.write(
+                "Event \(event.payload.eventName) is \(payloadBytes) bytes and exceeds the per-event limit"
+            )
+        }
+
+        let expiredDroppedCount = try self.deleteExpired(connection: connection, now: now)
+        try self.execute(
+            connection: connection,
+            sql: """
+                INSERT OR REPLACE INTO analytics_events
+                    (event_id, created_at, anonymous_id, session_id, payload, payload_bytes)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+            values: [
+                .text(event.payload.eventId),
+                .real(now.timeIntervalSince1970),
+                .text(event.anonymousId),
+                .text(event.sessionId),
+                .text(payloadJson),
+                .integer(Int64(payloadBytes))
+            ]
+        )
+        let overflowDroppedCount = try self.enforceCaps(connection: connection)
+
+        return AnalyticsQueueAppendOutcome(
+            queuedEventCount: try self.scalarInt(connection: connection, sql: "SELECT COUNT(*) FROM analytics_events"),
+            overflowDroppedCount: overflowDroppedCount,
+            expiredDroppedCount: expiredDroppedCount
+        )
+    }
+
+    func removeExpired(now: Date) throws -> Int {
+        let connection = try self.openedConnection()
+        return try self.deleteExpired(connection: connection, now: now)
+    }
+
+    /**
+     * Oldest events first, restricted to the identity pair of the oldest row so the batch envelope can
+     * carry one `anonymousId` and one `sessionId` truthfully.
+     *
+     * Every row that does not belong to `anonymousId` is deleted first, in the same call that produces
+     * the batch, which is the send-time half of the identity boundary. `anonymous_id` rotates in
+     * `UserDefaults` before the boundary's queue wipe is even scheduled, so a wipe that failed — or a
+     * process that died before it ran — leaves rows that are still recognisably pre-boundary here and
+     * are removed rather than posted under the next person's credential. If the purge itself fails the
+     * whole call throws and no batch is produced, so the failure is closed rather than silent.
+     */
+    func loadNextBatch(limit: Int, anonymousId: String) throws -> AnalyticsQueueBatchLoad {
+        let connection = try self.openedConnection()
+        let boundaryDiscardedCount = try self.removeEvents(notOwnedByAnonymousId: anonymousId)
+        let identity = try self.query(
+            connection: connection,
+            sql: "SELECT anonymous_id, session_id FROM analytics_events ORDER BY created_at ASC, rowid ASC LIMIT 1",
+            values: []
+        ) { statement in
+            (
+                AnalyticsQueue.columnText(statement: statement, index: 0),
+                AnalyticsQueue.columnText(statement: statement, index: 1)
+            )
+        }.first
+        guard let identity else {
+            return AnalyticsQueueBatchLoad(batch: nil, boundaryDiscardedCount: boundaryDiscardedCount)
+        }
+
+        let rows = try self.query(
+            connection: connection,
+            sql: """
+                SELECT event_id, payload FROM analytics_events
+                WHERE anonymous_id = ? AND session_id = ?
+                ORDER BY created_at ASC, rowid ASC
+                LIMIT ?
+                """,
+            values: [.text(identity.0), .text(identity.1), .integer(Int64(max(1, limit)))]
+        ) { statement in
+            (
+                AnalyticsQueue.columnText(statement: statement, index: 0),
+                AnalyticsQueue.columnText(statement: statement, index: 1)
+            )
+        }
+
+        var payloads: [AnalyticsEventPayload] = []
+        var undecodableEventIds: [String] = []
+        for row in rows {
+            guard let data = row.1.data(using: .utf8),
+                  let payload = try? self.decoder.decode(AnalyticsEventPayload.self, from: data) else {
+                undecodableEventIds.append(row.0)
+                continue
+            }
+            payloads.append(payload)
+        }
+
+        // A row that cannot be decoded can never be sent, so it is removed rather than left to block
+        // the head of the queue forever.
+        try self.delete(eventIds: undecodableEventIds)
+
+        guard payloads.isEmpty == false else {
+            return AnalyticsQueueBatchLoad(batch: nil, boundaryDiscardedCount: boundaryDiscardedCount)
+        }
+
+        return AnalyticsQueueBatchLoad(
+            batch: AnalyticsQueueBatch(
+                anonymousId: identity.0,
+                sessionId: identity.1,
+                payloads: payloads
+            ),
+            boundaryDiscardedCount: boundaryDiscardedCount
+        )
+    }
+
+    /**
+     * Removes every row that does not belong to `anonymousId`, and returns how many there were.
+     *
+     * Called at the identity boundary and again before every batch selection, so the boundary does not
+     * depend on either call succeeding: the rotated `anonymous_id` is the fact, and this is only the
+     * cleanup that acts on it.
+     */
+    @discardableResult
+    func removeEvents(notOwnedByAnonymousId anonymousId: String) throws -> Int {
+        let connection = try self.openedConnection()
+        return try self.execute(
+            connection: connection,
+            sql: "DELETE FROM analytics_events WHERE anonymous_id <> ?",
+            values: [.text(anonymousId)]
+        )
+    }
+
+    func delete(eventIds: [String]) throws {
+        guard eventIds.isEmpty == false else {
+            return
+        }
+
+        let connection = try self.openedConnection()
+        let placeholders = Array(repeating: "?", count: eventIds.count).joined(separator: ", ")
+        try self.execute(
+            connection: connection,
+            sql: "DELETE FROM analytics_events WHERE event_id IN (\(placeholders))",
+            values: eventIds.map { eventId in
+                SQLiteValue.text(eventId)
+            }
+        )
+    }
+
+    /// The kill switch, which drops everything regardless of who it belongs to. The identity boundary
+    /// uses `removeEvents(notOwnedByAnonymousId:)` instead, so a boundary discard stays distinguishable
+    /// from a disabled client.
+    @discardableResult
+    func removeAll() throws -> Int {
+        let connection = try self.openedConnection()
+        return try self.execute(connection: connection, sql: "DELETE FROM analytics_events", values: [])
+    }
+
+    private func encodePayload(payload: AnalyticsEventPayload) throws -> String {
+        let data = try self.encoder.encode(payload)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw AnalyticsQueueError.write("Event payload could not be encoded as UTF-8")
+        }
+
+        return json
+    }
+
+    private func deleteExpired(connection: OpaquePointer, now: Date) throws -> Int {
+        let cutoff = now.timeIntervalSince1970 - analyticsQueueTimeToLiveSeconds
+        return try self.execute(
+            connection: connection,
+            sql: "DELETE FROM analytics_events WHERE created_at < ?",
+            values: [.real(cutoff)]
+        )
+    }
+
+    /// Overflow policy is drop oldest, on both the event-count cap and the byte cap.
+    private func enforceCaps(connection: OpaquePointer) throws -> Int {
+        var droppedCount = try self.execute(
+            connection: connection,
+            sql: """
+                DELETE FROM analytics_events WHERE rowid IN (
+                    SELECT rowid FROM analytics_events
+                    ORDER BY created_at DESC, rowid DESC
+                    LIMIT -1 OFFSET ?
+                )
+                """,
+            values: [.integer(Int64(analyticsQueueMaximumEventCount))]
+        )
+
+        while true {
+            let totalByteCount = try self.scalarInt(
+                connection: connection,
+                sql: "SELECT COALESCE(SUM(payload_bytes), 0) FROM analytics_events"
+            )
+            guard totalByteCount > analyticsQueueMaximumByteCount else {
+                break
+            }
+
+            let removed = try self.execute(
+                connection: connection,
+                sql: """
+                    DELETE FROM analytics_events WHERE rowid IN (
+                        SELECT rowid FROM analytics_events
+                        ORDER BY created_at ASC, rowid ASC
+                        LIMIT 100
+                    )
+                    """,
+                values: []
+            )
+            guard removed > 0 else {
+                break
+            }
+            droppedCount += removed
+        }
+
+        return droppedCount
+    }
+
+    private func openedConnection() throws -> OpaquePointer {
+        if let connection = self.connection {
+            return connection
+        }
+
+        let directory = self.databaseURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        } catch {
+            throw AnalyticsQueueError.open(Flashcards.errorMessage(error: error))
+        }
+
+        var connection: OpaquePointer?
+        let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        let resultCode = sqlite3_open_v2(self.databaseURL.path, &connection, flags, nil)
+        guard resultCode == SQLITE_OK, let connection else {
+            let message = connection.map { openedConnection in
+                String(cString: sqlite3_errmsg(openedConnection))
+            } ?? "Unknown SQLite open error"
+            if let connection {
+                sqlite3_close_v2(connection)
+            }
+            throw AnalyticsQueueError.open(message)
+        }
+
+        sqlite3_busy_timeout(connection, 2_000)
+        do {
+            try self.createSchema(connection: connection)
+        } catch {
+            sqlite3_close_v2(connection)
+            throw error
+        }
+
+        self.connection = connection
+        return connection
+    }
+
+    private func createSchema(connection: OpaquePointer) throws {
+        let sql = """
+            PRAGMA journal_mode = WAL;
+            CREATE TABLE IF NOT EXISTS analytics_events (
+                event_id TEXT PRIMARY KEY NOT NULL,
+                created_at REAL NOT NULL,
+                anonymous_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                payload_bytes INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS analytics_events_created_at
+                ON analytics_events (created_at);
+            """
+        guard sqlite3_exec(connection, sql, nil, nil, nil) == SQLITE_OK else {
+            throw AnalyticsQueueError.open(String(cString: sqlite3_errmsg(connection)))
+        }
+    }
+
+    @discardableResult
+    private func execute(connection: OpaquePointer, sql: String, values: [SQLiteValue]) throws -> Int {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(connection, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw AnalyticsQueueError.write(String(cString: sqlite3_errmsg(connection)))
+        }
+        defer {
+            sqlite3_finalize(statement)
+        }
+
+        try self.bind(connection: connection, values: values, to: statement)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw AnalyticsQueueError.write(String(cString: sqlite3_errmsg(connection)))
+        }
+
+        return Int(sqlite3_changes(connection))
+    }
+
+    private func query<T>(
+        connection: OpaquePointer,
+        sql: String,
+        values: [SQLiteValue],
+        map: (OpaquePointer) -> T
+    ) throws -> [T] {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(connection, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw AnalyticsQueueError.read(String(cString: sqlite3_errmsg(connection)))
+        }
+        defer {
+            sqlite3_finalize(statement)
+        }
+
+        try self.bind(connection: connection, values: values, to: statement)
+
+        var rows: [T] = []
+        while true {
+            let stepResult = sqlite3_step(statement)
+            if stepResult == SQLITE_ROW {
+                rows.append(map(statement))
+                continue
+            }
+            if stepResult == SQLITE_DONE {
+                break
+            }
+
+            throw AnalyticsQueueError.read(String(cString: sqlite3_errmsg(connection)))
+        }
+
+        return rows
+    }
+
+    private func scalarInt(connection: OpaquePointer, sql: String) throws -> Int {
+        let rows = try self.query(connection: connection, sql: sql, values: []) { statement in
+            Int(sqlite3_column_int64(statement, 0))
+        }
+        guard let value = rows.first else {
+            throw AnalyticsQueueError.read("Expected one row for \(sql)")
+        }
+
+        return value
+    }
+
+    private func bind(connection: OpaquePointer, values: [SQLiteValue], to statement: OpaquePointer) throws {
+        for (offset, value) in values.enumerated() {
+            let index = Int32(offset + 1)
+            let resultCode: Int32
+            switch value {
+            case .integer(let integer):
+                resultCode = sqlite3_bind_int64(statement, index, integer)
+            case .real(let real):
+                resultCode = sqlite3_bind_double(statement, index, real)
+            case .text(let text):
+                resultCode = sqlite3_bind_text(statement, index, text, -1, sqliteTransient)
+            case .null:
+                resultCode = sqlite3_bind_null(statement, index)
+            }
+            guard resultCode == SQLITE_OK else {
+                throw AnalyticsQueueError.write(String(cString: sqlite3_errmsg(connection)))
+            }
+        }
+    }
+
+    private static func columnText(statement: OpaquePointer, index: Int32) -> String {
+        guard let value = sqlite3_column_text(statement, index) else {
+            return ""
+        }
+
+        return String(cString: value)
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsSurfaceTracking.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsSurfaceTracking.swift
@@ -1,0 +1,325 @@
+import Foundation
+
+extension Analytics {
+    /**
+     * Emits `screen_viewed` for a surface, skipping an immediate repeat of the surface the user is
+     * already on. SwiftUI re-presents the same screen on state changes, and a funnel built on a
+     * duplicated step reads as engagement that never happened.
+     */
+    static func trackScreenViewed(_ surface: AnalyticsSurface) {
+        guard self.surfaceTracker.beginViewing(surface: surface) else {
+            return
+        }
+
+        self.track(.screenViewed(screen: surface))
+    }
+
+    /**
+     * Emits `screen_viewed` only while nothing has been reported yet in this process.
+     *
+     * For the one report that names the tab the app opened on. That report arrives through the same
+     * call as a tab re-selection, which must stay silent because the user is not necessarily on the
+     * tab's own root, and an empty tracker is what tells the two apart: at launch nothing has been
+     * viewed, while a re-selection can only happen after something has.
+     */
+    static func trackInitialScreenViewed(_ surface: AnalyticsSurface) {
+        guard self.surfaceTracker.beginInitialViewing(surface: surface) else {
+            return
+        }
+
+        self.track(.screenViewed(screen: surface))
+    }
+
+    /**
+     * Emits `screen_viewed` for the surface a screen returns the user to as it goes away — but only
+     * while the tracker still holds the surface that screen itself set.
+     *
+     * `.onDisappear` fires both for the dismissal this restore is written for and for a switch away
+     * to somewhere else entirely, and SwiftUI gives no ordering guarantee between it and the
+     * destination reporting itself. An unconditional restore therefore risks naming a screen the user
+     * is not on, and the dedupe would then swallow the genuine next view of it — a false view and a
+     * hidden true one from the same line. Restoring only what this screen still owns makes the
+     * emission depend on observed state rather than on disappear ordering.
+     *
+     * In this app the destination always reports first for the case that motivated the guard, and by
+     * construction rather than by ordering: both the tab selection `Binding.set` in `RootTabView` and
+     * `AppNavigationModel.selectTab` emit the destination's `screen_viewed` synchronously before the
+     * selection moves, so it is already recorded when the view update that removes the outgoing
+     * hierarchy runs `.onDisappear`.
+     */
+    static func trackScreenViewedOnDismiss(
+        of dismissedSurface: AnalyticsSurface,
+        restoring restoredSurface: AnalyticsSurface
+    ) {
+        guard self.surfaceTracker.restoreViewing(
+            from: dismissedSurface,
+            to: restoredSurface
+        ) else {
+            return
+        }
+
+        self.track(.screenViewed(screen: restoredSurface))
+    }
+
+    /// Starts a review session if one is not already open. `deck_scope` describes what the queue was
+    /// built from.
+    static func startReviewSession(deckScope: AnalyticsReviewDeckScope) {
+        guard self.reviewSessionTracker.start(deckScope: deckScope, now: Date()) else {
+            return
+        }
+
+        self.track(.reviewSessionStarted(deckScope: deckScope), screen: .review)
+    }
+
+    /// One successfully recorded answer in the open review session.
+    static func recordReviewAnswer() {
+        self.reviewSessionTracker.recordAnswer()
+    }
+
+    /**
+     * Ends the open session as completed, but only once the user has actually answered something in
+     * it. The empty state also appears for a queue that was already empty when the user arrived, and
+     * briefly while a rebuilt queue settles, and neither of those is a completed session.
+     */
+    static func completeReviewSessionIfAnswered() {
+        guard self.reviewSessionTracker.hasRecordedAnswer() else {
+            return
+        }
+
+        self.endReviewSession(reason: .completed)
+    }
+
+    /// Ends the open review session, if any. Calling it when none is open does nothing, so the
+    /// leave/exhausted/backgrounded hooks can all fire without coordinating with each other.
+    static func endReviewSession(reason: AnalyticsReviewSessionEndReason) {
+        guard let event = self.makeReviewSessionEndedEvent(reason: reason, isResumable: false) else {
+            return
+        }
+
+        self.track(event, screen: .review)
+    }
+
+    /**
+     * Ends the open session as `interrupted` because the app is leaving the foreground, and awaits the
+     * queue write.
+     *
+     * Awaited because the backgrounded app starts its flush beside this call, and two independently
+     * scheduled jobs have no ordering between them, so the session-ended event would otherwise miss
+     * the very batch placed to carry it.
+     *
+     * The scope of the session being closed is kept so the return to the foreground can reopen an
+     * equivalent one. Contract §6 requires the restart, and nothing else can supply it: SwiftUI does
+     * not re-run `.onAppear` on a foreground return, because the review view was never removed from
+     * the hierarchy, so without this the session would only reopen at the user's next answer — and not
+     * at all for a return visit that reads, listens or finds an empty queue and leaves.
+     */
+    static func interruptReviewSessionAndWait() async {
+        guard let event = self.makeReviewSessionEndedEvent(reason: .interrupted, isResumable: true) else {
+            return
+        }
+
+        await self.trackAndWait(event, screen: .review)
+    }
+
+    /**
+     * Reopens the session that leaving the foreground interrupted, on the return to it.
+     *
+     * The marker is the structural statement of "the person is still on the review screen": it exists
+     * only because a session was genuinely open when the app left, and the review view cannot be
+     * unmounted while the app is in the background, so it cannot be reopened for somebody who is
+     * somewhere else. It is consumed here, so a foreground return that follows an ordinary end
+     * reopens nothing.
+     */
+    static func resumeInterruptedReviewSession() {
+        guard let deckScope = self.reviewSessionTracker.takeResumableDeckScope() else {
+            return
+        }
+
+        self.startReviewSession(deckScope: deckScope)
+    }
+
+    private static func makeReviewSessionEndedEvent(
+        reason: AnalyticsReviewSessionEndReason,
+        isResumable: Bool
+    ) -> AnalyticsEvent? {
+        guard let completion = self.reviewSessionTracker.end(now: Date(), isResumable: isResumable) else {
+            return nil
+        }
+
+        return .reviewSessionEnded(
+            endReason: reason,
+            answeredCount: completion.answeredCount,
+            durationMilliseconds: completion.durationMilliseconds
+        )
+    }
+}
+
+struct AnalyticsReviewSessionCompletion: Sendable, Equatable {
+    let answeredCount: Int
+    let durationMilliseconds: Int
+}
+
+/// Touched from SwiftUI lifecycle hooks and from the review submission path, so it is lock-protected
+/// rather than actor state: none of its callers may await.
+final class AnalyticsReviewSessionTracker: @unchecked Sendable {
+    private let lock: NSLock
+    private var startedAt: Date?
+    private var deckScope: AnalyticsReviewDeckScope?
+    private var answeredCount: Int
+    /// Set only by an interrupted end, consumed only by the matching foreground return. While it is
+    /// non-nil the app is in the background with the review screen still mounted underneath.
+    private var resumableDeckScope: AnalyticsReviewDeckScope?
+
+    init() {
+        self.lock = NSLock()
+        self.startedAt = nil
+        self.deckScope = nil
+        self.answeredCount = 0
+        self.resumableDeckScope = nil
+    }
+
+    func start(deckScope: AnalyticsReviewDeckScope, now: Date) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        guard self.startedAt == nil else {
+            return false
+        }
+
+        self.startedAt = now
+        self.deckScope = deckScope
+        self.answeredCount = 0
+        // An open session leaves nothing to resume: whoever opened this one got there first.
+        self.resumableDeckScope = nil
+        return true
+    }
+
+    func recordAnswer() {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        guard self.startedAt != nil else {
+            return
+        }
+
+        self.answeredCount += 1
+    }
+
+    func hasRecordedAnswer() -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.startedAt != nil && self.answeredCount > 0
+    }
+
+    /// `isResumable` marks the end as an interruption the app can come back from; every other end is
+    /// final and clears any marker a previous interruption left behind.
+    func end(now: Date, isResumable: Bool) -> AnalyticsReviewSessionCompletion? {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        // Cleared before the open-session check rather than after it, so that a genuine end always
+        // clears a marker and never only when a session happens to be open. Nothing is expected to
+        // reach here with a marker set and no session, but that expectation rests on an interrupt
+        // always completing before the next foreground return, and a marker that outlives its session
+        // would open one for somebody who has left the review screen and accrue `duration_ms` until
+        // they next enter and leave it.
+        self.resumableDeckScope = nil
+        guard let startedAt = self.startedAt else {
+            return nil
+        }
+
+        if isResumable {
+            self.resumableDeckScope = self.deckScope
+        }
+        self.startedAt = nil
+        self.deckScope = nil
+        let answeredCount = self.answeredCount
+        self.answeredCount = 0
+        return AnalyticsReviewSessionCompletion(
+            answeredCount: answeredCount,
+            durationMilliseconds: Int(max(0, now.timeIntervalSince(startedAt) * 1_000))
+        )
+    }
+
+    func takeResumableDeckScope() -> AnalyticsReviewDeckScope? {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        let resumableDeckScope = self.resumableDeckScope
+        self.resumableDeckScope = nil
+        return resumableDeckScope
+    }
+}
+
+final class AnalyticsSurfaceTracker: @unchecked Sendable {
+    private let lock: NSLock
+    private var currentSurface: AnalyticsSurface?
+
+    init() {
+        self.lock = NSLock()
+        self.currentSurface = nil
+    }
+
+    func beginViewing(surface: AnalyticsSurface) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        guard self.currentSurface != surface else {
+            return false
+        }
+
+        self.currentSurface = surface
+        return true
+    }
+
+    /// Claims the first surface of the process and nothing after it.
+    func beginInitialViewing(surface: AnalyticsSurface) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        guard self.currentSurface == nil else {
+            return false
+        }
+
+        self.currentSurface = surface
+        return true
+    }
+
+    /// Moves the current surface back to `restoredSurface`, but only while `dismissedSurface` is still
+    /// the one being viewed. A screen that something else has already superseded restores nothing.
+    func restoreViewing(
+        from dismissedSurface: AnalyticsSurface,
+        to restoredSurface: AnalyticsSurface
+    ) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        guard self.currentSurface == dismissedSurface, restoredSurface != dismissedSurface else {
+            return false
+        }
+
+        self.currentSurface = restoredSurface
+        return true
+    }
+}
+
+/// Maps the active review filter onto the shared `deck_scope` values.
+func analyticsReviewDeckScope(reviewFilter: ReviewFilter) -> AnalyticsReviewDeckScope {
+    switch reviewFilter {
+    case .allCards:
+        return .all
+    case .deck:
+        return .deck
+    case .tags:
+        return .filter
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsSyncFailureReporting.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsSyncFailureReporting.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+extension Analytics {
+    /**
+     * The one way this app emits `sync_failed`. Every surface that can notice a cloud sync failing
+     * reports it here, so one outage costs one event no matter which surface saw it first.
+     *
+     * Never call `track(.syncFailed(...))` directly. The sync paths are retried on a timer — every
+     * 15 s on the Review and Cards tabs — so a direct emit turns one outage into hundreds of rows per
+     * device per hour on an append-only table.
+     */
+    static func reportSyncFailure(reason: AnalyticsSyncFailureReason) {
+        guard self.syncFailureReporter.shouldReport(reason: reason) else {
+            return
+        }
+
+        self.track(.syncFailed(reason: reason))
+    }
+
+    /// A sync that completed ends the failure episode: the next failure is reported again, whatever
+    /// its reason.
+    static func recordSyncSucceeded() {
+        self.syncFailureReporter.rearm()
+    }
+}
+
+/**
+ * Holds `sync_failed` to the transition **into** failure rather than one event per attempt.
+ *
+ * Two harms come from the per-attempt version, and the second is the worse one. The event stops
+ * measuring failure incidence and starts measuring poll cadence; and because an offline device cannot
+ * flush either, the repeats fill the 5000-event queue and drop-oldest evicts the genuine events
+ * behind them. `product_events` is append-only, so neither is repairable after the fact.
+ *
+ * Reported reasons are held as a set rather than as a single last-reason slot. The two behave
+ * identically while one reason persists, which is the case the shared rule is written for, but a
+ * flapping connection maps alternately onto `offline` and `timeout`, and a slot would emit on every
+ * alternation — the per-attempt behaviour again, arriving by a different route. A set bounds a
+ * failure episode at one event per distinct reason.
+ *
+ * Web and Android carry the identical rule, so the three clients stay comparable. Android keys its
+ * gate on the reason *and* the screen because its emissions carry a screen; every emission here comes
+ * from the one cloud sync failure path and carries none, so the reason alone is the same key.
+ *
+ * Touched from the sync paths and from `Analytics.reset()`, none of which may await, so it is
+ * lock-protected rather than actor state.
+ */
+final class AnalyticsSyncFailureReporter: @unchecked Sendable {
+    private let lock: NSLock
+    /// The reasons already reported in the current failure episode.
+    private var reportedReasons: Set<AnalyticsSyncFailureReason>
+
+    init() {
+        self.lock = NSLock()
+        self.reportedReasons = []
+    }
+
+    /// True the first time a reason is seen in the current failure episode, and false while it
+    /// persists.
+    func shouldReport(reason: AnalyticsSyncFailureReason) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.reportedReasons.insert(reason).inserted
+    }
+
+    /// Ends the current episode, re-arming the next failure of every reason.
+    func rearm() {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        self.reportedReasons.removeAll()
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsWireContract.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsWireContract.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// `POST /v1/analytics/events`. The trailing-slash form answers 404 on purpose and also misses the
+/// endpoint's tighter API Gateway throttle and all three of its alarms, so the final URL is asserted
+/// rather than assembled by a base-URL join that might normalise one in.
+let analyticsEventsPath: String = "/analytics/events"
+let analyticsClientPlatformHeaderValue: String = "ios"
+
+/// Shared behavioural constants. These are identical on web, iOS and Android by contract; changing
+/// one here without changing it there makes the three clients incomparable in the data.
+let analyticsSessionTimeoutSeconds: TimeInterval = 30 * 60
+let analyticsFlushBatchThreshold: Int = 20
+let analyticsMaximumEventsPerBatch: Int = 50
+let analyticsQueueMaximumEventCount: Int = 5_000
+let analyticsQueueMaximumByteCount: Int = 5 * 1_024 * 1_024
+let analyticsQueueTimeToLiveSeconds: TimeInterval = 14 * 24 * 60 * 60
+let analyticsPeriodicFlushIntervalSeconds: TimeInterval = 5 * 60
+let analyticsRetryBaseDelaySeconds: TimeInterval = 2
+let analyticsRetryMaximumDelaySeconds: TimeInterval = 60 * 60
+
+/**
+ * How many batches one flush may post before it stops and waits for the next trigger.
+ *
+ * The contract requires a bound and leaves the number to each client. It exists because a batch
+ * refused at the envelope level is dropped and reported as `analytics_events_dropped`, and that
+ * report can be refused in turn: without a cap, one device off contract posts once per iteration
+ * forever and can consume the endpoint's entire 20 rps method throttle for every other client.
+ * Anything the cap leaves behind is picked up by the next trigger, so a real backlog still drains.
+ */
+let analyticsMaximumDrainIterationsPerFlush: Int = 25
+
+/// Server-side per-event cap, measured as UTF-8 bytes of the event's own JSON.
+let analyticsMaximumEventByteCount: Int = 4 * 1_024
+
+/**
+ * One event exactly as it goes on the wire. Every key is written explicitly, with `null` where there
+ * is no value, so the three hand-written clients produce identical output and no key placement
+ * depends on how a JSON encoder treats an absent optional.
+ */
+struct AnalyticsEventPayload: Sendable, Equatable, Codable {
+    let eventId: String
+    let eventName: String
+    let clientOccurredAt: String
+    let networkState: String?
+    let screen: String?
+    let properties: [String: AnalyticsPropertyValue]?
+    let experimentAssignments: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case eventId
+        case eventName
+        case clientOccurredAt
+        case networkState
+        case screen
+        case properties
+        case experimentAssignments
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.eventId, forKey: .eventId)
+        try container.encode(self.eventName, forKey: .eventName)
+        try container.encode(self.clientOccurredAt, forKey: .clientOccurredAt)
+        // `encode` rather than `encodeIfPresent`: an absent key and an explicit null are not the same
+        // wire output, and the contract asks for the explicit null.
+        try container.encode(self.networkState, forKey: .networkState)
+        try container.encode(self.screen, forKey: .screen)
+        try container.encode(self.properties, forKey: .properties)
+        try container.encode(self.experimentAssignments, forKey: .experimentAssignments)
+    }
+}
+
+/// The batch envelope. The server parses it `.strict()`, so an unexpected top-level key fails the
+/// whole request with 400.
+struct AnalyticsBatchPayload: Sendable, Equatable, Encodable {
+    let clientSentAt: String
+    let anonymousId: String?
+    let sessionId: String?
+    let context: AnalyticsContextPayload?
+    let events: [AnalyticsEventPayload]
+
+    private enum CodingKeys: String, CodingKey {
+        case clientSentAt
+        case anonymousId
+        case sessionId
+        case context
+        case events
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.clientSentAt, forKey: .clientSentAt)
+        try container.encode(self.anonymousId, forKey: .anonymousId)
+        try container.encode(self.sessionId, forKey: .sessionId)
+        try container.encode(self.context, forKey: .context)
+        try container.encode(self.events, forKey: .events)
+    }
+}
+
+struct AnalyticsContextPayload: Sendable, Equatable, Encodable {
+    let osVersion: String?
+    let deviceModel: String?
+    let deviceLocale: String?
+    let timezone: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case osVersion
+        case deviceModel
+        case deviceLocale
+        case timezone
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.osVersion, forKey: .osVersion)
+        try container.encode(self.deviceModel, forKey: .deviceModel)
+        try container.encode(self.deviceLocale, forKey: .deviceLocale)
+        try container.encode(self.timezone, forKey: .timezone)
+    }
+}
+
+/// `accepted` is a count only; no accepted ids come back. A client that waits for a list of accepted
+/// ids before purging its queue never purges.
+struct AnalyticsIngestResponse: Sendable, Equatable, Decodable {
+    let accepted: Int
+    let rejected: [AnalyticsRejectedEvent]
+}
+
+struct AnalyticsRejectedEvent: Sendable, Equatable, Decodable {
+    let eventId: String?
+    let reason: String
+}
+
+/**
+ * UTC with a `Z` suffix, which is the only shape `z.string().datetime()` accepts: a timezone offset
+ * fails, and `ISO8601DateFormatter` readily produces one when its time zone is not GMT. A bad
+ * `clientSentAt` 400s the whole batch and a bad `clientOccurredAt` rejects that event as
+ * `invalid_event`, so the produced string is checked rather than the formatter options.
+ */
+func analyticsTimestampString(date: Date) -> String {
+    let formatted = formatIsoTimestamp(date: date)
+    if formatted.hasSuffix("Z") {
+        return formatted
+    }
+
+    return analyticsFallbackUtcTimestampString(date: date)
+}
+
+private func analyticsFallbackUtcTimestampString(date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    return formatter.string(from: date)
+}

--- a/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+Analytics.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+Analytics.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+@MainActor
+extension FlashcardsStore {
+    /**
+     * The credential the analytics client posts with, read without touching the network.
+     *
+     * The endpoint accepts `bearer`, `session` and `guest`, and a guest credential is enough, so this
+     * prefers the live session and falls back to the stored guest session. It deliberately never
+     * refreshes a token and never creates a guest session: analytics must not drive cloud work of its
+     * own, and events simply wait in the queue until the app has a credential for its own reasons.
+     */
+    func analyticsCredentials() -> AnalyticsCredentials? {
+        if let activeSession = self.cloudRuntime.activeCloudSession() {
+            return AnalyticsCredentials(
+                apiBaseUrl: activeSession.apiBaseUrl,
+                authorizationHeaderValue: activeSession.authorizationHeaderValue
+            )
+        }
+
+        guard let storedGuestSession = try? self.loadUsableGuestSessionForCurrentConfiguration() else {
+            return nil
+        }
+
+        return AnalyticsCredentials(
+            apiBaseUrl: storedGuestSession.apiBaseUrl,
+            authorizationHeaderValue: CloudAuthorization.guest(storedGuestSession.guestToken).headerValue
+        )
+    }
+}
+
+/// Maps a top-level tab onto the shared, platform-independent surface enum. A native screen name is
+/// never sent.
+func analyticsSurface(tab: AppTab) -> AnalyticsSurface {
+    switch tab {
+    case .review:
+        return .review
+    case .progress:
+        return .progress
+    case .ai:
+        return .ai
+    case .cards:
+        return .cards
+    case .settings:
+        return .settings
+    }
+}
+
+/**
+ * Maps a failed review answer onto the shared `review_answer_failed` reasons.
+ *
+ * Review answers are recorded locally on iOS and reach the backend later through the sync outbox, so
+ * the network-flavoured reasons in the shared catalog do not all have a local counterpart. A write
+ * blocked by a pending guest upgrade is the one genuine conflict; a transport failure can only reach
+ * here through the surrounding refresh; everything else is the catch-all bucket, which on every client
+ * means the answer could not be recorded for a reason the user cannot act on.
+ */
+func analyticsReviewAnswerFailureReason(error: Error) -> AnalyticsReviewAnswerFailureReason {
+    if error is PendingGuestUpgradeLocalMutationError {
+        return .syncConflict
+    }
+    if isRetryableNetworkTransportFailure(error: error) {
+        return flashcardsURLErrorCode(error: error, remainingDepth: 4) == .timedOut ? .timeout : .offline
+    }
+
+    return .serverError
+}
+
+/**
+ * Maps a cloud sync failure onto the shared `sync_failed` reasons. Everything the client can tell
+ * apart locally is told apart here; anything else is a server error, which is what the remaining
+ * bucket means on all three clients.
+ */
+func analyticsSyncFailureReason(error: Error) -> AnalyticsSyncFailureReason {
+    if isRetryableNetworkTransportFailure(error: error) {
+        return flashcardsURLErrorCode(error: error, remainingDepth: 4) == .timedOut ? .timeout : .offline
+    }
+
+    guard let syncError = error as? CloudSyncError,
+          case .invalidResponse(let details, let statusCode) = syncError else {
+        return .serverError
+    }
+
+    if details.syncConflict != nil || statusCode == 409 {
+        return .conflict
+    }
+    if statusCode == 401 || statusCode == 403 {
+        return .unauthorized
+    }
+    if statusCode == 408 || statusCode == 504 {
+        return .timeout
+    }
+    if statusCode == 413 || statusCode == 507 {
+        return .storageFull
+    }
+
+    return .serverError
+}
+
+/**
+ * Maps a sign-in failure onto the shared `signin_failed` reasons, using the backend code where the
+ * server named the cause and the local classification otherwise.
+ */
+func analyticsSignInFailureReason(error: Error) -> AnalyticsSignInFailureReason {
+    if isRequestCancellationError(error: error) {
+        return .cancelled
+    }
+    if isRetryableNetworkTransportFailure(error: error) {
+        return .offline
+    }
+
+    guard let authError = error as? CloudAuthError,
+          case .invalidResponse(let details, let statusCode) = authError else {
+        return .serverError
+    }
+
+    switch details.code {
+    case "OTP_CODE_INVALID", "INVALID_EMAIL":
+        return .invalidCode
+    case "OTP_SESSION_EXPIRED", "OTP_CHALLENGE_CONSUMED":
+        return .expiredCode
+    case "OTP_TOO_MANY_ATTEMPTS":
+        return .rateLimited
+    default:
+        return statusCode == 429 ? .rateLimited : .serverError
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -55,6 +55,18 @@ struct FlashcardsApp: App {
         )
         let store = FlashcardsStore()
         let processInfo = ProcessInfo.processInfo
+        if isFlashcardsUITestLaunch(processInfo: processInfo) {
+            // The release-gate smoke suite signs into a real review account and the screenshot runs
+            // drive the same flows, so the kill switch goes on before anything can be recorded.
+            Analytics.setEnabled(false)
+        } else {
+            Analytics.configure { [weak store] in
+                store?.analyticsCredentials()
+            }
+            // Process start is the cold launch. Emitting it here rather than at startup-ready keeps
+            // it ahead of the first screen_viewed instead of landing after it.
+            Analytics.track(.appOpened(launchType: .cold))
+        }
         let selectedTab = processInfo.environment[flashcardsUITestSelectedTabEnvironmentKey]
             .flatMap(FlashcardsUITestSelectedTab.init(rawValue:))
             .map(\.appTab) ?? .review
@@ -219,6 +231,12 @@ struct FlashcardsApp: App {
                         store.reconcileReviewNotifications(trigger: .appActive, now: now)
                         store.reconcileStrictReminders(trigger: .appActive, now: now)
                     } else if nextPhase == .background {
+                        // No analytics work in this branch on purpose. `scenePhase` is per scene and
+                        // `UIApplicationSupportsMultipleScenes` is on, while every analytics reaction
+                        // to leaving or returning to the foreground — the warm open, the review
+                        // session, the flush — is a statement about the process. They are subscribed
+                        // once, to the app-level `UIApplication` notifications, in
+                        // `ReviewNotificationsAppDelegate`.
                         let now = Date()
                         runAppBackgroundTask(name: "AppBackgroundNotificationReconcile") {
                             await store.reconcileAppBackgroundNotifications(now: now)

--- a/apps/ios/Flashcards/Flashcards/App/Navigation/AppNavigationModel.swift
+++ b/apps/ios/Flashcards/Flashcards/App/Navigation/AppNavigationModel.swift
@@ -96,7 +96,35 @@ final class AppNavigationModel {
         self.progressPresentationRequest = progressPresentationRequest
     }
 
+    /**
+     * Every tab change goes through here, and the destination's `screen_viewed` is claimed before the
+     * selection actually moves.
+     *
+     * Doing it before the mutation is what makes the funnel independent of SwiftUI callback ordering.
+     * The tab-bar tap already had that property, because the selection `Binding.set` in `RootTabView`
+     * reports the destination and only then calls this. A programmatic change — a deck or tag opening
+     * review, a notification tap, `openCardCreation`, `openProgress`, `openSettings` — used to be
+     * reported afterwards, from an ancestor's `.onChange(of: selectedTab)`, and the ordering between
+     * that and the outgoing screen's `.onDisappear` is not established. Losing the race let a screen
+     * that restores a surface on dismissal name one the user had already left, which would also hide
+     * their genuine next view of it behind the dedupe.
+     *
+     * The reports from `prepareVisibleTabForPresentation` stay where they are: that one also covers
+     * the tab shown at launch, which never passes through here, and a repeat of the surface already
+     * being viewed is dropped.
+     *
+     * A call that names the tab already selected is not a tab change and reports nothing. The tab-bar
+     * re-selection tap arrives here right behind the same binding setter that feeds
+     * `prepareVisibleTabForPresentation`, so the gate has to hold at both or the re-selection would
+     * simply be reported from this one instead — and it would report a tab whose pushed detail screen
+     * is what the user is actually looking at. `openCardCreation`, `openProgress` and `openSettings`
+     * can also target the tab already on screen, and what the user then arrives at is the editor or
+     * the pushed destination, which is not this tab's own surface.
+     */
     func selectTab(_ tab: AppTab) {
+        if self.selectedTab != tab {
+            Analytics.trackScreenViewed(analyticsSurface(tab: tab))
+        }
         if self.selectedTab != .ai, tab == .ai {
             self.aiTabVisitID = UUID()
         }

--- a/apps/ios/Flashcards/Flashcards/App/UITestLaunchSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestLaunchSupport.swift
@@ -7,6 +7,20 @@ private let flashcardsUITestAIHandoffCardEnvironmentKey: String = "FLASHCARDS_UI
 @MainActor
 private var hasConsumedFlashcardsUITestAppNotificationTapEnvironment: Bool = false
 
+/**
+ * True when the process was launched by the XCUITest harness — the grouped live smoke suite, which
+ * signs into a real review account, or a marketing screenshot run. Both harnesses always set the
+ * selected-tab key and set the scenario key for a prepared launch.
+ *
+ * Product analytics stays off for those launches: `product_events` is append-only, and synthetic app
+ * opens, screen views, review sessions and card-create intents written into it would corrupt the
+ * exact dataset the analytics module exists to produce.
+ */
+func isFlashcardsUITestLaunch(processInfo: ProcessInfo) -> Bool {
+    processInfo.environment[flashcardsUITestSelectedTabEnvironmentKey] != nil
+        || processInfo.environment[flashcardsUITestLaunchScenarioEnvironmentKey] != nil
+}
+
 enum FlashcardsUITestSelectedTab: String {
     case review
     case progress

--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -203,6 +203,10 @@ struct CardsScreen: View {
 
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
+                    // Emitted at the intent site rather than in beginCreating(), which is also the
+                    // convergence point for a request routed here from the Review screen and would
+                    // count that one twice.
+                    Analytics.track(.cardCreateStarted(entryPoint: .cards), screen: .cards)
                     self.beginCreating()
                 } label: {
                     Label(String(localized: "Add card", table: reviewCardsStringsTableName), systemImage: "plus")
@@ -237,6 +241,15 @@ struct CardsScreen: View {
             .technicalErrorSheet(store: self.store)
             .accessibilityIdentifier(UITestIdentifier.cardEditorScreen)
             .interactiveDismissDisabled()
+            .onAppear {
+                Analytics.trackScreenViewed(.cardEditor)
+            }
+            .onDisappear {
+                // The editor only ever presents over the Cards tab, so the restore is already safe
+                // here; it is written conditionally anyway because it costs nothing and keeps the one
+                // rule for restoring a surface identical at both sites.
+                Analytics.trackScreenViewedOnDismiss(of: .cardEditor, restoring: .cards)
+            }
         }
         .sheet(isPresented: $isFilterSheetPresented) {
             NavigationStack {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -74,6 +74,23 @@ extension FlashcardsStore {
         tab: AppTab,
         now: Date
     ) {
+        // Single funnel for every top-level destination, including the one selected at launch.
+        //
+        // Tapping the tab the user is already on reaches this too, because that is how SwiftUI reports
+        // a re-selection: through the selection binding's setter, with the tab unchanged. The user is
+        // then not necessarily on that tab's root — a pushed deck detail stays pushed — so reporting
+        // it would name a screen they are not looking at and hide their genuine next view of it behind
+        // the dedupe. If SwiftUI instead pops the stack to its root, the detail screen's own dismissal
+        // restores the surface, so staying silent here is right whichever way that behaves.
+        //
+        // The tab shown at launch arrives with the tab already stored, and is the only such call that
+        // must still be reported. Nothing has been viewed yet at that point, which is what the initial
+        // report keys on.
+        if self.currentVisibleTab == tab {
+            Analytics.trackInitialScreenViewed(analyticsSurface(tab: tab))
+        } else {
+            Analytics.trackScreenViewed(analyticsSurface(tab: tab))
+        }
         self.updateCurrentVisibleTab(tab: tab)
 
         guard isProgressConsumerTab(tab: tab) else {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudServerConfiguration.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudServerConfiguration.swift
@@ -41,6 +41,11 @@ extension FlashcardsStore {
     private func switchCloudServer(override: CloudServerOverride?) throws {
         let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
 
+        // The second identity boundary: this disconnects the account and clears the guest session,
+        // and the next credential belongs to a different backend entirely. Queued analytics events
+        // were created against the server being left, so they are discarded here for the same reason
+        // they are on logout rather than posted to the new one under a new identity.
+        Analytics.reset()
         self.cloudRuntime.cancelForAccountDeletion()
         self.clearCloudCredentialRecoveryState()
         try self.cloudRuntime.clearCredentials()

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/Identity/FlashcardsStore+CloudIdentity.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/Identity/FlashcardsStore+CloudIdentity.swift
@@ -14,6 +14,13 @@ extension FlashcardsStore {
      it were the same pre-reset guest identity.
      */
     func resetLocalStateForCloudIdentityChange() throws {
+        // The identity boundary logout and account deletion share. It rotates anonymous_id and
+        // discards whatever analytics events are still queued: they belong to the person leaving,
+        // and this function never suspends before the credentials are cleared below, so anything
+        // left behind would be posted later under a fresh guest session or the next account and
+        // would name the wrong user on an append-only table. The discarded count is reported
+        // through observability, not as an analytics_events_dropped reason.
+        Analytics.reset()
         let database = try requireLocalDatabase(database: self.database)
         let previousStrictReminderNotificationScope = storedStrictReminderNotificationScope(userDefaults: self.userDefaults)
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -261,6 +261,9 @@ extension FlashcardsStore {
                 trigger: trigger
             )
             await self.processMediaUploadTransfersAfterCloudSync(linkedSession: activeSession)
+            // Re-arms the failure gate: this attempt is the same unit of work the catch below reports,
+            // so a sync that got through is what ends the episode it opened.
+            Analytics.recordSyncSucceeded()
             self.addCloudSyncForegroundOperationBreadcrumb(
                 stage: "sync_now",
                 phase: .success,
@@ -276,6 +279,14 @@ extension FlashcardsStore {
                 self.syncStatus = .idle
                 throw error
             }
+            // Emitted here rather than in captureCloudSyncFailureIfNeeded: that path deliberately
+            // drops offline, conflicts and every non-user-visible trigger, which are exactly the
+            // sync failures the product needs counted.
+            //
+            // Through the shared reporter rather than a direct track, because this catch is what the
+            // 15 s fast-polling loop reaches on every attempt: the reporter emits on the transition
+            // into failure and stays silent while the same reason persists.
+            Analytics.reportSyncFailure(reason: analyticsSyncFailureReason(error: error))
             try self.throwIfCloudCredentialRecoveryRequired()
             let failureError: Error
             do {
@@ -587,6 +598,11 @@ extension FlashcardsStore {
                     }
                 }
 
+                // No analytics identity boundary here on purpose. `analyticsCredentials()` reads the
+                // active cloud session, which this state never has, and falls back to a stored guest
+                // session, which this branch does not have either — so nothing analytics could ever
+                // have posted under is being cleared, and rotating `anonymous_id` would only split one
+                // install's history in two.
                 try self.cloudRuntime.clearCredentials()
                 self.globalErrorMessage = ""
                 return .stopSync
@@ -595,6 +611,19 @@ extension FlashcardsStore {
             if hasStoredCredentials && hasStoredGuestSession {
                 try self.cloudRuntime.clearCredentials()
                 try self.dependencies.guestCredentialStore.clearGuestSession()
+                // The guest session just cleared is the credential `analyticsCredentials()` falls back
+                // to, so anything still queued was created while it was the identity those events would
+                // have gone out under, and the next credential this device obtains belongs to a
+                // different server-side user. That is the boundary of contract §6. This state is only
+                // reached when the persisted local state disagrees with the Keychain — leftovers of an
+                // install that is not this one — so carrying the same `anonymous_id` into the next
+                // identity is exactly the first-wins mislink the rule exists to prevent.
+                //
+                // After the clears rather than before, unlike `resetLocalStateForCloudIdentityChange`:
+                // this reconciliation runs before every sync, and firing the boundary first would
+                // rotate `anonymous_id` again on every attempt if a clear kept failing. Neither
+                // statement above suspends, so no new credential can appear in between.
+                Analytics.reset()
                 self.globalErrorMessage = ""
                 return .stopSync
             }

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -12,6 +12,7 @@ enum ObservabilityAccountKind: String, Sendable {
 }
 
 enum IOSObservationFeature: String, Sendable {
+    case analytics = "analytics"
     case appStartup = "app_startup"
     case cards = "cards"
     case cloudAuth = "cloud_auth"

--- a/apps/ios/Flashcards/Flashcards/PrivacyInfo.xcprivacy
+++ b/apps/ios/Flashcards/Flashcards/PrivacyInfo.xcprivacy
@@ -4,6 +4,40 @@
 <dict>
 	<key>NSPrivacyTracking</key>
 	<false/>
+	<!-- Product analytics posts app opens, screen views, review sessions, card-create intents and
+	     sign-in/sync failures to our own server over an authenticated request from which the server
+	     derives user_id and workspace_id, so the data is collected and linked. anonymous_id is
+	     declared as a device ID because it is a client-generated identifier we transmit and join to
+	     the account; the reading is arguable, but under-declaring is the only side of it that costs
+	     anything at review. Nothing here is used for tracking: no data leaves for a third party and
+	     there is no advertising identifier. -->
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -220,6 +220,10 @@ extension FlashcardsStore {
     func dismissReviewNotificationPrePrompt(markDismissed: Bool) {
         self.isReviewNotificationPrePromptPresented = false
         if markDismissed {
+            Analytics.track(
+                .onboardingStepCompleted(step: .notifications, outcome: .skipped),
+                screen: .review
+            )
             self.updateNotificationPermissionPromptState(
                 state: NotificationPermissionPromptState(
                     hasShownPrePrompt: true,
@@ -232,6 +236,10 @@ extension FlashcardsStore {
 
     func continueReviewNotificationPrePrompt() {
         self.isReviewNotificationPrePromptPresented = false
+        Analytics.track(
+            .onboardingStepCompleted(step: .notifications, outcome: .completed),
+            screen: .review
+        )
         self.updateNotificationPermissionPromptState(
             state: NotificationPermissionPromptState(
                 hasShownPrePrompt: true,

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsAppDelegate.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsAppDelegate.swift
@@ -8,7 +8,56 @@ final class ReviewNotificationsAppDelegate: NSObject, UIApplicationDelegate, UNU
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        self.observeAppLifecycleForAnalytics()
         return true
+    }
+
+    /**
+     * Subscribes the process-wide app lifecycle signals every analytics reaction to leaving and
+     * returning to the foreground is built on: the warm `app_opened`, the review-session interruption
+     * and restart, and the backgrounded flush.
+     *
+     * `didFinishLaunchingWithOptions` runs exactly once per process, which is the whole point of doing
+     * it here. Both notifications are application-level and posted once, so a subscription attached to
+     * a view inside the `WindowGroup` would be built per scene and a user with two iPad windows open
+     * would record two opens per foreground return — `UIApplicationSupportsMultipleScenes` is on and
+     * the target is universal. `ScenePhase` is per scene for the same reason and is not usable for any
+     * of this: with two windows open, backgrounding one would end a review session the other window is
+     * still running. The delegate's own `applicationWillEnterForeground` is not usable either: UIKit
+     * does not call it in a scene-based app, which this is.
+     *
+     * The observers are never removed because the delegate lives as long as the process, and they
+     * capture nothing, so they stay usable from a `@Sendable` context.
+     */
+    private func observeAppLifecycleForAnalytics() {
+        _ = NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            Analytics.recordAppBackgrounded()
+            runAnalyticsAppLifecycleWork {
+                // Held open by a background task: without one the process is suspended before the
+                // batch leaves, and the events wait for the next launch instead. The interrupted
+                // session is ended and awaited inside the same task, because a session ended beside
+                // the flush has no ordering against it and would miss the very batch placed to
+                // carry it.
+                runAppBackgroundTask(name: "AppBackgroundAnalyticsFlush") {
+                    await Analytics.interruptReviewSessionAndWait()
+                    await Analytics.flushAndWait()
+                }
+            }
+        }
+        _ = NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            runAnalyticsAppLifecycleWork {
+                Analytics.trackAppForegrounded()
+                Analytics.resumeInterruptedReviewSession()
+            }
+        }
     }
 
     nonisolated func userNotificationCenter(
@@ -187,5 +236,31 @@ final class ReviewNotificationsAppDelegate: NSObject, UIApplicationDelegate, UNU
         @unknown default:
             return "unknown"
         }
+    }
+}
+
+/**
+ * Runs an app lifecycle notification's main-actor analytics work inline, on the notification's own
+ * thread.
+ *
+ * UIKit posts those notifications on the main thread and `queue: nil` delivers on the posting thread,
+ * so `assumeIsolated` holds and the work runs before the process can be suspended. Running it inline
+ * is the point on the way out: a scheduled hop would let the suspension beat the background task
+ * placed to hold the process awake for the flush.
+ *
+ * The thread check keeps the case that should not happen from becoming a crash. Nothing in the
+ * analytics module may fail a user's app, and a deferred batch is a far smaller loss than a
+ * termination.
+ */
+private func runAnalyticsAppLifecycleWork(_ operation: @escaping @MainActor @Sendable () -> Void) {
+    guard Thread.isMainThread else {
+        Task { @MainActor in
+            operation()
+        }
+        return
+    }
+
+    MainActor.assumeIsolated {
+        operation()
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
@@ -741,6 +741,10 @@ extension FlashcardsStore {
 
     func handleReviewSubmissionFailure(request: ReviewSubmissionRequest, submissionError: Error) async {
         let submissionErrorMessage = Flashcards.errorMessage(error: submissionError)
+        Analytics.track(
+            .reviewAnswerFailed(reason: analyticsReviewAnswerFailureReason(error: submissionError)),
+            screen: .review
+        )
         let now = Date()
         // Capture the pre-refresh validation context once so the staleness classification
         // is independent of the bootstrap-refresh outcome below. The catch branch reuses

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -90,6 +90,16 @@ extension ReviewView {
     func submitReview(cardId: String, rating: ReviewRating) {
         do {
             try store.enqueueReviewSubmission(cardId: cardId, rating: rating)
+            // A no-op while a session is already open. It matters when FSRS learning steps make cards
+            // due again during the same visit: the session was already ended when the queue emptied,
+            // and without reopening one here every one of those answers would belong to no session.
+            Analytics.startReviewSession(
+                deckScope: analyticsReviewDeckScope(reviewFilter: store.selectedReviewFilter)
+            )
+            // Counted at the tap, not when the asynchronous submission settles: the queue advances
+            // optimistically, so a session that empties on its last answer ends before that
+            // submission completes and would report one answer fewer than the user gave.
+            Analytics.recordReviewAnswer()
             self.screenErrorMessage = ""
         } catch {
             if let inlineErrorMessage = reviewSubmissionInlineErrorMessage(error: error) {

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -137,6 +137,11 @@ struct ReviewView: View {
         .accessibilityIdentifier(UITestIdentifier.reviewScreen)
         .navigationTitle(String(localized: "Review", table: reviewCardsStringsTableName))
         .onAppear {
+            // A review session is the user's contiguous stay on this screen. It ends when they leave
+            // it, when the queue is exhausted, or when the app is backgrounded.
+            Analytics.startReviewSession(
+                deckScope: analyticsReviewDeckScope(reviewFilter: store.selectedReviewFilter)
+            )
             if self.areReviewReactionAnimationsEnabled {
                 self.prewarmReviewReactionLottieAssets()
             }
@@ -154,6 +159,7 @@ struct ReviewView: View {
             self.reviewSpeechController.stopSpeech()
         }
         .onDisappear {
+            Analytics.endReviewSession(reason: .abandoned)
             self.reviewSpeechController.stopSpeech()
             self.cancelReviewReactionLottiePrewarm()
         }
@@ -783,6 +789,7 @@ struct ReviewView: View {
         } actions: {
             VStack(spacing: 8) {
                 Button {
+                    Analytics.track(.cardCreateStarted(entryPoint: .review), screen: .review)
                     navigation.openCardCreation()
                 } label: {
                     Label(String(localized: "Create card", table: reviewCardsStringsTableName), systemImage: "plus")
@@ -796,6 +803,7 @@ struct ReviewView: View {
                     .foregroundStyle(.secondary)
 
                 Button {
+                    Analytics.track(.cardCreateStarted(entryPoint: .ai), screen: .review)
                     navigation.openAICardCreation()
                 } label: {
                     Label(String(localized: "Create with AI", table: reviewCardsStringsTableName), systemImage: "sparkles")
@@ -817,6 +825,11 @@ struct ReviewView: View {
                     .buttonStyle(.glass)
                 }
             }
+        }
+        .onAppear {
+            // The queue ran out while the user was here, so the session finished rather than being
+            // abandoned.
+            Analytics.completeReviewSessionIfAnswered()
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
@@ -204,6 +204,7 @@ struct CloudOtpVerificationSheet: View {
                 if isRequestCancellationError(error: error) {
                     return
                 }
+                Analytics.track(.signInFailed(reason: analyticsSignInFailureReason(error: error)))
                 self.applyOtpErrorState(error: error)
                 self.presentAuthErrorPresentation(
                     makeCloudAuthInlineErrorPresentation(
@@ -244,6 +245,7 @@ struct CloudOtpVerificationSheet: View {
                 if isRequestCancellationError(error: error) {
                     return
                 }
+                Analytics.track(.signInFailed(reason: analyticsSignInFailureReason(error: error)))
                 self.presentAuthErrorPresentation(
                     makeCloudAuthInlineErrorPresentation(
                         error: error,

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -360,6 +360,7 @@ struct CloudSignInSheet: View {
                 if self.otpSheetState?.id == nextOtpSheetState.id {
                     self.otpSheetState = nil
                 }
+                Analytics.track(.signInFailed(reason: analyticsSignInFailureReason(error: error)))
                 self.presentAuthErrorPresentation(
                     makeCloudAuthInlineErrorPresentation(
                         error: error,

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
@@ -35,6 +35,10 @@ extension FlashcardsStore {
     }
 
     func acceptGuestSignInAfterReviewPrompt(now: Date) {
+        Analytics.track(
+            .onboardingStepCompleted(step: .signin, outcome: .completed),
+            screen: .review
+        )
         self.updateGuestSignInAfterReviewPromptState(
             state: makeAcceptedGuestSignInAfterReviewPromptState(
                 promptState: self.guestSignInAfterReviewPromptState,
@@ -45,6 +49,10 @@ extension FlashcardsStore {
     }
 
     func snoozeGuestSignInAfterReviewPrompt(reviewedCount: Int, now: Date) {
+        Analytics.track(
+            .onboardingStepCompleted(step: .signin, outcome: .skipped),
+            screen: .review
+        )
         self.updateGuestSignInAfterReviewPromptState(
             state: makeSnoozedGuestSignInAfterReviewPromptState(
                 promptState: self.guestSignInAfterReviewPromptState,

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
@@ -434,6 +434,16 @@ private struct DeckDetailScreen: View {
         .task(id: "\(self.currentDeckId ?? "all")|\(store.localReadVersion)") {
             await self.reloadDetailState()
         }
+        .onAppear {
+            Analytics.trackScreenViewed(.deckDetail)
+        }
+        .onDisappear {
+            // Popping back lands on the decks list, which is inside Settings and emits nothing of its
+            // own. Conditional, because this also fires for a tab switch away from an open deck
+            // detail, and naming Settings then would both record a view the user never had and hide
+            // their next real one behind the dedupe.
+            Analytics.trackScreenViewedOnDismiss(of: .deckDetail, restoring: .settings)
+        }
         .toolbar {
             if detailState?.allowsEditing == true {
                 ToolbarItem(placement: .topBarTrailing) {


### PR DESCRIPTION
The second of three clients. Events are an `enum` with typed associated values mirroring the backend's frozen catalog — a typo or an undeclared property does not compile, and there is no `track(name:properties:)` anywhere. Ten of the eleven client events have call sites; the app has no public catalog, so `catalog_deck_install_started` has nothing to fire from.

Events queue in their own SQLite file under Application Support, separate from the product database so a flush never contends with sync. `track()` is synchronous, non-throwing, and hands off to a detached task — nothing on a tap path awaits it.

New Swift files land through the synchronized root group, so `project.pbxproj` is untouched by design.

## Queued events never cross an identity boundary

A row is deliverable only while its stored `anonymous_id` matches the current one. `reset()` rotates the id **synchronously and flushes it to disk** before the queue sweep is even scheduled, and `loadNextBatch` purges mismatched rows in the same call that produces a batch — so a batch cannot be obtained without the purge having run.

It is failure-closed in both directions: a failed delete leaves rows carrying an id the selection no longer matches, and a failed purge throws and produces no batch at all. Nothing in memory is load-bearing, so a process death between logout and the sweep cannot deliver the outgoing person's events under the next credential — which the server would attribute to the wrong `user_id` permanently, with `analytics.identity_links` resolving first-wins and no repair path.

`reset()` reaches every path that ends an identity, including `switchCloudServer` — which points the app at a different backend, so queued events would otherwise have been posted to another server under a new identity.

## Release-gate runs no longer pollute production

Analytics is disabled for UI-test launches, so the grouped live smoke suite (which signs into a real account) and the marketing screenshot runs stop writing synthetic `app_opened` / `screen_viewed` / `review_session_*` rows into the append-only `product_events`. A consequence worth knowing: re-verifying the wire format cannot go through the XCUITest harness any more — it needs a plain manual simulator launch.

## Verification

Six review rounds, each by a reviewer that had not written or fixed the patch; the last two returned no findings at any severity. No unit tests, per this repository's testing philosophy.

The authorized simulator run exercised the whole path against **production** and returned `{"accepted":6,"rejected":[]}` and `{"accepted":2,"rejected":[]}` — an empty `rejected` array is the real pass condition, since a fully rejected batch also answers `200`. Observed on the wire: every `eventId` with `7` at string index 14, every timestamp ending in `Z`, `screen` as a top-level field, `experimentAssignments` null. The first batch carried events queued by the previous process, which also demonstrated durability across restarts.

That run found three defects static review would very likely have missed: SQLite rejects `rowid` in an index expression, so the store failed to open on first launch and every event was lost; `review_session_ended` reported `answered_count: 0` because answers were counted when the async submission settled rather than at the tap; and a false `review_session_ended` fired 400 ms after start from the empty state flashing while a rebuilt queue settled.

**Before you submit to TestFlight:** the App Store Connect privacy questionnaire lives outside this repository and currently says the app collects nothing. `PrivacyInfo.xcprivacy` now declares `ProductInteraction` and `DeviceID`, both linked and non-tracking, and the questionnaire needs the matching answers or the two disagree. Separately, introducing `NSPrivacyCollectedDataTypes` at all arguably makes the manifest read as exhaustive, and the rest of the binary also collects an email address at sign-in and user content through sync — completing that declaration is an app-wide compliance decision, not an analytics one.

## Accepted residuals

- App prewarming: whether iOS posts `didEnterBackgroundNotification` for a launch that begins in the background could not be established from the repository. If it does, one user-visible open could record both a cold and a warm event. The code comment says exactly that rather than asserting either way; it needs a device-level check.
- Two iPad windows both showing the review screen share one process-wide session tracker, so the second window's appearance is a no-op. That is inherent to modelling a review session per person rather than per window, which is what `duration_ms` and `answered_count` describe.
- `reset()` clears the identity, the queue, the drop counts and the sync-failure gate, but not the surface tracker — so the first `screen_viewed` after a logout for the screen the user is already standing on is deduped away.
- Two sync surfaces emit nothing on failure: pre-transport failures, and workspace-switch / guest-upgrade / AI-run syncs. Widening `sync_failed` to cover them would change its meaning relative to web and Android, so it is a cross-client decision rather than an iOS fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)