### PR TITLE
Report a deliberately abandoned sign-in as signin_failed(cancelled)

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -78,8 +78,16 @@ internal fun CloudCredentialRecoveryGateContainer(
         mutableStateOf(null)
     }
 
-    LaunchedEffect(recoveryState) {
+    // Leaves the gate's sign-in surface without recording an abandonment. The step and the sign-in
+    // draft are reset together on purpose: `resetSignInState` closes the latch that a later
+    // `returnToOverview` reports through, so resetting the draft while the person stayed on the
+    // email or code step would silently swallow the cancel they go on to make.
+    fun leaveSignInSurfaceWithoutAbandonment() {
         gateStep = CloudCredentialRecoveryGateStep.OVERVIEW
+        signInViewModel.resetSignInState()
+    }
+
+    LaunchedEffect(recoveryState) {
         isEraseConfirmationVisible = false
         isErasing = false
         eraseErrorMessage = ""
@@ -87,7 +95,7 @@ internal fun CloudCredentialRecoveryGateContainer(
         eraseErrorTechnicalDetailsReportId = null
         // Entering the gate composition, which also happens on every configuration change and on
         // every process start while recovery is active. Not a cancelled sign-in.
-        signInViewModel.resetSignInState()
+        leaveSignInSurfaceWithoutAbandonment()
     }
 
     LaunchedEffect(postAuthUiState.completionToken) {
@@ -117,7 +125,7 @@ internal fun CloudCredentialRecoveryGateContainer(
         eraseErrorTechnicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
         onSignIn = {
             // The person is starting a sign-in, not abandoning one.
-            signInViewModel.resetSignInState()
+            signInViewModel.startSignIn()
             eraseErrorMessage = ""
             eraseErrorTechnicalDetails = null
             eraseErrorTechnicalDetailsReportId = null
@@ -190,7 +198,7 @@ internal fun CloudCredentialRecoveryGateContainer(
                 try {
                     appGraph.cloudAccountRepository.eraseLocalDataForCredentialRecovery()
                     // The erase succeeded and the gate is finished; no sign-in was abandoned.
-                    signInViewModel.resetSignInState()
+                    leaveSignInSurfaceWithoutAbandonment()
                     isEraseConfirmationVisible = false
                     onRecoveryGateFinished()
                 } catch (error: CancellationException) {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/MainActivity.kt
@@ -12,6 +12,8 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.flashcardsopensourceapp.app.notifications.consumeAppNotificationTapRequest
+import com.flashcardsopensourceapp.core.ui.markHostActivityStarted
+import com.flashcardsopensourceapp.core.ui.markHostActivityStopped
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -76,6 +78,20 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    // Overridden rather than observed from the composition: the marks have to be unconditional, and
+    // `setContent` returns early on the unsupported-runtime and missing-graph branches. `onStop`
+    // always precedes a system-initiated `onDestroy`, which is what makes the flag a usable
+    // discriminator for a `ViewModel` being cleared.
+    override fun onStart() {
+        super.onStart()
+        markHostActivityStarted()
+    }
+
+    override fun onStop() {
+        markHostActivityStopped()
+        super.onStop()
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/AppHostActivityPresence.kt
+++ b/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/AppHostActivityPresence.kt
@@ -1,0 +1,32 @@
+package com.flashcardsopensourceapp.core.ui
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Whether the app's single hosting Activity is currently started.
+ *
+ * It exists so a `ViewModel` can tell a person leaving a screen from the system taking that screen
+ * away, because both clear the same `ViewModelStore` and produce an identical `onCleared()`:
+ * `NavController` clears a popped back stack entry's store, and `ComponentActivity` clears the store
+ * that owns every entry on a non-configuration `ON_DESTROY` — which the "Don't keep activities"
+ * developer setting and some OEM background-destroy behaviour trigger with the process still alive.
+ * Only the person's departure can happen while the Activity is started.
+ *
+ * Process-scoped rather than held on the app graph, because the graph is torn down and rebuilt
+ * inside a running process while the Activity keeps running, and there is exactly one Activity.
+ * `ProcessLifecycleOwner` is deliberately not the source: it debounces its stop by 700 ms to absorb
+ * configuration changes, and "Don't keep activities" destroys the Activity well inside that window.
+ */
+private val hostActivityStartedState = AtomicBoolean(false)
+
+fun markHostActivityStarted() {
+    hostActivityStartedState.set(true)
+}
+
+fun markHostActivityStopped() {
+    hostActivityStartedState.set(false)
+}
+
+fun isHostActivityStarted(): Boolean {
+    return hostActivityStartedState.get()
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.core.ui.isHostActivityStarted
 import com.flashcardsopensourceapp.core.ui.nextAppTechnicalErrorReportId
 import com.flashcardsopensourceapp.core.ui.renderTechnicalErrorDetails
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
@@ -82,6 +83,23 @@ class CloudSignInViewModel(
     private val draftState = MutableStateFlow(
         value = initialCloudSignInDraftState()
     )
+
+    /**
+     * Whether the sign-in the person opened this surface for still owes one `signin_failed`.
+     * Reporting a failure and verifying the credentials both settle it, so a later dismissal cannot
+     * add a second event for the same attempt.
+     */
+    private var isSignInAttemptOpen: Boolean = true
+
+    /**
+     * Whether the person is on the sign-in surface this model backs.
+     *
+     * `sendCode` and `verifyCode` run in the navigation host's scope rather than `viewModelScope`,
+     * so a request outlives the surface: leaving on a hanging network would otherwise report the
+     * abandonment and then the timeout, two events for one attempt. Two failures the person actually
+     * saw stay two events, because the surface is present for both and neither is an abandonment.
+     */
+    private var isSignInSurfacePresent: Boolean = true
 
     val uiState: StateFlow<CloudSignInUiState> = draftState.mapToStateIn(
         scope = viewModelScope,
@@ -251,6 +269,7 @@ class CloudSignInViewModel(
                 isVerifyingCode = isVerifyingCode
             )
         }
+        isSignInAttemptOpen = false
         return true
     }
 
@@ -482,28 +501,76 @@ class CloudSignInViewModel(
     }
 
     /**
-     * The person deliberately backed out of a sign-in they had started. This is the only path that
-     * records `signin_failed(cancelled)`, so `cancelled` keeps meaning an abandonment.
+     * The person deliberately backed out of a sign-in they had started. This and [onCleared] are the
+     * only paths that record `signin_failed(cancelled)`, so `cancelled` keeps meaning an abandonment.
      */
     fun cancelSignIn() {
-        trackSignInFailed(reason = AnalyticsSignInFailureReason.CANCELLED)
+        reportSignInAbandonment()
+        isSignInSurfacePresent = false
         clearPostAuthState()
     }
 
     /**
-     * Clears the sign-in draft without recording an abandonment.
+     * The person tapped *Sign in* on a surface that keeps this model across the whole flow, so a
+     * fresh attempt starts on a clean draft.
+     */
+    fun startSignIn() {
+        clearPostAuthState()
+        isSignInAttemptOpen = true
+        isSignInSurfacePresent = true
+    }
+
+    /**
+     * Clears the sign-in draft without recording an abandonment, and leaves the sign-in surface.
      *
-     * Entering a surface that hosts sign-in, starting the flow and finishing a local erase all need
-     * a clean draft, and none of them is a person giving up: a composition entered on every
-     * configuration change and every process start, a tap on *Sign in*, and a completed erase would
-     * otherwise fill the `cancelled` bucket on an append-only table with rows that mean the
-     * opposite of what they say.
+     * Entering a surface that hosts sign-in and finishing a local erase both need a clean draft, and
+     * neither is a person giving up: a composition entered on every configuration change and every
+     * process start, and a completed erase, would otherwise fill the `cancelled` bucket on an
+     * append-only table with rows that mean the opposite of what they say.
+     *
+     * Callers must put the surface back on its entry step in the same act, so the person is never
+     * left mid-flow on a closed latch; `CloudCredentialRecoveryGateContainer` keeps the two
+     * together in one helper for that reason.
      */
     fun resetSignInState() {
         clearPostAuthState()
+        isSignInAttemptOpen = false
+        isSignInSurfacePresent = false
+    }
+
+    override fun onCleared() {
+        // The sign-in graph leaving the back stack: the back arrow, the system back gesture and
+        // predictive back all end here, and none of them reaches a route callback. It does **not**
+        // fire on a configuration change, and a process kill never runs it at all.
+        //
+        // It does fire, with the process alive, when the system destroys the hosting Activity while
+        // the app is backgrounded — the "Don't keep activities" developer setting and some OEM
+        // background-destroy behaviour — because `ComponentActivity` clears the `ViewModelStore`
+        // that owns every back stack entry. That is not a dismissal the person made, and the
+        // Activity is stopped for it while a real back press needs it started, so the check below
+        // separates the two. Switching tabs is the remaining departure and saves this entry rather
+        // than clearing it, so it reports nothing here and nothing on the later restore either.
+        if (isHostActivityStarted()) {
+            reportSignInAbandonment()
+        }
+        isSignInSurfacePresent = false
+        super.onCleared()
+    }
+
+    private fun reportSignInAbandonment() {
+        if (isSignInAttemptOpen.not()) {
+            return
+        }
+
+        trackSignInFailed(reason = AnalyticsSignInFailureReason.CANCELLED)
     }
 
     private fun trackSignInFailed(reason: AnalyticsSignInFailureReason) {
+        if (isSignInSurfacePresent.not()) {
+            return
+        }
+
+        isSignInAttemptOpen = false
         analytics.track(
             event = AnalyticsEvent.SignInFailed(
                 reason = reason,

--- a/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+Analytics.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+Analytics.swift
@@ -100,11 +100,13 @@ func analyticsSyncFailureReason(error: Error) -> AnalyticsSyncFailureReason {
 /**
  * Maps a sign-in failure onto the shared `signin_failed` reasons, using the backend code where the
  * server named the cause and the local classification otherwise.
+ *
+ * It deliberately never returns `.cancelled`. That reason means the person walked away from the
+ * sign-in surface, which no thrown error can tell us; a transport cancellation is not the same
+ * event and would be indistinguishable from an abandonment in the funnel. Every call site already
+ * drops cancelled requests through `isRequestCancellationError` before reporting anything.
  */
 func analyticsSignInFailureReason(error: Error) -> AnalyticsSignInFailureReason {
-    if isRequestCancellationError(error: error) {
-        return .cancelled
-    }
     if isRetryableNetworkTransportFailure(error: error) {
         return .offline
     }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
@@ -204,7 +204,7 @@ struct CloudOtpVerificationSheet: View {
                 if isRequestCancellationError(error: error) {
                     return
                 }
-                Analytics.track(.signInFailed(reason: analyticsSignInFailureReason(error: error)))
+                self.store.reportCloudSignInFailure(reason: analyticsSignInFailureReason(error: error))
                 self.applyOtpErrorState(error: error)
                 self.presentAuthErrorPresentation(
                     makeCloudAuthInlineErrorPresentation(
@@ -245,7 +245,7 @@ struct CloudOtpVerificationSheet: View {
                 if isRequestCancellationError(error: error) {
                     return
                 }
-                Analytics.track(.signInFailed(reason: analyticsSignInFailureReason(error: error)))
+                self.store.reportCloudSignInFailure(reason: analyticsSignInFailureReason(error: error))
                 self.presentAuthErrorPresentation(
                     makeCloudAuthInlineErrorPresentation(
                         error: error,

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -25,6 +25,7 @@ struct CloudSignInSheet: View {
     @State private var isSendingCode: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
     @State private var hasRecordedActivePresentation: Bool = false
+    @State private var wasCredentialRecoveryGateActiveAtPresentation: Bool = false
     @State private var postAuthLoadingTask: CloudSignInPostAuthTaskHandle?
     @State private var postAuthGuestLocalRecoveryPreparationTask: CloudSignInPostAuthTaskHandle?
     @State private var postAuthSyncTask: CloudSignInPostAuthTaskHandle?
@@ -283,21 +284,43 @@ struct CloudSignInSheet: View {
         }
     }
 
+    private var isCredentialRecoveryGateActive: Bool {
+        self.store.cloudCredentialRecoveryState != nil
+    }
+
     private func recordActivePresentationIfNeeded() {
         guard self.hasRecordedActivePresentation == false else {
             return
         }
 
         self.hasRecordedActivePresentation = true
+        self.wasCredentialRecoveryGateActiveAtPresentation = self.isCredentialRecoveryGateActive
         self.store.beginCloudSignInSheetPresentation()
     }
 
+    /**
+     * The sheet is gone. This is the one place that sees every way it can go: the Close button, the
+     * interactive swipe, and the programmatic dismissals that follow success, logout or a post-auth
+     * failure. Backgrounding the app does not reach it, so an attempt still open here was abandoned
+     * by the person — with one exception.
+     *
+     * The exception is the credential-recovery gate. `RootTabView.body` swaps its whole tab root for
+     * `CloudCredentialRecoveryGateView` the moment `cloudCredentialRecoveryState` becomes non-nil,
+     * and swaps it back when the state clears; either swap tears down whichever sheet the other
+     * branch was presenting, and a background poll can flip that state while the person is typing.
+     * That is the system taking the surface away, not a person closing it, so the gate's activation
+     * is latched at presentation time and a mismatch here reports nothing. Android's gate sits above
+     * its navigation host and reports nothing for the same swap, so the two clients agree.
+     */
     private func clearActivePresentationIfNeeded() {
         guard self.hasRecordedActivePresentation else {
             return
         }
 
         self.hasRecordedActivePresentation = false
+        if self.isCredentialRecoveryGateActive == self.wasCredentialRecoveryGateActiveAtPresentation {
+            self.store.reportCloudSignInAbandonment()
+        }
         self.store.endCloudSignInSheetPresentation()
     }
 
@@ -360,7 +383,7 @@ struct CloudSignInSheet: View {
                 if self.otpSheetState?.id == nextOtpSheetState.id {
                     self.otpSheetState = nil
                 }
-                Analytics.track(.signInFailed(reason: analyticsSignInFailureReason(error: error)))
+                self.store.reportCloudSignInFailure(reason: analyticsSignInFailureReason(error: error))
                 self.presentAuthErrorPresentation(
                     makeCloudAuthInlineErrorPresentation(
                         error: error,
@@ -403,6 +426,8 @@ struct CloudSignInSheet: View {
     }
 
     private func handleVerifiedAuthContext(_ verifiedContext: CloudVerifiedAuthContext) {
+        self.store.recordCloudSignInVerified()
+
         let loadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
         self.otpSheetState = nil
         self.postAuthLoadingState = loadingState

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
@@ -23,7 +23,12 @@ struct CloudOtpSheetState: Identifiable, Hashable {
 @MainActor
 extension FlashcardsStore {
     func beginCloudSignInSheetPresentation() {
+        assert(
+            self.activeCloudSignInSheetCount == 0,
+            "A second cloud sign-in sheet was presented while one was already on screen."
+        )
         self.activeCloudSignInSheetCount += 1
+        self.isCloudSignInAttemptOpen = true
     }
 
     func endCloudSignInSheetPresentation() {
@@ -33,6 +38,61 @@ extension FlashcardsStore {
         }
 
         self.activeCloudSignInSheetCount -= 1
+    }
+
+    /**
+     * Whether a sign-in surface is on screen.
+     *
+     * At most one `CloudSignInSheet` exists at a time, which is why one latch is enough for what is
+     * otherwise a counter: the credential-recovery gate and the tab root are the two mutually
+     * exclusive branches of `RootTabView.body`, the guest-sign-in prompt is blocked outright while
+     * this count is non-zero, and a presented sheet covers the tab bar, so no second presenter can
+     * be reached. `beginCloudSignInSheetPresentation` asserts on the overlap rather than leaving
+     * that as an assumption.
+     */
+    var isCloudSignInSurfacePresented: Bool {
+        self.activeCloudSignInSheetCount > 0
+    }
+
+    /**
+     * One sign-in attempt reports exactly one `signin_failed`, and only while its surface is on
+     * screen.
+     *
+     * Reporting a failure settles the attempt, so closing the sheet afterwards cannot add a second
+     * event. The same holds from the other side: `sendCode` and the OTP calls outlive the sheet, so
+     * a request that fails after the sheet is gone reports nothing, because the dismissal has
+     * already accounted for that attempt. Two failures the person actually saw stay two events —
+     * the surface is on screen for both, and neither is an abandonment.
+     */
+    func reportCloudSignInFailure(reason: AnalyticsSignInFailureReason) {
+        guard self.isCloudSignInSurfacePresented else {
+            return
+        }
+
+        self.trackCloudSignInFailed(reason: reason)
+    }
+
+    /// Credentials were verified, so whatever happens next in post-auth is not an abandoned sign-in.
+    func recordCloudSignInVerified() {
+        self.isCloudSignInAttemptOpen = false
+    }
+
+    /**
+     * The person closed the sign-in sheet on an attempt that had neither failed nor been verified.
+     * A programmatic dismissal after success or after a reported failure finds the attempt settled
+     * and reports nothing.
+     */
+    func reportCloudSignInAbandonment() {
+        guard self.isCloudSignInAttemptOpen else {
+            return
+        }
+
+        self.trackCloudSignInFailed(reason: .cancelled)
+    }
+
+    private func trackCloudSignInFailed(reason: AnalyticsSignInFailureReason) {
+        self.isCloudSignInAttemptOpen = false
+        Analytics.track(.signInFailed(reason: reason))
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -128,6 +128,8 @@ final class FlashcardsStore {
     @ObservationIgnored var isAccountPreferencesUpdateInFlight: Bool
     @ObservationIgnored var isAccountDeletionRunning: Bool
     @ObservationIgnored var isGuestUpgradeLocalOutboxMutationBlocked: Bool
+    /// Whether the presented sign-in sheet still owes one `signin_failed`.
+    @ObservationIgnored var isCloudSignInAttemptOpen: Bool
     @ObservationIgnored var cachedAIChatStore: AIChatStore?
     @ObservationIgnored var currentVisibleTab: AppTab
     @ObservationIgnored var lastImmediateCloudSyncTriggerAt: Date?
@@ -469,6 +471,7 @@ final class FlashcardsStore {
         self.isAccountPreferencesUpdateInFlight = false
         self.isAccountDeletionRunning = false
         self.isGuestUpgradeLocalOutboxMutationBlocked = false
+        self.isCloudSignInAttemptOpen = false
         self.currentVisibleTab = .review
         self.lastImmediateCloudSyncTriggerAt = nil
         self.activeReviewNotificationsRescheduleTask = nil

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -3,6 +3,10 @@
  * (`apps/backend/src/productAnalytics/catalog.ts`). The union is closed on `name`, so an event the
  * server would reject cannot be constructed. `guest_upgrade_completed` and `catalog_deck_installed`
  * are server-derived and deliberately absent.
+ *
+ * `signin_failed` is declared but never tracked from here. The web sign-in surface is the auth
+ * service's own login page on a different origin, reached by a full page navigation, so this app
+ * observes neither a sign-in attempt nor its dismissal.
  */
 
 export type AnalyticsSurface =


### PR DESCRIPTION
An abandoned sign-in was indistinguishable from one that never started. iOS and Android now report it, so it lands in the same funnel as a failure.

**Web is deliberately excluded, on evidence.** All seven web sign-in entry points are cross-origin full-page navigations to the auth service's own login page, which carries no analytics client and cannot share this app's `anonymous_id` or `session_id`. The web app observes neither a sign-in attempt nor its dismissal, and emits `signin_failed` nowhere today. A note in the event catalog records that, next to the events already absent by design.

**What counts as cancellation** is only an explicit dismissal by the person. Leaving a screen after requesting a code is not — it is indistinguishable from going to fetch the code from an email client. Neither backgrounding nor a system-initiated teardown counts. The shared reason set exists so funnels compare across clients, and a value that means different things on two clients is worse than no value.

**Two latches, not one.** "Attempt open" says the attempt still owes an abandonment and gates only that. "Surface present" says the person is on the sign-in surface and gates every emission. That split lets a late failure landing after the surface is gone report nothing, while two wrong codes entered without leaving still report two failures — which is shipped behaviour.

**Departures that are not the person's doing are silent.** On iOS the credential-recovery gate replaces the whole tab root and tears the sheet down, so the sheet compares the gate state it was presented with against the one at disappear. On Android a system-initiated Activity destruction clears the view model with no dismissal, so a process-scoped host-presence flag marked from the Activity's own `onStart`/`onStop` gates the report — `ProcessLifecycleOwner` is unsuitable there, its stop debounce being longer than such a destruction.

**Also fixes an existing double report.** The Android credential-recovery gate already emitted this reason, unguarded, so a dismissal after a reported failure produced a second row on an append-only table. And the iOS failure-reason mapping no longer turns a transport cancellation into the person's `cancelled`; every caller already guarded it, so nothing reachable changes, but the reason now carries product meaning.

No backend change: `cancelled` was already allowlisted in the catalog and simply never produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)