### PR TITLE
Update monitoring owner references

### DIFF
--- a/apps/backend/src/observability/cloudWatch.ts
+++ b/apps/backend/src/observability/cloudWatch.ts
@@ -33,7 +33,8 @@ export function createCloudWatchRecord(
 // `infra/aws/lib/backend-lambda-logging.ts`, so the runtime nests this object under `message` and
 // the whole log event is a JSON document. That is what makes `$.message.<field>` resolvable for a
 // CloudWatch metric filter, which is what the log-derived alarms in `infra/aws/lib/monitoring.ts`
-// select on. A pre-serialized string leaves `message` a string and no field inside it addressable.
+// and `infra/aws/lib/product-analytics-monitoring.ts` select on. A pre-serialized string leaves
+// `message` a string and no field inside it addressable.
 //
 // One shape for every surface, with no branch on the runtime's log format: a branch would leave the
 // tests and the local server exercising an emission path that production never takes, and would

--- a/apps/backend/src/observability/sentry/config.ts
+++ b/apps/backend/src/observability/sentry/config.ts
@@ -179,8 +179,9 @@ function readBackendConsoleLogRecord(
  *
  * Those records are handed to `console` as objects rather than pre-serialized JSON
  * (../cloudWatch.ts), which is the only thing that makes `$.message.<field>` resolvable for the
- * log-derived metric filters in `infra/aws/lib/monitoring.ts`. The default `consoleIntegration`
- * turns every such call into a `category: "console"` breadcrumb, and inside a Lambda it builds that
+ * log-derived metric filters in `infra/aws/lib/monitoring.ts` and
+ * `infra/aws/lib/product-analytics-monitoring.ts`. The default `consoleIntegration` turns every such
+ * call into a `category: "console"` breadcrumb, and inside a Lambda it builds that
  * breadcrumb's `message` with `safeJoin`, not `util.format`: the pinned @sentry/core reaches
  * `util.format` only when `globalThis.util` exists, which is true under `node -e`, `node -p` and the
  * REPL and false in a loaded handler file. `safeJoin` renders any object as the constant

--- a/apps/backend/src/routes/productAnalytics.ts
+++ b/apps/backend/src/routes/productAnalytics.ts
@@ -543,9 +543,9 @@ function captureBatchViolation(
 // An occurred_at_out_of_window rejection means a device clock rather than a client off contract, so
 // the two are counted apart on the ingest record: the clock signal is routed to its own alarm and is
 // deliberately kept out of Sentry, while every other rejection reason is a broken client release.
-// infra/aws/lib/monitoring.ts alarms on the difference directly, so the record carries it as its own
-// field: a CloudWatch metric filter can read a field but cannot subtract one field from another, and
-// this is the only place that knows the two counts describe the same batch.
+// infra/aws/lib/product-analytics-monitoring.ts alarms on the difference directly, so the record
+// carries it as its own field: a CloudWatch metric filter can read a field but cannot subtract one
+// field from another, and this is the only place that knows the two counts describe the same batch.
 function countOutOfWindowRejections(
   rejected: ReadonlyArray<ProductAnalyticsRejectedEvent>,
 ): number {

--- a/docs/agent-sql-telemetry.md
+++ b/docs/agent-sql-telemetry.md
@@ -63,7 +63,7 @@ The function names are the `BackendFunctionName`, `McpFunctionName`, and
 to compare surfaces.
 
 Retention on the backend API group is owned by CDK, not by the console.
-`infra/aws/lib/monitoring.ts` reads `backendFn.logGroup` to attach the product
+`infra/aws/lib/product-analytics-monitoring.ts` reads `backendFn.logGroup` to attach the product
 analytics metric filters, which makes the stack declare that group's retention,
 and what it declares is never-expire. It is not re-asserted on every deploy:
 the retention is applied by a CloudFormation custom resource, and CloudFormation

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -1009,7 +1009,8 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
         // A per-method entry overrides the stage-wide `*/*` settings for this method instead of
         // merging with them, so metrics are restated here. Without it the method falls back to the
         // service default of no detailed metrics, and the analytics alarms in
-        // infra/aws/lib/monitoring.ts read exactly the per-method dimensions this enables.
+        // infra/aws/lib/product-analytics-monitoring.ts read exactly the per-method dimensions this
+        // enables.
         [productAnalyticsIngestMethodPath]: {
           metricsEnabled: true,
           throttlingRateLimit: productAnalyticsIngestThrottlingRateLimit,


### PR DESCRIPTION
## Summary
- point product analytics comments and docs at the extracted monitoring owner
- clarify that structured backend logs support filters in both monitoring modules
- keep the patch comment and documentation only

## Validation
- local project checks intentionally not run; cloud PR CI owns validation