### PR TITLE
Fix iOS progress dates across DST transitions

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
@@ -954,7 +954,7 @@ private func makeSnapshotProgressDailyReviews(
             throw LocalStoreError.validation("Progress date range could not be advanced")
         }
 
-        currentDate = nextDate
+        currentDate = calendar.startOfDay(for: nextDate)
     }
 
     return progressDays

--- a/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressDateSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressDateSupport.swift
@@ -727,7 +727,7 @@ func makeZeroFilledProgressDays(requestRange: ProgressRequestRange) throws -> [P
             throw LocalStoreError.validation("Progress date range could not be advanced")
         }
 
-        currentDate = nextDate
+        currentDate = calendar.startOfDay(for: nextDate)
     }
 
     return progressDays

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
@@ -694,7 +694,7 @@ private func makeProgressTimeline(
         guard let nextDate = calendar.date(byAdding: .day, value: 1, to: currentDate) else {
             throw ProgressPresentationError.invalidRange(series.from, series.to)
         }
-        currentDate = nextDate
+        currentDate = calendar.startOfDay(for: nextDate)
     }
 
     return timeline


### PR DESCRIPTION
## Summary
- re-anchor iOS progress day iteration at each local day boundary
- preserve the final day across midnight DST transitions in local fallback, presentation, and snapshot reconstruction
- keep existing validation and error behavior unchanged

## Validation
- not run locally per repository policy; cloud PR CI owns validation

## Issue
- FLASHCARDS-IOS-4H