### PR TITLE
Correct three stale claims in the backend Sentry breadcrumb restoration

### DIFF
--- a/apps/backend/src/observability/sentry/config.ts
+++ b/apps/backend/src/observability/sentry/config.ts
@@ -139,9 +139,8 @@ function createSentryIntegrations(): BackendSentryIntegrationFactory {
 
 // Recognizes one of this backend's own structured log records among the arguments of a console
 // breadcrumb. `domain: "backend"` is on every record this repository hands to `console` as an object
-// - the ones from ../cloudWatch.ts and ../../server/logging.ts, and the ones the direct image
-// ingestion and multipart reconciliation entrypoints build inline - and on nothing else, so this
-// matches exactly those calls and leaves every dependency's console output alone.
+// and on nothing else, so this matches exactly those calls and leaves every dependency's console
+// output alone.
 //
 // The console arguments are read from the hint, which is where Sentry documents them for this
 // category, and from the breadcrumb's own `data.arguments` when the hint carries none: the
@@ -205,9 +204,7 @@ function readBackendConsoleLogRecord(
  * breadcrumb the process produces, including ones from dependencies, and rewrites the message of
  * those that match the check above. What it puts there is what the pre-serialized string used to put
  * there - the same record, `JSON.stringify`d, already sanitized before it ever reached `console` -
- * so this restores a payload rather than introducing one. It is more than the same breadcrumb's
- * `data.arguments` carries, because the client's `normalizeDepth` of 3 drops the record's nested
- * `details` there.
+ * so this restores a payload rather than introducing one.
  */
 function restoreBackendConsoleBreadcrumbMessage(
   breadcrumb: BackendSentryBreadcrumb,
@@ -217,12 +214,12 @@ function restoreBackendConsoleBreadcrumbMessage(
     return breadcrumb;
   }
 
-  const record = readBackendConsoleLogRecord(breadcrumb, hint);
-  if (record === null) {
-    return breadcrumb;
-  }
-
   try {
+    const record = readBackendConsoleLogRecord(breadcrumb, hint);
+    if (record === null) {
+      return breadcrumb;
+    }
+
     return { ...breadcrumb, message: JSON.stringify(record) };
   } catch {
     return breadcrumb;


### PR DESCRIPTION
Three residuals recorded during review of the item that introduced the backend Sentry breadcrumb restoration.

- **False docstring.** It claimed the restored message carries more than the breadcrumb's own `data.arguments` because the client's `normalizeDepth` of 3 drops the record's nested `details`. No emitter produces a `details` key at all — `createCloudWatchRecord` spreads the event's details *flat* into the record. The sentence named something that does not exist, so it is deleted rather than rewritten.
- **Narrow `try`.** `readBackendConsoleLogRecord` ran outside it, so only `JSON.stringify` was guarded. `beforeBreadcrumb` is a client-wide hook that also runs for breadcrumbs produced by dependencies, whose shape this backend does not control, so a throw in the recognition read escaped into Sentry's own breadcrumb pipeline. The guarded region now covers that read.
- **Stale producer enumeration.** It had drifted twice: `entrypoints/index.ts` was missing, and the multipart reconciliation entrypoint delegates to `createCloudWatchRecord` rather than building the record inline. The enumeration is deleted in favour of the invariant a grep for the domain marker cannot state by itself.

No behavioural change beyond widening the guard. The object handed to `console` is untouched, so the CloudWatch metric filters are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)