### PR TITLE
Measure signed-out web visitors with a lazy guest session

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -388,7 +388,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0115_product_analytics_resolved_view.sql
+            --require-migration 0116_guest_session_web_platform.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,8 +71,8 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0115_product_analytics_resolved_view.sql",
-    expectedMigrationCount: 117,
+    migrationFileName: "0116_guest_session_web_platform.sql",
+    expectedMigrationCount: 118,
     testFiles: Object.freeze([
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/catalog/distribution/install/install.postgres.integration.ts",

--- a/apps/backend/src/chat/http/dependencies.ts
+++ b/apps/backend/src/chat/http/dependencies.ts
@@ -1,4 +1,5 @@
 import type { AuthTransport } from "../../auth";
+import { assertGuestPlatformSupportsSurface } from "../../guestAuth/webPlatform";
 import { HttpError } from "../../shared/errors";
 import {
   loadRequestContextFromRequest,
@@ -61,18 +62,23 @@ export type ChatRouteDependencies = Readonly<{
 
 /**
  * Restricts the backend-owned chat surface to human-facing auth transports.
+ *
+ * `guest` here means a native guest session. The web guest platform is refused, and this repeats the
+ * default-deny gate in `server/requestContext.ts` on purpose: chat is the guest surface that spends
+ * money — every run bills against `auth.guest_ai_monthly_usage` — while the web guest token sits in
+ * `localStorage` where the visitor and any script on the page can read it.
  */
 function assertSupportedTransport(requestContext: RequestContext): void {
   const supportedTransports = new Set<AuthTransport>(["bearer", "session", "guest"]);
-  if (supportedTransports.has(requestContext.transport)) {
-    return;
+  if (supportedTransports.has(requestContext.transport) === false) {
+    throw new HttpError(
+      403,
+      "This endpoint requires Bearer, session, or guest authentication.",
+      "AI_CHAT_V2_HUMAN_AUTH_REQUIRED",
+    );
   }
 
-  throw new HttpError(
-    403,
-    "This endpoint requires Bearer, session, or guest authentication.",
-    "AI_CHAT_V2_HUMAN_AUTH_REQUIRED",
-  );
+  assertGuestPlatformSupportsSurface(requestContext.guestPlatform);
 }
 
 export function createChatRouteDependencies(options: ChatRoutesOptions): ChatRouteDependencies {

--- a/apps/backend/src/chat/live/request.ts
+++ b/apps/backend/src/chat/live/request.ts
@@ -1,4 +1,5 @@
 import { authenticateRequest, type AuthResult } from "../../auth";
+import { assertGuestPlatformSupportsSurface } from "../../guestAuth/webPlatform";
 import { HttpError } from "../../shared/errors";
 import {
   ensureCognitoUserProfile,
@@ -150,6 +151,11 @@ export async function handleLiveRequest(
     authorizationHeader: effectiveAuth,
     sessionToken: undefined,
   });
+  // The live stream Lambda authenticates on its own path instead of building a request context, so
+  // the default-deny gate in server/requestContext.ts does not cover it. A web guest cannot start a
+  // chat run, but that is an argument the refusal upstream is working, not a reason to accept its
+  // token here.
+  assertGuestPlatformSupportsSurface(authResult.guestPlatform);
 
   const userProfile: UserProfile | null = authResult.transport === "api_key"
     ? null

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0115_product_analytics_resolved_view.sql",
+      RequiredMigration: "0116_guest_session_web_platform.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0115_product_analytics_resolved_view.sql",
+    requiredMigration: "0116_guest_session_web_platform.sql",
   });
 });
 

--- a/apps/backend/src/guestAuth/types.ts
+++ b/apps/backend/src/guestAuth/types.ts
@@ -1,4 +1,11 @@
-export type GuestSessionPlatform = "ios" | "android";
+/**
+ * Platform bound to a guest session. `ios` and `android` guest sessions own an offline workspace and
+ * can be upgraded into an account. `web` is deliberately narrower: it exists only so a signed-out
+ * browser can authenticate an analytics batch against an endpoint that always requires a credential.
+ * `guestAuth/webPlatform.ts` is the single gate that enforces that, refused by default on every
+ * authenticated surface and opted into only by analytics ingest.
+ */
+export type GuestSessionPlatform = "ios" | "android" | "web";
 
 export type GuestUpgradeMode = "bound" | "merge_required";
 

--- a/apps/backend/src/guestAuth/upgrade/index.ts
+++ b/apps/backend/src/guestAuth/upgrade/index.ts
@@ -40,7 +40,12 @@ import {
   type GuestSessionRecord,
 } from "../store/index";
 import { hashGuestToken } from "../shared";
+import {
+  assertGuestPlatformSupportsSurface,
+  webGuestUpgradeRefusal,
+} from "../webPlatform";
 import type {
+  GuestSessionPlatform,
   GuestUpgradeCompleteCapabilities,
   GuestUpgradeCompletion,
   GuestUpgradePreparation,
@@ -67,6 +72,21 @@ function createGuestWorkspaceNotDrainedError(): HttpError {
 
 function createGuestUpgradeAccountRequiredError(): HttpError {
   return new HttpError(409, "Create or sign in to the destination account first.", "GUEST_UPGRADE_ACCOUNT_REQUIRED");
+}
+
+/**
+ * A web guest session is an analytics credential and nothing else, and this whole module is shaped
+ * around the mobile flow — it merges a synced guest workspace, records upgrade history and rekeys
+ * replicas — so feeding a web guest token to it is not a supported path.
+ *
+ * Both upgrade routes take the guest token from the request body rather than from the credential on
+ * the request, so the default-deny gate in `server/requestContext.ts` cannot see this platform. The
+ * invariant is enforced here instead, where the session record is loaded, rather than left resting
+ * on the absence of a web caller. `null` stays accepted through the shared helper: pre-1.7.0
+ * iOS/Android guest sessions are created unbound and are upgraded through this path today.
+ */
+function assertGuestUpgradeSupportedPlatform(platform: GuestSessionPlatform | null): void {
+  assertGuestPlatformSupportsSurface(platform, webGuestUpgradeRefusal);
 }
 
 function toUniqueSortedUserIds(userIds: ReadonlyArray<string>): Array<string> {
@@ -341,6 +361,7 @@ export async function prepareGuestUpgradeInExecutor(
   await lockCognitoIdentityLifecycleInExecutor(executor, cognitoSubject);
   await assertSubjectIsNotDeletedInExecutor(executor, cognitoSubject);
   const guestSession = await loadGuestSessionWithUserSettingsLockInExecutor(executor, guestToken);
+  assertGuestUpgradeSupportedPlatform(guestSession.platform);
   const existingMapping = await loadCognitoIdentityMappingInExecutor(executor, cognitoSubject);
 
   if (existingMapping !== null) {
@@ -410,6 +431,8 @@ export async function completeGuestUpgradeInExecutor(
       capabilities,
     );
   }
+
+  assertGuestUpgradeSupportedPlatform(unlockedGuestSession.platform);
 
   // Phase 2: resolve the mapped target user.
   const targetMapping = await loadCognitoIdentityMappingInExecutor(executor, cognitoSubject);

--- a/apps/backend/src/guestAuth/webPlatform.ts
+++ b/apps/backend/src/guestAuth/webPlatform.ts
@@ -1,0 +1,56 @@
+import { HttpError } from "../shared/errors";
+import type { GuestSessionPlatform } from "./types";
+
+/**
+ * The one place that decides what a `web` guest platform may reach.
+ *
+ * A web guest session is an analytics credential and nothing more. It is minted by a signed-out
+ * browser on its first interaction and kept in `localStorage`, where the visitor and any script on
+ * the page can read it, so it must not authenticate anything that spends money, writes product data
+ * or exposes an account surface. `ios` and `android` guest sessions are the opposite: they own an
+ * offline workspace, sync it and can be upgraded into an account.
+ *
+ * Only the literal `"web"` is refused. Inverting this into an `ios`/`android` allowlist would also
+ * refuse `null`, which is what pre-1.7.0 iOS and Android guest sessions still carry, and would take
+ * every guest surface away from those shipped clients.
+ *
+ * `guestPlatform` is non-null only for the guest transport — every other transport reports `null` in
+ * `auth/index.ts` — so a platform check alone is a complete test and no transport argument is needed.
+ */
+export type WebGuestRefusal = Readonly<{
+  message: string;
+  code: string;
+}>;
+
+/**
+ * The refusal for the default-deny gate in `server/requestContext.ts`, which every authenticated
+ * HTTP surface passes through.
+ */
+export const webGuestSurfaceRefusal: WebGuestRefusal = {
+  message: "Web guest sessions can only send product analytics. Sign in to use this endpoint.",
+  code: "GUEST_WEB_PLATFORM_UNSUPPORTED",
+};
+
+/**
+ * The refusal for guest upgrade, which is reached with a token from the request body rather than
+ * from the request context and so cannot go through the gate above.
+ */
+export const webGuestUpgradeRefusal: WebGuestRefusal = {
+  message: "Web guest sessions cannot be upgraded. Sign in on the web app instead.",
+  code: "GUEST_UPGRADE_WEB_PLATFORM_UNSUPPORTED",
+};
+
+export function isWebGuestSessionPlatform(platform: GuestSessionPlatform | null): boolean {
+  return platform === "web";
+}
+
+export function assertGuestPlatformSupportsSurface(
+  platform: GuestSessionPlatform | null,
+  refusal: WebGuestRefusal = webGuestSurfaceRefusal,
+): void {
+  if (isWebGuestSessionPlatform(platform) === false) {
+    return;
+  }
+
+  throw new HttpError(403, refusal.message, refusal.code);
+}

--- a/apps/backend/src/routes/guestAuth.test.ts
+++ b/apps/backend/src/routes/guestAuth.test.ts
@@ -149,12 +149,12 @@ test("POST /guest-auth/session creates a platform-bound native guest session", a
   });
 });
 
-test("POST /guest-auth/session rejects web guest sessions", async () => {
-  let createCalls = 0;
+test("POST /guest-auth/session creates a platform-bound web guest session", async () => {
+  let receivedPlatform: GuestSessionPlatform | null | undefined;
   const app = createGuestAuthTestApp({
     authResult: createAuthResult("none"),
     onCreateGuestSession: async (platform) => {
-      createCalls += 1;
+      receivedPlatform = platform;
       return createGuestSessionSnapshot(platform);
     },
   });
@@ -167,12 +167,12 @@ test("POST /guest-auth/session rejects web guest sessions", async () => {
     body: JSON.stringify({ platform: "web" }),
   });
 
-  assert.equal(response.status, 403);
-  assert.equal(createCalls, 0);
+  assert.equal(response.status, 200);
+  assert.equal(receivedPlatform, "web");
   assert.deepEqual(await response.json(), {
-    error: "Guest web sessions are not supported. Sign in before using cloud sync on the web app.",
-    requestId: "request-1",
-    code: "GUEST_WEB_SESSION_UNSUPPORTED",
+    guestToken: "guest-token-create-route",
+    userId: "guest-user-create-route",
+    workspaceId: "guest-workspace-create-route",
   });
 });
 

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -68,23 +68,17 @@ function parseGuestSessionPlatformValue(value: unknown): GuestSessionPlatform | 
   }
 
   if (typeof value !== "string") {
-    throw new HttpError(400, "platform must be ios or android", "GUEST_SESSION_PLATFORM_INVALID");
+    throw new HttpError(400, "platform must be ios, android, or web", "GUEST_SESSION_PLATFORM_INVALID");
   }
 
+  // A web guest session is an analytics credential and nothing more: guest sync stays refused for it
+  // in routes/sync/guestPlatform.ts, so issuing one never opens cloud sync to a signed-out browser.
   const platform = value.trim();
-  if (platform === "ios" || platform === "android") {
+  if (platform === "ios" || platform === "android" || platform === "web") {
     return platform;
   }
 
-  if (platform === "web") {
-    throw new HttpError(
-      403,
-      "Guest web sessions are not supported. Sign in before using cloud sync on the web app.",
-      "GUEST_WEB_SESSION_UNSUPPORTED",
-    );
-  }
-
-  throw new HttpError(400, "platform must be ios or android", "GUEST_SESSION_PLATFORM_INVALID");
+  throw new HttpError(400, "platform must be ios, android, or web", "GUEST_SESSION_PLATFORM_INVALID");
 }
 
 async function parseGuestSessionCreatePlatform(request: Request): Promise<GuestSessionPlatform | null> {

--- a/apps/backend/src/routes/productAnalytics.ts
+++ b/apps/backend/src/routes/productAnalytics.ts
@@ -693,7 +693,14 @@ export function createProductAnalyticsRoutes(options: ProductAnalyticsRoutesOpti
     let rows: ReadonlyArray<ProductAnalyticsEventRow> = [];
 
     try {
-      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      // The one surface a `web` guest credential may reach. Everywhere else the default-deny gate in
+      // server/requestContext.ts refuses it, which is what keeps a token every signed-out visitor
+      // holds in localStorage from reaching AI quota, sync, or any account surface.
+      const loadedContext = await loadRequestContextFromRequestFn(
+        context.req.raw,
+        options.allowedOrigins,
+        { allowWebGuestPlatform: true },
+      );
       requestContext = loadedContext.requestContext;
       assertProductAnalyticsTransport(loadedContext.requestContext);
 

--- a/apps/backend/src/routes/sync/guestPlatform.ts
+++ b/apps/backend/src/routes/sync/guestPlatform.ts
@@ -4,6 +4,14 @@ import { HttpError } from "../../shared/errors";
 
 export type SyncClientPlatform = "ios" | "android" | "web";
 
+/**
+ * Returns the guest platform that may sync, from the platform the client declares on the request.
+ *
+ * A guest session actually bound to `web` never reaches this file: the default-deny gate in
+ * `server/requestContext.ts` refuses that credential on every surface but analytics ingest. What
+ * this still refuses is the other half — a native guest token presented with `web` as the declared
+ * sync platform — which is why the mapping stays.
+ */
 export function toGuestSessionPlatform(platform: SyncClientPlatform): GuestSessionPlatform | null {
   if (platform === "ios" || platform === "android") {
     return platform;

--- a/apps/backend/src/server/requestContext.ts
+++ b/apps/backend/src/server/requestContext.ts
@@ -5,6 +5,7 @@ import {
   type AuthTransport,
 } from "../auth";
 import type { GuestSessionPlatform } from "../guestAuth/types";
+import { assertGuestPlatformSupportsSurface } from "../guestAuth/webPlatform";
 import { isDeletedSubject } from "../auth/deletedSubjects";
 import { HttpError } from "../shared/errors";
 import {
@@ -38,6 +39,18 @@ export type RequestContext = Readonly<{
   connectionId: string | null;
   guestSessionId: string | null;
   guestPlatform: GuestSessionPlatform | null;
+}>;
+
+/**
+ * Per-surface guest policy. Every authenticated HTTP route in this service builds its context here,
+ * so this is the one place a `web` guest credential can be admitted or refused for all of them at
+ * once, rather than through a transport check repeated in each route that happens to remember it.
+ *
+ * Default-deny: a surface that says nothing refuses `web`. The analytics ingest route is the only
+ * caller that opts in, because a web guest session exists solely to authenticate its batches.
+ */
+export type LoadRequestContextOptions = Readonly<{
+  allowWebGuestPlatform?: boolean;
 }>;
 
 export type WorkspaceRequestContext = Readonly<{
@@ -95,12 +108,14 @@ export function getAllowedOrigins(): Array<string> {
 export async function loadRequestContextWithDependencies(
   requestAuthInputs: RequestAuthInputs,
   dependencies: LoadRequestContextDependencies,
+  options: LoadRequestContextOptions = {},
 ): Promise<RequestContext> {
   const auth = await dependencies.authenticateRequestFn(toAuthRequest(requestAuthInputs));
   return loadAuthenticatedRequestContext(
     auth,
     dependencies,
     () => {},
+    options,
   );
 }
 
@@ -112,8 +127,16 @@ async function loadAuthenticatedRequestContext(
     ensureUserProfileFn: typeof ensureUserProfile;
   }>,
   assertRequestActive: () => void,
+  options: LoadRequestContextOptions,
 ): Promise<RequestContext> {
   assertRequestActive();
+  // Before the deleted-subject read and the profile write below, so a refused web guest costs
+  // nothing and leaves nothing behind. This is the choke point every guest request context is minted
+  // through, which is what makes the refusal hold for routes nobody has written yet.
+  if (options.allowWebGuestPlatform !== true) {
+    assertGuestPlatformSupportsSurface(auth.guestPlatform);
+  }
+
   const subjectUserId = auth.subjectUserId;
   if (auth.transport !== "none") {
     const deleted = await dependencies.isDeletedSubjectFn(subjectUserId);
@@ -149,6 +172,7 @@ export async function loadRequestContextWithAbortSignalAndDependencies(
   requestAuthInputs: RequestAuthInputs,
   abortSignal: AbortSignal,
   dependencies: LoadRequestContextWithAbortSignalDependencies,
+  options: LoadRequestContextOptions = {},
 ): Promise<RequestContext> {
   abortSignal.throwIfAborted();
   const auth = await dependencies.authenticateRequestWithAbortSignalFn(
@@ -160,23 +184,26 @@ export async function loadRequestContextWithAbortSignalAndDependencies(
     auth,
     dependencies,
     () => abortSignal.throwIfAborted(),
+    options,
   );
 }
 
 export async function loadRequestContext(
   requestAuthInputs: RequestAuthInputs,
+  options: LoadRequestContextOptions = {},
 ): Promise<RequestContext> {
   return loadRequestContextWithDependencies(requestAuthInputs, {
     authenticateRequestFn: authenticateRequest,
     isDeletedSubjectFn: isDeletedSubject,
     ensureCognitoUserProfileFn: ensureCognitoUserProfile,
     ensureUserProfileFn: ensureUserProfile,
-  });
+  }, options);
 }
 
 export async function loadRequestContextWithAbortSignal(
   requestAuthInputs: RequestAuthInputs,
   abortSignal: AbortSignal,
+  options: LoadRequestContextOptions = {},
 ): Promise<RequestContext> {
   return loadRequestContextWithAbortSignalAndDependencies(
     requestAuthInputs,
@@ -188,18 +215,20 @@ export async function loadRequestContextWithAbortSignal(
       ensureCognitoUserProfileFn: ensureCognitoUserProfile,
       ensureUserProfileFn: ensureUserProfile,
     },
+    options,
   );
 }
 
 export async function loadRequestContextFromRequest(
   request: Request,
   allowedOrigins: ReadonlyArray<string>,
+  options: LoadRequestContextOptions = {},
 ): Promise<Readonly<{
   requestAuthInputs: RequestAuthInputs;
   requestContext: RequestContext;
 }>> {
   const requestAuthInputs = extractRequestAuthInputs(request);
-  const requestContext = await loadRequestContext(requestAuthInputs);
+  const requestContext = await loadRequestContext(requestAuthInputs, options);
 
   if (requestContext.transport === "session") {
     await enforceSessionCsrfProtection(request.method, requestAuthInputs, allowedOrigins);
@@ -215,6 +244,7 @@ export async function loadRequestContextFromRequestWithAbortSignal(
   request: Request,
   allowedOrigins: ReadonlyArray<string>,
   abortSignal: AbortSignal,
+  options: LoadRequestContextOptions = {},
 ): Promise<Readonly<{
   requestAuthInputs: RequestAuthInputs;
   requestContext: RequestContext;
@@ -224,6 +254,7 @@ export async function loadRequestContextFromRequestWithAbortSignal(
   const requestContext = await loadRequestContextWithAbortSignal(
     requestAuthInputs,
     abortSignal,
+    options,
   );
   abortSignal.throwIfAborted();
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { AccountMenu } from "./AccountMenu";
 import { AccountDeletionRecoveryGate } from "./accountDeletionRecovery";
 import { AnalyticsLifecycle } from "./analytics";
 import { AppDataProvider, useAppData } from "./appData";
+import { WebGuestSessionLifecycle } from "./appData/session/guest/WebGuestSessionLifecycle";
 import { AppErrorDialogProvider } from "./appError/AppErrorContext";
 import { buildLoginUrl, buildLogoutUrl } from "./api";
 import { ChatDraftProvider } from "./chat/composer/drafts/ChatDraftContext";
@@ -791,6 +792,7 @@ export default function App(): ReactElement {
     <AppErrorBoundary fallback={<AppCrashFallback />}>
       <BrowserRouter>
         <AnalyticsLifecycle />
+        <WebGuestSessionLifecycle />
         <AppErrorDialogProvider>
           <TestModeProvider>
             <SentryRoutes>

--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -3,6 +3,7 @@ import {
   getCachedSessionCsrfToken,
   sendAnalyticsEventsBatch,
   type AnalyticsIngestResult,
+  type AnalyticsRequestCredential,
 } from "../api";
 import {
   analyticsCatalogSlugPattern,
@@ -93,6 +94,18 @@ let remainingFlushRequestCount = 0;
  * rather than trusted to be cleared in the right order: nothing ships until they name one person.
  */
 let confirmedOwnerId: string | null = null;
+/**
+ * The credential the confirmed owner authenticates with. It is published together with the owner and
+ * starts null, so nothing can ship before a credential has actually been named: a session batch also
+ * needs the browser's CSRF token loaded, while a guest batch carries its own token.
+ */
+let confirmedOwnerCredential: AnalyticsRequestCredential | null = null;
+/**
+ * The guest identity issued to this browser, if any. It grants nothing and is never a credential
+ * here: it only tells a guest signing in — the same person on the same install — apart from a switch
+ * between two accounts, which the queue owner change alone cannot distinguish.
+ */
+let guestOwnerId: string | null = null;
 /**
  * Cleared the moment a new owner is published, set again only once the queue's stored owner has been
  * reconciled with it. It never widens what may be sent — the stored-owner comparison in `runFlush` is
@@ -282,6 +295,7 @@ async function handleDeliveryFailure(
   error: unknown,
   events: ReadonlyArray<QueuedAnalyticsEvent>,
   flushGeneration: number,
+  credential: AnalyticsRequestCredential,
 ): Promise<void> {
   // The queue these events came from has been discarded. Nothing here may purge from, count against,
   // or arm a backoff for the identity that replaced it.
@@ -308,8 +322,8 @@ async function handleDeliveryFailure(
     }
 
     const midpoint = Math.ceil(events.length / 2);
-    await deliverBatch(events.slice(0, midpoint), flushGeneration);
-    await deliverBatch(events.slice(midpoint), flushGeneration);
+    await deliverBatch(events.slice(0, midpoint), flushGeneration, credential);
+    await deliverBatch(events.slice(midpoint), flushGeneration, credential);
     return;
   }
 
@@ -329,15 +343,38 @@ async function handleDeliveryFailure(
   scheduleFlush(delayMs);
 }
 
+/**
+ * The credential a batch may go out with right now, or null while there is none. Failure-closed: a
+ * session owner without a loaded CSRF token would be refused with 403 on every batch, and no owner
+ * at all means no credential exists yet.
+ */
+function readSendableOwnerCredential(): AnalyticsRequestCredential | null {
+  const credential = confirmedOwnerCredential;
+  if (credential === null) {
+    return null;
+  }
+
+  // The guest token authenticates its own request, so the session CSRF model — which the backend
+  // derives from the session cookie and enforces only for the session transport — does not apply.
+  if (credential.kind === "guest") {
+    return credential;
+  }
+
+  return getCachedSessionCsrfToken() === null ? null : credential;
+}
+
 async function deliverBatch(
   events: ReadonlyArray<QueuedAnalyticsEvent>,
   flushGeneration: number,
+  credential: AnalyticsRequestCredential,
 ): Promise<void> {
   // Rechecked synchronously immediately before the batch is built, and nothing between this line and
   // the request may await: `buildWireBatch` reads the current `anonymousId`, so a `reset()` landing
   // in the queue round trips above would otherwise ship the previous account's events under the next
   // account's id. The server resolves `analytics.identity_links` first-link-wins on an append-only
-  // table, so that merge of two people is permanent and has no repair path.
+  // table, so that merge of two people is permanent and has no repair path. The same check covers
+  // the credential carried in: every owner change bumps the generation, so one that landed after the
+  // credential was read stops this batch instead of letting it out on the previous identity's token.
   if (flushGeneration !== analyticsGeneration) {
     return;
   }
@@ -358,9 +395,9 @@ async function deliverBatch(
 
   let result: AnalyticsIngestResult;
   try {
-    result = await sendAnalyticsEventsBatch(buildWireBatch(events));
+    result = await sendAnalyticsEventsBatch(buildWireBatch(events), credential);
   } catch (error) {
-    await handleDeliveryFailure(error, events, flushGeneration);
+    await handleDeliveryFailure(error, events, flushGeneration, credential);
     return;
   }
 
@@ -416,12 +453,13 @@ async function runFlush(): Promise<void> {
     // events, so this is a comparison of two recorded facts rather than an assumption about when the
     // session layer's cleanup happens to run. Refusing here only holds events back: they stay in the
     // queue under the 14-day TTL and ship on a later load that does confirm an owner.
+    const credential = readSendableOwnerCredential();
     if (
       queued.events.length === 0
       || confirmedOwnerId === null
       || isQueueOwnerReconciled === false
       || queued.ownerId !== confirmedOwnerId
-      || getCachedSessionCsrfToken() === null
+      || credential === null
     ) {
       return;
     }
@@ -429,7 +467,7 @@ async function runFlush(): Promise<void> {
     hasDeliveredInFlush = false;
     remainingFlushRequestCount = flushRequestBudget;
     const sendableEvents = takeLeadingSessionRun(queued.events);
-    await deliverBatch(sendableEvents, flushGeneration);
+    await deliverBatch(sendableEvents, flushGeneration, credential);
     // More events are waiting either because the read filled the batch limit, or because a session
     // boundary cut the sent run short. Both drain immediately: a backlog that crossed several
     // sessions would otherwise advance by one session run per periodic timer tick.
@@ -458,7 +496,27 @@ function claimQueueOwner(userId: string): void {
     try {
       const claim = await claimAnalyticsQueueOwner(userId);
       if (claim.didReplaceForeignOwner) {
-        resetAnalyticsIdentity();
+        // The events are gone either way — the claim emptied the queue — and only the identity
+        // behind them is decided here. A guest issued on this browser and then signed in is one
+        // person on one install, so that one case keeps `anonymous_id` and every other replaced
+        // owner is somebody else and rotates it. An unreadable guest identity leaves `guestOwnerId`
+        // null and rotates, which undercounts rather than risking a merge of two people.
+        //
+        // What keeping it buys is exactly one thing: `analytics.product_events` then carries the
+        // same raw `anonymous_id` on the guest's tail and on the account's rows, so the two sides
+        // can be joined directly on that column. It does not resolve the guest into the account in
+        // `analytics.product_events_resolved`, and this item does not deliver that. A guest batch
+        // writes no identity link at all (`routes/productAnalytics.ts` derives one only for the
+        // bearer and session transports), and the `authenticated_client` link the account writes
+        // later joins `first_anonymous_link`, which sits third in the `actor_id` COALESCE and so
+        // only reaches rows whose `user_id` is NULL. Guest rows carry the guest user id, so their
+        // `actor_id` keeps naming the guest. Only a `server_derived` link on `subject_user_id`
+        // redirects them, and that is written solely by the guest-upgrade machinery, which the web
+        // app deliberately never calls.
+        if (claim.replacedOwnerId === null || claim.replacedOwnerId !== guestOwnerId) {
+          resetAnalyticsIdentity();
+        }
+
         if (claim.discardedEventCount > 0) {
           reportAnalyticsQueueDiscardedOnReset(claim.discardedEventCount);
         }
@@ -479,13 +537,42 @@ function claimQueueOwner(userId: string): void {
 }
 
 /**
- * Publishes the account the current credential belongs to. Call it wherever the session layer has
- * verified a session; publishing late only delays delivery, and never publishing at all only holds
- * events in the queue for the next page load, because nothing is sent until a published owner and the
- * queue's stored owner name the same person.
+ * Records the guest identity this browser holds, without confirming it as an owner and without
+ * granting it anything. Publish it on every load, before any owner is confirmed: it is the only way
+ * a later owner change can tell a guest signing in apart from a switch between two accounts, and
+ * that distinction decides whether `anonymous_id` survives the boundary.
  */
-export function setAnalyticsConfirmedOwner(userId: string): void {
+export function setAnalyticsGuestOwnerId(nextGuestOwnerId: string | null): void {
+  guestOwnerId = nextGuestOwnerId;
+}
+
+/**
+ * Publishes the identity the current credential belongs to, and the credential it authenticates
+ * with. Call it wherever the session layer has verified a session, or wherever a guest session has
+ * been issued to this browser; publishing late only delays delivery, and never publishing at all
+ * only holds events in the queue for the next page load, because nothing is sent until a published
+ * owner and the queue's stored owner name the same person.
+ *
+ * A guest identity may never displace a confirmed account, and that rule lives here rather than in
+ * the caller that asks for the guest session. The two publishes genuinely race on an ordinary
+ * returning-user boot: the guest path only sees the absence of a session, which is also what a
+ * signed-in person whose token has expired but is still refreshable looks like, while the session
+ * layer refreshes and publishes the account. This function is last-writer-wins, so a guest landing
+ * second would take over the account's queue — discarding its events, rotating `anonymous_id`, and
+ * storing the rest of that page load under the guest user id on an append-only table with no repair
+ * path. Refusing the demotion here holds for every ordering and every future caller. The reverse is
+ * allowed on purpose: an account signing in after a guest is a real promotion, and `reset()` clears
+ * the credential at every identity boundary so a later guest can publish again.
+ */
+export function setAnalyticsConfirmedOwner(
+  userId: string,
+  credential: AnalyticsRequestCredential,
+): void {
   try {
+    if (credential.kind === "guest" && confirmedOwnerCredential?.kind === "session") {
+      return;
+    }
+
     if (confirmedOwnerId === userId) {
       return;
     }
@@ -493,6 +580,7 @@ export function setAnalyticsConfirmedOwner(userId: string): void {
     // Shuts the gate and invalidates any flush already in flight before the claim can touch a
     // record: work started under the previous owner may no longer send or purge from here.
     confirmedOwnerId = userId;
+    confirmedOwnerCredential = credential;
     isQueueOwnerReconciled = false;
     analyticsGeneration += 1;
     consecutiveFailureCount = 0;
@@ -614,8 +702,12 @@ export function reset(): void {
   try {
     // The stored queue owner is released with the events: the next account confirmed on this browser
     // then adopts an empty queue instead of inheriting one, and until one is confirmed the gate in
-    // `runFlush` refuses to send at all.
+    // `runFlush` refuses to send at all. The guest identity goes with it, because a logout is the one
+    // boundary where the person leaving may have been the guest: keeping it would let the next
+    // account on this browser inherit the previous person's `anonymous_id`.
     confirmedOwnerId = null;
+    confirmedOwnerCredential = null;
+    guestOwnerId = null;
     isQueueOwnerReconciled = false;
     discardQueuedWork(true, true);
     resetAnalyticsIdentity();

--- a/apps/web/src/analytics/index.ts
+++ b/apps/web/src/analytics/index.ts
@@ -2,6 +2,7 @@ export {
   flush,
   reset,
   setAnalyticsConfirmedOwner,
+  setAnalyticsGuestOwnerId,
   setEnabled,
   track,
   trackCatalogDeckInstallStarted,

--- a/apps/web/src/analytics/queue.ts
+++ b/apps/web/src/analytics/queue.ts
@@ -49,6 +49,12 @@ export type AnalyticsQueueOwnerClaim = Readonly<{
   /** The queue held another account's events; they were discarded by the claim. */
   didReplaceForeignOwner: boolean;
   discardedEventCount: number;
+  /**
+   * The owner the claim replaced, or `null` when the queue was unclaimed. The caller needs the
+   * identity behind it, not only the fact that it changed: a guest issued on this browser and then
+   * signed in is the same person, while any other replaced owner is a different one.
+   */
+  replacedOwnerId: string | null;
 }>;
 
 type AnalyticsQueueTotals = {
@@ -368,7 +374,11 @@ export function claimAnalyticsQueueOwner(ownerId: string): Promise<AnalyticsQueu
       // An unclaimed queue holds events created before any credential existed. Those belong to the
       // account signing in now, so it adopts them rather than discarding them.
       if (storedOwnerId === null || storedOwnerId === ownerId) {
-        resolveResult({ didReplaceForeignOwner: false, discardedEventCount: 0 });
+        resolveResult({
+          didReplaceForeignOwner: false,
+          discardedEventCount: 0,
+          replacedOwnerId: storedOwnerId,
+        });
         return;
       }
 
@@ -377,7 +387,11 @@ export function claimAnalyticsQueueOwner(ownerId: string): Promise<AnalyticsQueu
         const discardedEventCount = toTotals(totalsRequest.result).eventCount;
         eventsStore.clear();
         metaStore.put(createEmptyTotals());
-        resolveResult({ didReplaceForeignOwner: true, discardedEventCount });
+        resolveResult({
+          didReplaceForeignOwner: true,
+          discardedEventCount,
+          replacedOwnerId: storedOwnerId,
+        });
       };
     };
   });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -29,7 +29,14 @@ export {
 } from "./api/endpoints/analytics";
 export type {
   AnalyticsIngestResult,
+  AnalyticsRequestCredential,
 } from "./api/endpoints/analytics";
+export {
+  createWebGuestSession,
+} from "./api/endpoints/guestAuth";
+export type {
+  WebGuestSessionEnvelope,
+} from "./apiContracts/guestAuth";
 export {
   queryCards,
 } from "./api/endpoints/cards";

--- a/apps/web/src/api/endpoints/analytics.ts
+++ b/apps/web/src/api/endpoints/analytics.ts
@@ -1,11 +1,20 @@
 import type { AnalyticsWireBatch } from "../../analytics/events";
 import { webAppVersion } from "../../clientIdentity";
-import { requestJson, type RequestOptions } from "../transport/transport";
+import { requestGuestJson, requestJson, type RequestOptions } from "../transport/transport";
 
 export type AnalyticsIngestResult = Readonly<{
   acceptedCount: number;
   rejectedCount: number;
 }>;
+
+/**
+ * Which credential a batch is authenticated with. The ingest endpoint always requires one, and it
+ * accepts both: a signed-in browser posts on its shared session cookie, and a signed-out visitor who
+ * has interacted posts on the guest token issued for this browser.
+ */
+export type AnalyticsRequestCredential =
+  | Readonly<{ kind: "session" }>
+  | Readonly<{ kind: "guest"; guestToken: string }>;
 
 /**
  * Analytics runs entirely in the background, so it never joins auth recovery: a batch that meets an
@@ -35,15 +44,21 @@ function readRejectedCount(value: unknown): number {
  * `X-Client-Platform` and `X-Client-Version` are the only source of the append-only `platform` and
  * `app_version` columns, and this repository sets them per endpoint rather than globally.
  */
-export async function sendAnalyticsEventsBatch(batch: AnalyticsWireBatch): Promise<AnalyticsIngestResult> {
-  const payload = await requestJson("/analytics/events", {
+export async function sendAnalyticsEventsBatch(
+  batch: AnalyticsWireBatch,
+  credential: AnalyticsRequestCredential,
+): Promise<AnalyticsIngestResult> {
+  const requestInit: RequestInit = {
     method: "POST",
     headers: {
       "X-Client-Platform": "web",
       "X-Client-Version": webAppVersion,
     },
     body: JSON.stringify(batch),
-  }, analyticsRequestOptions);
+  };
+  const payload = credential.kind === "guest"
+    ? await requestGuestJson("/analytics/events", requestInit, credential.guestToken, analyticsRequestOptions)
+    : await requestJson("/analytics/events", requestInit, analyticsRequestOptions);
 
   if (typeof payload.value !== "object" || payload.value === null || Array.isArray(payload.value)) {
     return { acceptedCount: 0, rejectedCount: 0 };

--- a/apps/web/src/api/endpoints/guestAuth.ts
+++ b/apps/web/src/api/endpoints/guestAuth.ts
@@ -1,0 +1,44 @@
+import {
+  parseWebGuestSessionResponse,
+  type WebGuestSessionEnvelope,
+} from "../../apiContracts/guestAuth";
+import { parseContractResponse } from "../transport/response";
+import { requestGuestJson, skipAuthRecoveryWithoutNetworkRetry } from "../transport/transport";
+
+/**
+ * Budget for the single attempt this call makes. Without it a hung fetch never settles and the
+ * caller's one attempt for this page load is parked in flight for the rest of it, measuring nothing.
+ * Long enough that an ordinary slow network still succeeds, because a request that times out may
+ * have created the server-side rows anyway and a later interaction that retries then mints a second
+ * set nothing will ever read.
+ */
+const createWebGuestSessionTimeoutMs = 10 * 1000;
+
+/**
+ * Creates a guest session bound to the web platform.
+ *
+ * The request carries no credential of its own, so it goes out through the guest transport rather
+ * than the session one: the session pipeline loads `/me` first to obtain a CSRF token, which a
+ * signed-out browser has no way to get. Auth recovery is skipped for the same reason — a signed-out
+ * visitor must never be redirected to sign in because analytics wanted an identity.
+ *
+ * It is also sent exactly once, never retried. The route has no idempotency key: every call writes a
+ * guest user, a workspace, a membership and the session row, and nothing removes them. A connection
+ * dropped after the server committed is indistinguishable from one dropped before it, so a transient
+ * retry mints a second permanent set of rows from one interaction — the same failure the timeout
+ * above exists to bound, reached by a different route. Not creating the rows is always the cheaper
+ * mistake here, and it costs nothing durable: `webGuestSession.ts` re-arms after its own retry delay,
+ * so a genuinely transient failure gets another chance from the next interaction, and the events
+ * wait in the local queue under their 14-day TTL until it does.
+ */
+export async function createWebGuestSession(): Promise<WebGuestSessionEnvelope> {
+  return parseContractResponse(
+    await requestGuestJson("/guest-auth/session", {
+      method: "POST",
+      body: JSON.stringify({ platform: "web" }),
+      signal: AbortSignal.timeout(createWebGuestSessionTimeoutMs),
+    }, null, skipAuthRecoveryWithoutNetworkRetry),
+    "POST /guest-auth/session",
+    parseWebGuestSessionResponse,
+  );
+}

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -201,6 +201,14 @@ export const allowAuthRecoveryWithTransientNetworkRetry: RequestOptions = {
 
 export const skipAuthRecoveryWithTransientNetworkRetry: RequestOptions = createSkipAuthRecoveryOptions("transient");
 
+/**
+ * For a request that must not be repeated. A dropped connection tells the client nothing about
+ * whether the server acted, so retrying a write with no idempotency key can produce a second
+ * permanent effect from a single caller attempt. Such a call fails on the first network error and
+ * leaves retrying to whoever knows it is safe.
+ */
+export const skipAuthRecoveryWithoutNetworkRetry: RequestOptions = createSkipAuthRecoveryOptions("none");
+
 function createSkipAuthRecoveryOptions(networkRetryMode: NetworkRetryMode): RequestOptions {
   return {
     authRecoveryMode: "skip",
@@ -287,12 +295,18 @@ function buildSanitizedRequestEndpoint(pathname: string, init: RequestInit): str
   return `${getMethod(init)} ${sanitizeRequestPath(pathname)}`;
 }
 
-function createHeaders(init: RequestInit): Headers {
+function createBaseHeaders(init: RequestInit): Headers {
   const headers = new Headers(init.headers);
 
   if (init.body !== undefined && !headers.has("Content-Type") && !(init.body instanceof FormData)) {
     headers.set("Content-Type", "application/json");
   }
+
+  return headers;
+}
+
+function createHeaders(init: RequestInit): Headers {
+  const headers = createBaseHeaders(init);
 
   if (isUnsafeMethod(getMethod(init))) {
     if (sessionCsrfState === "unknown") {
@@ -408,6 +422,33 @@ async function performFetch(
     return await fetch(`${config.apiBaseUrl}${pathname}`, {
       ...init,
       credentials,
+      headers,
+    });
+  } catch (error) {
+    throwIfRequestAborted(init.signal ?? null);
+    throw createFetchApiNetworkError(pathname, init, error, attemptCount);
+  }
+}
+
+async function performGuestFetch(
+  pathname: string,
+  init: RequestInit,
+  guestToken: string | null,
+  attemptCount: number,
+): Promise<Response> {
+  const config = getAppConfig();
+  const headers = createBaseHeaders(init);
+  if (guestToken !== null) {
+    headers.set("Authorization", `Guest ${guestToken}`);
+  }
+
+  try {
+    // "omit" keeps the guest token the only credential on the request. A session cookie riding along
+    // would be ignored by the backend, which reads the Authorization header first, but leaving the
+    // request with exactly one credential is what makes the identity it is attributed to obvious.
+    return await fetch(`${config.apiBaseUrl}${pathname}`, {
+      ...init,
+      credentials: "omit",
       headers,
     });
   } catch (error) {
@@ -900,6 +941,43 @@ export async function requestPublicJson(pathname: string): Promise<ParsedRespons
     const endpoint = buildSanitizedRequestEndpoint(pathname, requestInit);
     return await performWithNetworkRetry(endpoint, requestInit, options, async (attemptCount: number) => {
       const response = await performFetch(pathname, requestInit, "omit", attemptCount);
+      return parseJsonPayload(
+        response,
+        buildRequestEndpoint(pathname, requestInit),
+        {
+          attemptCount,
+          endpoint,
+        },
+      );
+    });
+  } finally {
+    disposeRequestSignal();
+  }
+}
+
+/**
+ * Sends one request authenticated by a guest token instead of the shared browser session.
+ *
+ * The guest token is the whole credential, so the session cookie is deliberately not attached and
+ * the session CSRF token — which the backend derives from that cookie — does not apply. This mirrors
+ * `apps/backend/src/auth/requestSecurity.ts`, where `enforceSessionCsrfProtection` runs only for the
+ * session transport: a header the browser has to be told to send is not an ambient credential a
+ * cross-site page could ride on. It is the same shared pipeline as every other call — same base URL,
+ * same network retry, same error parsing — rather than a second token mechanism beside it.
+ *
+ * `guestToken` is null only when creating the guest session itself, which carries no credential yet.
+ */
+export async function requestGuestJson(
+  pathname: string,
+  init: RequestInit,
+  guestToken: string | null,
+  options: RequestOptions,
+): Promise<ParsedResponsePayload> {
+  const { requestInit, dispose: disposeRequestSignal } = attachRecoverySignal(init);
+  try {
+    const endpoint = buildSanitizedRequestEndpoint(pathname, requestInit);
+    return await performWithNetworkRetry(endpoint, requestInit, options, async (attemptCount: number) => {
+      const response = await performGuestFetch(pathname, requestInit, guestToken, attemptCount);
       return parseJsonPayload(
         response,
         buildRequestEndpoint(pathname, requestInit),

--- a/apps/web/src/apiContracts/guestAuth.ts
+++ b/apps/web/src/apiContracts/guestAuth.ts
@@ -1,0 +1,27 @@
+import { parseObject, parseRequiredField, parseString } from "./core";
+
+/**
+ * The web guest session, reduced to the two fields the browser uses: the token that authenticates an
+ * analytics batch, and the guest user id the analytics queue records as its owner.
+ *
+ * Creating one is not free on the server: it writes a guest user, an auto-created workspace and its
+ * membership, and nothing removes them. The workspace id the backend returns is deliberately ignored
+ * here — the backend refuses the web guest platform on every authenticated surface but analytics
+ * ingest, so the browser never reads or writes that workspace, it is never surfaced in the app, and
+ * this identity can never become a cloud-sync account. It is an analytics credential that happens to
+ * arrive with rows attached, which is why the browser mints one only on a real interaction and only
+ * when it can remember it afterwards.
+ */
+export type WebGuestSessionEnvelope = Readonly<{
+  guestToken: string;
+  userId: string;
+}>;
+
+export function parseWebGuestSessionResponse(value: unknown, endpoint: string): WebGuestSessionEnvelope {
+  const objectValue = parseObject(value, endpoint, "");
+
+  return {
+    guestToken: parseRequiredField(objectValue, "guestToken", endpoint, "", parseString),
+    userId: parseRequiredField(objectValue, "userId", endpoint, "", parseString),
+  };
+}

--- a/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
@@ -24,6 +24,7 @@ import {
 import {
   buildLinkedCloudSettings,
 } from "../cloud/workspaceSessionCloud";
+import { resetWebGuestSession } from "../guest/webGuestSession";
 import {
   defaultWorkspaceName,
 } from "./workspaceActivationHelpers";
@@ -86,6 +87,11 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     // events on the new account's credential. The discarded events are counted and reported inside
     // `reset()`.
     resetAnalytics();
+    // Removed here, synchronously, rather than by the `flashcards-` prefix sweep inside
+    // `clearAllLocalBrowserData` below: that sweep is several awaits away and does not run at all
+    // when the IndexedDB recovery guard fires first, and a stored guest session left readable in
+    // that window would be published as the confirmed analytics owner by the next interaction.
+    resetWebGuestSession();
     workspaceBootstrapGenerationRef.current += 1;
     deferredBootstrapWorkspaceRef.current = null;
     setSession(null);

--- a/apps/web/src/appData/session/guest/WebGuestSessionLifecycle.tsx
+++ b/apps/web/src/appData/session/guest/WebGuestSessionLifecycle.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import {
+  registerWebGuestOwnerForAnalytics,
+  requestWebGuestSessionOnInteraction,
+} from "./webGuestSession";
+
+/**
+ * Watches for the first real interaction on any surface a signed-out visitor can reach, and asks for
+ * a guest session then — never on a page view.
+ *
+ * That boundary is what keeps crawlers and pure readers out of `auth.guest_sessions`. A crawler
+ * renders the page and dispatches no pointer or keyboard events at all, and `isTrusted` additionally
+ * excludes anything page script synthesises. Someone who lands on a public deck or invite page,
+ * reads it and leaves never activates a control either: scrolling, hovering and selecting text all
+ * fail the check, so neither creates a server-side user.
+ */
+const interactiveElementSelector = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "label",
+  "[role=\"button\"]",
+  "[role=\"link\"]",
+  "[role=\"menuitem\"]",
+  "[role=\"tab\"]",
+  "[role=\"switch\"]",
+  "[contenteditable=\"true\"]",
+  "[tabindex]:not([tabindex=\"-1\"])",
+].join(", ");
+
+function isRealInteraction(event: Event): boolean {
+  if (event.isTrusted === false) {
+    return false;
+  }
+
+  const target = event.target;
+  if (target instanceof Element === false) {
+    return false;
+  }
+
+  return target.closest(interactiveElementSelector) !== null;
+}
+
+export function WebGuestSessionLifecycle(): null {
+  useEffect(() => {
+    // Registered before the session layer can confirm an account owner, so a sign-in that follows an
+    // earlier guest visit is recognised as the same person continuing on this browser.
+    registerWebGuestOwnerForAnalytics();
+  }, []);
+
+  useEffect(() => {
+    function handleInteraction(event: Event): void {
+      if (isRealInteraction(event)) {
+        requestWebGuestSessionOnInteraction();
+      }
+    }
+
+    // Capture phase and passive: this observes the interaction and never participates in it, so a
+    // handler that stops propagation cannot hide a real activation, and nothing here can delay the
+    // action the person is performing.
+    const listenerOptions: AddEventListenerOptions = { capture: true, passive: true };
+    document.addEventListener("pointerdown", handleInteraction, listenerOptions);
+    document.addEventListener("keydown", handleInteraction, listenerOptions);
+    return (): void => {
+      document.removeEventListener("pointerdown", handleInteraction, listenerOptions);
+      document.removeEventListener("keydown", handleInteraction, listenerOptions);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/appData/session/guest/webGuestSession.ts
+++ b/apps/web/src/appData/session/guest/webGuestSession.ts
@@ -1,0 +1,356 @@
+import {
+  createWebGuestSession,
+  getCachedSessionCsrfToken,
+  getOptionalSession,
+  type WebGuestSessionEnvelope,
+} from "../../../api";
+import { setAnalyticsConfirmedOwner, setAnalyticsGuestOwnerId } from "../../../analytics";
+import { readStoredAnalyticsEnabled } from "../../../analytics/identity";
+import { hasLoggedInCookie } from "../activation/warmStart";
+
+/**
+ * The signed-out browser's identity for product analytics, and nothing else.
+ *
+ * The ingest endpoint always requires a credential, so a visitor who never signs in cannot be
+ * measured at all without one. This module obtains that credential lazily, on the first real
+ * interaction, never on a page view: creating a guest session writes a user row and a workspace on
+ * the server, so a page-view trigger would mint one for every crawler that renders the public
+ * catalog, invite and share pages.
+ *
+ * The token is kept in `localStorage`, where the visitor and any script on the page can read it, so
+ * it grants nothing beyond measurement. `apps/backend/src/guestAuth/webPlatform.ts` refuses the web
+ * guest platform by default on every authenticated backend surface — sync, chat and its AI quota,
+ * guest upgrade, every account surface — and analytics ingest is the only route that opts in.
+ *
+ * The stored session is deliberately not cleared when the person signs in. It is the record that
+ * lets the analytics client recognise, on the next page load, that the queue's previous owner was
+ * this browser's own guest rather than a different account — which is what keeps `anonymous_id`
+ * alive across the sign-in, so the guest's tail and the account's rows carry the same raw
+ * `anonymous_id` in `analytics.product_events` and can be joined on it. It does not resolve the
+ * guest into the account in `analytics.product_events_resolved`; `analytics/client.ts` documents
+ * why, at the rotation exception that decides it.
+ *
+ * Every real identity boundary drops it: `resetWebGuestSession` removes it synchronously alongside
+ * the analytics reset, and the key also carries the `flashcards-` prefix that
+ * `clearAllLocalBrowserData` wipes on logout, account deletion, and a confirmed account switch.
+ */
+
+const guestSessionStorageKey = "flashcards-web-guest-session";
+/** Carries the `flashcards-` prefix too, so a probe left behind by a crash is swept like the rest. */
+const guestSessionStorageProbeKey = "flashcards-web-guest-session-probe";
+
+/** A failed attempt must not turn a click-happy visitor into a burst of session requests. */
+const guestSessionRetryDelayMs = 30 * 1000;
+
+type WebGuestSessionState = "idle" | "requesting" | "settled";
+
+let state: WebGuestSessionState = "idle";
+let retryNotBeforeMs = 0;
+/**
+ * Bumped by every identity boundary. A request captures it before it starts, so work that began
+ * before the boundary can neither store nor publish the identity it obtained under the person who
+ * has since left.
+ */
+let identityGeneration = 0;
+/**
+ * How many session layers are mounted right now. The session layer is the only thing that publishes
+ * a confirmed account owner for the analytics queue, and it is mounted only under the authenticated
+ * app shell: the public catalog, invite and share routes render without it. So while this is above
+ * zero an account owner can still arrive on this page load, and while it is zero none can.
+ */
+let sessionOwnerPublisherCount = 0;
+
+/**
+ * Announces the session layer for as long as it is mounted, and returns the release.
+ *
+ * It exists so the `logged_in` cookie can be read as "an account may still claim this load" rather
+ * than as "an account owns this browser". The cookie carries a 35-day max-age and the auth service
+ * clears it only when a refresh is actually attempted and fails, so on the public routes — where no
+ * refresh ever runs — treating the cookie on its own as a reason to stay silent would leave a
+ * visitor who signed in once unmeasured for weeks on exactly the signed-out funnel this module
+ * exists to cover. Pairing it with a mounted session layer keeps the protection where an account
+ * can actually be raced and drops it where none can.
+ */
+export function registerWebSessionOwnerPublisher(): () => void {
+  sessionOwnerPublisherCount += 1;
+  let isReleased = false;
+  return (): void => {
+    // A double release would decrement the count below the publishers that are still mounted, and
+    // this guard fails closed: the count only ever over-reports, never under-reports.
+    if (isReleased) {
+      return;
+    }
+
+    isReleased = true;
+    sessionOwnerPublisherCount -= 1;
+  };
+}
+
+/**
+ * Whether an account owner can still be published on this page load and this browser says one
+ * exists, in which case the guest identity stands down for the rest of the load.
+ *
+ * `getOptionalSession()` cannot answer this on its own: it deliberately does not refresh, so a
+ * signed-in person whose access token has expired but is still refreshable answers 401 there and
+ * looks signed out. A click landing in that window would let the guest claim the analytics queue
+ * ahead of the account — discarding what the account had queued and rotating its `anonymous_id`,
+ * neither of which has a repair path. Where no session layer is mounted the same cookie says only
+ * that this visitor signed in at some point, and they are measured as the signed-out visitor they
+ * are right now.
+ */
+function shouldDeferToBrowserSessionOwner(): boolean {
+  return sessionOwnerPublisherCount > 0 && hasLoggedInCookie();
+}
+
+function readBrowserStorageItem(storageKey: string): string | null {
+  try {
+    return window.localStorage.getItem(storageKey);
+  } catch {
+    // Storage is unusable in a few real configurations (Safari private browsing, storage disabled by
+    // policy). Analytics must never surface that to the user; the visitor simply stays unmeasured.
+    return null;
+  }
+}
+
+function writeBrowserStorageItem(storageKey: string, value: string): void {
+  try {
+    window.localStorage.setItem(storageKey, value);
+  } catch {
+    // The session still works for this page load; it just will not be reused on the next one.
+  }
+}
+
+function removeBrowserStorageItem(storageKey: string): void {
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // Nothing readable is left behind either: the same store is what a read would have failed on.
+  }
+}
+
+/**
+ * Whether a guest session obtained now could actually be remembered.
+ *
+ * Creating one is not a local operation: the backend writes a user row, a workspace, a membership
+ * and the guest session itself, and nothing deletes them. Where `localStorage` is unusable — blocked
+ * by policy or setting, some embedded webviews — the stored-session guard can never match, so every
+ * page load would mint another permanent set of rows, for a visitor who cannot persist an
+ * `anonymous_id` or an IndexedDB queue and therefore produces no measurement to pay for them.
+ *
+ * The probe writes and reads back rather than only writing: a store that accepts a write and keeps
+ * nothing fails exactly the same way as one that throws.
+ */
+function canPersistWebGuestSession(): boolean {
+  try {
+    window.localStorage.setItem(guestSessionStorageProbeKey, "1");
+    const didPersist = window.localStorage.getItem(guestSessionStorageProbeKey) === "1";
+    window.localStorage.removeItem(guestSessionStorageProbeKey);
+    return didPersist;
+  } catch {
+    return false;
+  }
+}
+
+function toWebGuestSession(value: unknown): WebGuestSessionEnvelope | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const { guestToken, userId } = value as Readonly<{ guestToken?: unknown; userId?: unknown }>;
+  if (
+    typeof guestToken !== "string"
+    || guestToken.trim() === ""
+    || typeof userId !== "string"
+    || userId.trim() === ""
+  ) {
+    return null;
+  }
+
+  return { guestToken, userId };
+}
+
+function readStoredWebGuestSession(): WebGuestSessionEnvelope | null {
+  const storedValue = readBrowserStorageItem(guestSessionStorageKey);
+  if (storedValue === null) {
+    return null;
+  }
+
+  try {
+    return toWebGuestSession(JSON.parse(storedValue) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tells the analytics client which guest identity this browser holds. It confirms no owner and sends
+ * nothing; it only lets a later sign-in be recognised as this guest continuing rather than a second
+ * person arriving. Call it on every load, before the session layer can confirm an account owner.
+ */
+export function registerWebGuestOwnerForAnalytics(): void {
+  try {
+    setAnalyticsGuestOwnerId(readStoredWebGuestSession()?.userId ?? null);
+  } catch {
+    // Leaving it unregistered only costs the `anonymous_id` continuity at a later sign-in, which
+    // undercounts rather than attributing one person's history to another.
+  }
+}
+
+/**
+ * Whether the session layer already owns the analytics identity on this browser. Synchronous and
+ * cheap on purpose, so it can be re-read immediately before a publish: the cached CSRF token is set
+ * by the same `/me` load the session layer confirms its owner from, and it is only ever cached for
+ * the session transport.
+ */
+function hasVerifiedBrowserSession(): boolean {
+  return getCachedSessionCsrfToken() !== null;
+}
+
+function publishWebGuestOwner(guestSession: WebGuestSessionEnvelope): void {
+  // Re-checked synchronously here, immediately before the publish, rather than only at the top of
+  // `resolveWebGuestSession`: awaits sit between the two, and the session layer both mounts and
+  // verifies the browser session on its own schedule. This narrows the window; it does not close it.
+  // What closes it is `setAnalyticsConfirmedOwner` refusing to let a guest replace a session owner
+  // at all.
+  if (hasVerifiedBrowserSession() || shouldDeferToBrowserSessionOwner()) {
+    return;
+  }
+
+  setAnalyticsGuestOwnerId(guestSession.userId);
+  setAnalyticsConfirmedOwner(guestSession.userId, {
+    kind: "guest",
+    guestToken: guestSession.guestToken,
+  });
+}
+
+async function resolveWebGuestSession(requestGeneration: number): Promise<void> {
+  // The kill switch is an explicit opt-out, and a guest session writes a user row on the server.
+  // Nothing about an opted-out visitor may reach the backend, so this stops before the identity is
+  // requested rather than only holding the events back.
+  if (readStoredAnalyticsEnabled() === false) {
+    return;
+  }
+
+  // A verified browser session means the session layer owns the analytics identity. A guest
+  // credential must never compete with it, and the cached CSRF token is the cheap half of the check:
+  // inside the app shell it is already loaded, so a signed-in person's click costs no request.
+  if (hasVerifiedBrowserSession()) {
+    return;
+  }
+
+  // A mounted session layer is about to publish an account owner for this browser, and `logged_in`
+  // is this browser's own statement that an account owns it. Standing down on that pair is what
+  // keeps a guest out of the refresh window; standing down on the cookie alone is what would leave
+  // the public routes unmeasured, so the two are only ever checked together.
+  if (shouldDeferToBrowserSessionOwner()) {
+    return;
+  }
+
+  if (await getOptionalSession() !== null) {
+    return;
+  }
+
+  // The only await in this module that had no generation check after it. A boundary landing inside
+  // it used to fall straight through to `createWebGuestSession()` and mint a permanent server-side
+  // guest user, workspace and membership for nobody, which the check below the request then threw
+  // away.
+  if (requestGeneration !== identityGeneration) {
+    return;
+  }
+
+  // Re-checked after the await as well, because the interaction that started this may itself be the
+  // click that leaves a public route for the app shell: the session layer mounts while `/me` is in
+  // flight, and from that moment an account owner is still coming on this load.
+  if (shouldDeferToBrowserSessionOwner()) {
+    return;
+  }
+
+  const storedGuestSession = readStoredWebGuestSession();
+  if (storedGuestSession !== null) {
+    publishWebGuestOwner(storedGuestSession);
+    return;
+  }
+
+  // Nothing is minted that this browser could not recognise again on its next load. Giving up rather
+  // than retrying is the point: every retry would be another permanent set of server rows.
+  if (canPersistWebGuestSession() === false) {
+    return;
+  }
+
+  const guestSession = await createWebGuestSession();
+  // An identity boundary crossed while the request was in flight. This guest belongs to nobody on
+  // this browser now, so it is neither stored nor published; the next interaction starts over.
+  if (requestGeneration !== identityGeneration) {
+    return;
+  }
+
+  writeBrowserStorageItem(guestSessionStorageKey, JSON.stringify(guestSession));
+  publishWebGuestOwner(guestSession);
+}
+
+/**
+ * Drops this browser's guest identity at an identity boundary.
+ *
+ * Synchronous, and called next to `reset()` in the analytics client rather than left to the
+ * `flashcards-` prefix sweep in `clearAllLocalBrowserData`. That sweep runs several awaits later and
+ * is skipped entirely when the IndexedDB recovery guard fires first, and until the key is gone an
+ * interaction inside that window would read the outgoing person's guest session back out of storage
+ * and publish it as the confirmed owner for the rest of the page load.
+ *
+ * The module state goes back to idle with it: this browser now holds no guest identity, so a later
+ * interaction by a signed-out visitor may obtain a fresh one, exactly as it would on a new load.
+ */
+export function resetWebGuestSession(): void {
+  try {
+    identityGeneration += 1;
+    state = "idle";
+    retryNotBeforeMs = 0;
+    removeBrowserStorageItem(guestSessionStorageKey);
+  } catch {
+    // Identity-boundary cleanup must not fail because the guest record could not be removed.
+  }
+}
+
+/**
+ * Obtains and publishes the guest identity, at most once per browser load and once more after each
+ * identity boundary. Returns immediately: the request runs in the background, because no user action
+ * may be blocked, delayed, or failed by anything analytics needs.
+ *
+ * Settling once per load is the bound that keeps server-side rows finite, and it is kept even though
+ * it has a cost: if the published identity is invalidated later in the same load — the session
+ * deleted server-side, say — nothing here tries again, and the rest of that load goes unmeasured.
+ * That is the accepted side of the trade. Re-arming on invalidation would put minting back on a path
+ * a repeating failure can drive, and every mint is a permanent guest user, workspace and membership.
+ * Only a real failure re-arms, once per `guestSessionRetryDelayMs`.
+ */
+export function requestWebGuestSessionOnInteraction(): void {
+  try {
+    if (state !== "idle" || Date.now() < retryNotBeforeMs) {
+      return;
+    }
+
+    state = "requesting";
+    const requestGeneration = identityGeneration;
+    void resolveWebGuestSession(requestGeneration).then((): void => {
+      // An identity boundary already put this module back to idle for whoever is here now; a
+      // finished request from before it may not settle the state on their behalf.
+      if (requestGeneration !== identityGeneration) {
+        return;
+      }
+
+      state = "settled";
+    }).catch((): void => {
+      // Offline, throttled, or refused: the events stay queued under their 14-day TTL and a later
+      // interaction tries again. Nothing here is reported — the request the server refused is
+      // already visible to the server.
+      if (requestGeneration !== identityGeneration) {
+        return;
+      }
+
+      state = "idle";
+      retryNotBeforeMs = Date.now() + guestSessionRetryDelayMs;
+    });
+  } catch {
+    // Nothing on the interaction path may surface as an uncaught error.
+  }
+}

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -31,6 +31,7 @@ import {
   buildLinkingReadyCloudSettings,
   resolveLocalDataCleanupReasonForVerifiedSession,
 } from "../cloud/workspaceSessionCloud";
+import { registerWebSessionOwnerPublisher } from "../guest/webGuestSession";
 import {
   createSessionAccountSwitchError,
   hasLoggedOutMarker,
@@ -243,7 +244,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       // account it was filled under, so this is what lets analytics compare the two and either ship
       // or discard; until it is published nothing is sent, which is why it is only reached once the
       // session is verified and any user-scoped cleanup has already run.
-      setAnalyticsConfirmedOwner(currentSession.userId);
+      setAnalyticsConfirmedOwner(currentSession.userId, { kind: "session" });
       setSessionVerificationState("verified");
     } catch (error) {
       const normalizedError = normalizeCaughtError(error);
@@ -308,6 +309,16 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     initializeRef.current = initialize;
   }, [initialize]);
 
+  // Announces, for as long as this layer is mounted, that an account owner can still be published on
+  // this page load. The web guest identity stands down while that holds and the browser's own
+  // `logged_in` cookie names an account, so an interaction during a session refresh cannot let a
+  // guest claim the analytics queue ahead of the account that is about to arrive. The public
+  // catalog, invite and share routes mount no session layer, and a signed-out visitor there is
+  // measured as one instead of being silenced by a cookie nothing on those routes will ever clear.
+  useEffect(() => {
+    return registerWebSessionOwnerPublisher();
+  }, []);
+
   useEffect(() => {
     void initializeRef.current();
   }, []);
@@ -349,7 +360,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             return false;
           }
 
-          setAnalyticsConfirmedOwner(currentSession.userId);
+          setAnalyticsConfirmedOwner(currentSession.userId, { kind: "session" });
           setSessionVerificationState("verified");
           setSessionErrorMessage("");
           setErrorMessage("");

--- a/db/migrations/0116_guest_session_web_platform.sql
+++ b/db/migrations/0116_guest_session_web_platform.sql
@@ -1,0 +1,56 @@
+-- Migration status: Current / additive.
+-- Introduces: web as an accepted auth.guest_sessions.platform value, so a signed-out browser can
+--   hold a guest credential for the analytics ingest endpoint, which always requires authentication.
+--   A web guest identity exists for measurement only and never carries an offline workspace. It is
+--   refused by default on every authenticated surface through apps/backend/src/guestAuth/
+--   webPlatform.ts, which the request-context loader applies to every route; analytics ingest is the
+--   only caller that opts in.
+-- Schemas touched/read explicitly: auth, pg_catalog.
+
+-- 0055 added the column with an inline CHECK, so the constraint carries the name PostgreSQL derived
+-- rather than one this repository chose. Dropping the CHECK by shape instead of by name keeps a name
+-- that differs from the derived default from silently leaving the old two-value constraint in place
+-- beside the new one, which would reject every web guest session in production.
+--
+-- The shape is pinned to conkey, the single platform column, rather than to a definition that merely
+-- mentions the column. This file is immutable once merged and replays in order on every fresh
+-- database, so a later migration's multi-column check that happens to reference platform must not be
+-- dropped by this one on that replay.
+DO $$
+DECLARE
+  platform_attnum smallint;
+  platform_constraint RECORD;
+BEGIN
+  SELECT attnum INTO STRICT platform_attnum
+  FROM pg_catalog.pg_attribute
+  WHERE attrelid = 'auth.guest_sessions'::regclass
+    AND attname = 'platform'
+    AND attnum > 0
+    AND NOT attisdropped;
+
+  FOR platform_constraint IN
+    SELECT conname
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'auth.guest_sessions'::regclass
+      AND contype = 'c'
+      AND conkey = ARRAY[platform_attnum]
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE auth.guest_sessions DROP CONSTRAINT %I',
+      platform_constraint.conname
+    );
+  END LOOP;
+END
+$$;
+
+ALTER TABLE auth.guest_sessions
+  ADD CONSTRAINT guest_sessions_platform_check
+  CHECK (platform IN ('ios', 'android', 'web'));
+
+COMMENT ON COLUMN auth.guest_sessions.platform IS
+  'Client platform bound to the guest session. ios and android guest sessions own an offline '
+  'workspace and can be upgraded into an account; web guest sessions exist only so a signed-out '
+  'browser can authenticate an analytics batch, and every other authenticated surface refuses '
+  'them. NULL is kept '
+  'only for pre-1.7.0 iOS/Android clients that create guest sessions without platform; remove this '
+  'legacy unbound path after those mobile versions are no longer supported.';

--- a/docs/auth-service.md
+++ b/docs/auth-service.md
@@ -3,6 +3,21 @@
 Email + OTP authentication via AWS Cognito (passwordless).
 
 - `AUTH_MODE`: `none` (local dev, no auth) or `cognito` (verify JWT from `Authorization: Bearer`)
+- Guest sessions (`POST /v1/guest-auth/session`) are bound to `ios`, `android`, or `web`. A `web`
+  guest session is an analytics credential only: the browser requests one lazily on a signed-out
+  visitor's first real interaction and sends it as `Authorization: Guest <token>` to
+  `POST /v1/analytics/events` alone.
+  - `apps/backend/src/guestAuth/webPlatform.ts` is the single gate. Every authenticated route builds
+    its context through `loadRequestContextFromRequest`, which refuses a `web` guest platform with
+    `403 GUEST_WEB_PLATFORM_UNSUPPORTED` unless the route opts in; analytics ingest is the only
+    caller that does. The chat surface repeats the check because it spends AI quota, and the chat
+    live stream Lambda applies it on its own auth path.
+  - Guest upgrade takes the token from the request body, so it enforces the same rule against the
+    loaded session record and answers `403 GUEST_UPGRADE_WEB_PLATFORM_UNSUPPORTED`.
+  - Only the literal `web` is refused. A `null` platform is a pre-1.7.0 iOS/Android guest session and
+    keeps every guest surface it has today.
+  - `POST /v1/guest-auth/session` and `POST /v1/guest-auth/session/delete` stay open to it: they are
+    the credential's own lifecycle and authenticate outside the request-context loader.
 - Auth Lambda serves the auth UI/API on `auth.<domain>` and `/v1` execute-api stage paths
 - Backend Lambda verifies JWTs with `aws-jwt-verify`
 - Key files:

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0115_product_analytics_resolved_view.sql",
+    "0116_guest_session_web_platform.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0115_product_analytics_resolved_view.sql"
+    && resource.Properties?.RequiredMigration === "0116_guest_session_web_platform.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -98,7 +98,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
   for (const { relativePath, requiredMigration } of [
     {
       relativePath: "../../.github/workflows/aws-web-release.yml",
-      requiredMigration: "0115_product_analytics_resolved_view.sql",
+      requiredMigration: "0116_guest_session_web_platform.sql",
     },
     {
       relativePath: "../../scripts/deploy/bootstrap.sh",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -208,7 +208,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0115_product_analytics_resolved_view.sql",
+    "--require-migration 0116_guest_session_web_platform.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -238,7 +238,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0115_product_analytics_resolved_view\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0116_guest_session_web_platform\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -351,7 +351,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0115_product_analytics_resolved_view.sql",
+      "0116_guest_session_web_platform.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,


### PR DESCRIPTION
The last item of the product-analytics block. The analytics endpoint always requires authentication and the web app had no guest concept, so signed-out visitors on the public catalog, invite and share routes were invisible — which is the SEO funnel the whole feature was meant to measure.

## What issues a session, and what does not

The first **trusted** pointer or key event whose target `closest()`-matches an interactive control. A crawler renders the page and dispatches no such events; a reader who scrolls, hovers or selects text never matches, because those targets resolve to `body` or a paragraph. `isTrusted` additionally excludes anything page script synthesises.

Three further bounds keep server-side cost finite, which matters because minting writes a guest user, an auto-created workspace and a membership that nothing removes: it is once per browser, never when browser storage cannot persist the result, and never retried inside the transport.

That last one took three passes to get right — the same defect arrived by three routes. Unusable `localStorage` would have minted on every page load; a boundary landing inside an unguarded `await` would have minted rows for nobody; and a transient network retry on a non-idempotent POST would have minted a second set from one interaction.

## The migration

`0116` widens the platform constraint to allow `'web'`. It drops the previous constraint by **looking up the check on the platform column** rather than by a name PostgreSQL derived — a name mismatch on a blind `DROP CONSTRAINT IF EXISTS` would leave the old two-value constraint in place beside the new one and refuse every web guest session in production, silently. The lookup is pinned to the column's `attnum` rather than a text match, so a later check that merely mentions the column is not caught on a fresh-database replay.

## "Analytics credential only" is now enforced, not asserted

Review found that a `web` guest token also authenticated AI chat, billing against the guest AI quota — while the design asserted the opposite in four places including this migration, which becomes immutable on merge. Shipping a permanent claim the code contradicts is worse than the capability itself.

`loadAuthenticatedRequestContext` — the choke point every authenticated request context is minted through — now refuses a web guest platform by default, with the analytics ingest route as the only caller that opts in. A route added later is covered without remembering to be. The three surfaces that authenticate outside that loader are covered explicitly, and every guest-accepting backend surface was enumerated and classified.

Only the literal `"web"` is refused. A `null` platform is what guest sessions from clients before 1.7.0 still carry, and an allowlist would have taken AI away from those shipped apps.

## A guest can never displace an account

The analytics client refuses to replace a session owner with a guest one, evaluated on current state at the moment of the call, so no ordering defeats it. On routes where an account owner can still be published, the guest stands down entirely — keyed on whether the session layer is actually mounted, so public routes get zero deferral and the authenticated shell gets full protection.

A guest signing in keeps its `anonymous_id`, so the guest tail and the account rows carry the same value in `analytics.product_events` and join directly on that column. Note what that does **not** do: it does not resolve the guest into the account in `product_events_resolved`. A guest batch writes no identity link, and the account's link only reaches rows whose `user_id` is NULL. Making the tail resolve needs a `server_derived` link written on web sign-in — queued as a follow-up rather than bolted on here.

## Verification

Four review rounds, each by a reviewer that had not written or fixed the patch; the last two returned no findings. No unit tests, per this repository's testing philosophy.

Manual check after deploy, signed out in a clean profile on `/catalog/import/<published-version-id>`:

1. `/me` returns 401 and **no** `POST /v1/guest-auth/session` fires. Scroll and select text — still nothing.
2. Click any control. The guest session is created with `{"platform":"web"}`, and within about a second `POST /v1/analytics/events` fires with `Authorization: Guest …`, no cookie, no `X-CSRF-Token`, and both `X-Client-*` headers. Expect `200` with an **empty** `rejected` array.
3. `SELECT user_id, trust_level, platform FROM analytics.product_events ORDER BY server_received_at DESC LIMIT 5;` → `trust_level = 'guest_client'`, `platform = 'web'`.
4. Sign in from the same browser: `flashcards-analytics-anonymous-id` is unchanged and the next batch posts on the session cookie.
5. Negative: a web guest token must be refused by `/v1/sync/pull` and by `/v1/chat/*`.

## Accepted residuals

- No idempotency key on guest-session creation, so a request that times out after the server committed leaves rows nothing reads, and a later interaction mints another set. Closing it needs a column and a unique index — a follow-up.
- Nothing removes web guest users, workspaces or memberships. A reaper is a follow-up.
- A server-revoked guest token is never replaced. Unreachable today, and it should land with the reaper.
- `await getOptionalSession()` carries no timeout, unlike its sibling which does for the same reason, so a hung `/me` costs that page load its measurement.
- A returning visitor with unflushed account-owned events who interacts on a public route has them discarded when the guest claims. That is the contract's prefer-undercount-to-misattribution rule, and the loss is counted and reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)