### PR TITLE
Count a sent AI chat message as a product analytics event

### DIFF
--- a/apps/backend/src/chat/http/dependencies.ts
+++ b/apps/backend/src/chat/http/dependencies.ts
@@ -13,6 +13,7 @@ import {
   getRecoveredPaginatedSession,
   interruptPreparedChatRun,
   prepareChatRun,
+  recordAiMessageSentAnalytics,
   requestChatRunCancellation,
 } from "../runs";
 import {
@@ -33,6 +34,7 @@ export type ChatRoutesOptions = Readonly<{
   createFreshChatSessionFn?: typeof createFreshChatSession;
   getChatSessionIdFn?: typeof getChatSessionId;
   prepareChatRunFn?: typeof prepareChatRun;
+  recordAiMessageSentAnalyticsFn?: typeof recordAiMessageSentAnalytics;
   interruptPreparedChatRunFn?: typeof interruptPreparedChatRun;
   invokeChatWorkerFn?: typeof invokeChatWorkerOrPersistFailure;
   requestChatRunCancellationFn?: typeof requestChatRunCancellation;
@@ -51,6 +53,7 @@ export type ChatRouteDependencies = Readonly<{
   createFreshChatSessionFn: typeof createFreshChatSession;
   getChatSessionIdFn: typeof getChatSessionId;
   prepareChatRunFn: typeof prepareChatRun;
+  recordAiMessageSentAnalyticsFn: typeof recordAiMessageSentAnalytics;
   interruptPreparedChatRunFn: typeof interruptPreparedChatRun;
   invokeChatWorkerFn: typeof invokeChatWorkerOrPersistFailure;
   requestChatRunCancellationFn: typeof requestChatRunCancellation;
@@ -116,6 +119,7 @@ export function createChatRouteDependencies(options: ChatRoutesOptions): ChatRou
     createFreshChatSessionFn: options.createFreshChatSessionFn ?? createFreshChatSession,
     getChatSessionIdFn: options.getChatSessionIdFn ?? getChatSessionId,
     prepareChatRunFn: options.prepareChatRunFn ?? prepareChatRun,
+    recordAiMessageSentAnalyticsFn: options.recordAiMessageSentAnalyticsFn ?? recordAiMessageSentAnalytics,
     interruptPreparedChatRunFn: options.interruptPreparedChatRunFn ?? interruptPreparedChatRun,
     invokeChatWorkerFn: options.invokeChatWorkerFn ?? invokeChatWorkerOrPersistFailure,
     requestChatRunCancellationFn: options.requestChatRunCancellationFn ?? requestChatRunCancellation,

--- a/apps/backend/src/chat/http/handlers.ts
+++ b/apps/backend/src/chat/http/handlers.ts
@@ -183,16 +183,34 @@ export function createPostChatHandler(dependencies: ChatRouteDependencies): Hand
       return mapStoreError(error);
     }
 
-    if (preparedRun.shouldInvokeWorker) {
-      await startBackendSpan("chat.worker.invoke", "faas.invoke", () => dependencies.invokeChatWorkerFn({
-        runId: preparedRun.runId,
-        userId: requestContext.userId,
+    // The turn is committed once prepareChatRunFn returns, so the analytics write belongs here
+    // rather than inside it: dispatching the worker first keeps the analytics write off the path
+    // to generation, and `finally` still reports the turn the user did send when the dispatch
+    // itself fails. The emission never throws. It does still precede this POST response, which is
+    // an accepted residual: the container freezes after the response and this runtime has no
+    // post-response hook.
+    try {
+      if (preparedRun.shouldInvokeWorker) {
+        await startBackendSpan("chat.worker.invoke", "faas.invoke", () => dependencies.invokeChatWorkerFn({
+          runId: preparedRun.runId,
+          userId: requestContext.userId,
+          workspaceId,
+          routeRequestId: requestId,
+          chatRequestId: body.clientRequestId,
+          sessionId: preparedRun.sessionId,
+          initiatingAuthIsSignedIn: preparedRun.initiatingAuthIsSignedIn,
+        }));
+      }
+    } finally {
+      await dependencies.recordAiMessageSentAnalyticsFn(
+        requestContext.userId,
         workspaceId,
-        routeRequestId: requestId,
-        chatRequestId: body.clientRequestId,
-        sessionId: preparedRun.sessionId,
-        initiatingAuthIsSignedIn: preparedRun.initiatingAuthIsSignedIn,
-      }));
+        preparedRun.runId,
+        {
+          subjectUserId: requestContext.subjectUserId,
+          guestSessionId: requestContext.guestSessionId,
+        },
+      );
     }
 
     try {

--- a/apps/backend/src/chat/runs.ts
+++ b/apps/backend/src/chat/runs.ts
@@ -3,6 +3,7 @@
  * Internal implementation is split across focused modules under `./runs/`.
  */
 export type {
+  ChatRunActor,
   ChatRunClaimToken,
   ChatRunHeartbeatState,
   ChatRunSnapshot,
@@ -12,6 +13,8 @@ export type {
   PreparedChatRun,
   RecoveredPaginatedSession,
 } from "./runs/types";
+
+export { recordAiMessageSentAnalytics } from "./runs/analytics";
 
 export {
   assertActiveChatRunClaimWithExecutor,

--- a/apps/backend/src/chat/runs/analytics.ts
+++ b/apps/backend/src/chat/runs/analytics.ts
@@ -1,0 +1,34 @@
+import {
+  deriveServerDerivedProductAnalyticsEventId,
+  emitServerDerivedProductAnalyticsEvent,
+} from "../../productAnalytics/serverEvents";
+import type { ChatRunActor } from "./types";
+
+/**
+ * Reports one user-sent chat turn to product analytics.
+ *
+ * Runs for every prepared run, deduplicated or not. A client that retries the same request replays
+ * the run its first attempt stored, so the id derived from that run id is the same id again and the
+ * writer's `ON CONFLICT (event_id) DO NOTHING` keeps exactly one row per turn however many times
+ * this runs. Skipping the deduplicated prepare would leave that protection unreachable and turn a
+ * dropped write — which this path swallows by design, and which a container killed between the
+ * turn's COMMIT and this call produces just as well — into a permanent loss, because the retry
+ * carrying the same clientRequestId is exactly the attempt that would otherwise still report it.
+ */
+export async function recordAiMessageSentAnalytics(
+  userId: string,
+  workspaceId: string,
+  runId: string,
+  actor: ChatRunActor,
+): Promise<void> {
+  await emitServerDerivedProductAnalyticsEvent({
+    eventId: deriveServerDerivedProductAnalyticsEventId("ai_message_sent", [workspaceId, runId]),
+    eventName: "ai_message_sent",
+    occurredAt: new Date(),
+    userId,
+    subjectUserId: actor.subjectUserId,
+    guestSessionId: actor.guestSessionId,
+    workspaceId,
+    properties: {},
+  });
+}

--- a/apps/backend/src/chat/runs/lifecycleService.ts
+++ b/apps/backend/src/chat/runs/lifecycleService.ts
@@ -70,6 +70,10 @@ import type {
 
 /**
  * Persists the user turn, creates the assistant placeholder, and enqueues a new run for the target session.
+ *
+ * The `ai_message_sent` analytics event is deliberately not emitted here. The caller writes it once
+ * the worker has been dispatched, so generation never waits on the analytics pool, and a new caller
+ * of this function has to call `recordAiMessageSentAnalytics` itself.
  */
 export async function prepareChatRun(
   userId: string,

--- a/apps/backend/src/chat/runs/types.ts
+++ b/apps/backend/src/chat/runs/types.ts
@@ -22,6 +22,17 @@ export type ChatRunStatus =
 
 export type ChatRunClaimToken = string;
 
+// The identity the turn was sent by, taken from the request context and carried alongside the
+// workspace-scoped `userId`, because the analytics row a prepared run emits has to name a guest as
+// precisely as an account. For a guest turn `subjectUserId` is the guest user id that guest's own
+// client events already carry, and it is the key the upgrade's identity link resolves to the
+// account. `guestSessionId` only records which guest session the turn came from; no attribution
+// resolves through it.
+export type ChatRunActor = Readonly<{
+  subjectUserId: string;
+  guestSessionId: string | null;
+}>;
+
 export type PreparedChatRun = Readonly<{
   sessionId: string;
   runId: string;

--- a/apps/backend/src/chat/tests/routes/contract.test.ts
+++ b/apps/backend/src/chat/tests/routes/contract.test.ts
@@ -530,12 +530,17 @@ test("GET /chat fails with a stable contract code when a running snapshot cannot
 
 test("POST /chat captures unexpected live envelope failures before returning the stable contract code", async () => {
   let interruptCount = 0;
+  const postChatCallOrder: Array<string> = [];
   const routes = createChatRoutes({
     allowedOrigins: [],
     loadRequestContextFromRequestFn: async () => ({
       requestAuthInputs: {} as never,
       requestContext: createRequestContext(),
     }),
+    recordAiMessageSentAnalyticsFn: async (_userId, _workspaceId, runId) => {
+      assert.equal(runId, "run-1");
+      postChatCallOrder.push("ai_message_sent");
+    },
     prepareChatRunFn: async () => ({
       sessionId: SESSION_ONE,
       runId: "run-1",
@@ -558,6 +563,7 @@ test("POST /chat captures unexpected live envelope failures before returning the
     },
     interruptPreparedChatRunFn: async () => {
       interruptCount += 1;
+      postChatCallOrder.push("interrupt");
     },
   });
   const app = createRoutesWithHttpErrorJson();
@@ -591,6 +597,10 @@ test("POST /chat captures unexpected live envelope failures before returning the
 
   const exceptionLog = findLog(logs, "request_failed");
   assert.equal(interruptCount, 1);
+  // The turn was sent, so it is reported even though the envelope that follows never builds. This
+  // is the only test that asserts the order in which these two run, so it is the one that would
+  // notice the emission being moved after envelope construction, where this request never arrives.
+  assert.deepEqual(postChatCallOrder, ["ai_message_sent", "interrupt"]);
   assert.equal(exceptionLog?.consoleMethod, "error");
   assert.equal(exceptionLog?.requestId, "request-route-2");
   assert.equal(exceptionLog?.runId, "run-1");
@@ -782,6 +792,7 @@ test("POST /chat fails with a stable contract code when a running response canno
       requestAuthInputs: {} as never,
       requestContext: createRequestContext(),
     }),
+    recordAiMessageSentAnalyticsFn: async () => {},
     prepareChatRunFn: async () => ({
       sessionId: SESSION_ONE,
       runId: "run-1",

--- a/apps/backend/src/chat/tests/routes/start.test.ts
+++ b/apps/backend/src/chat/tests/routes/start.test.ts
@@ -8,9 +8,12 @@ import { createChatRoutes } from "../../../routes/chat";
 import { ChatSessionConflictError } from "../../store";
 import {
   EXPLICIT_WORKSPACE_ID,
+  GUEST_SESSION_ID,
+  GUEST_SUBJECT_USER_ID,
   LEGACY_WORKSPACE_ID,
   SESSION_ONE,
   createExpectedChatConfig,
+  createGuestRequestContext,
   createRoutesWithHttpErrorJson,
   createRequestContext,
   createRequestContextWithSelectedWorkspace,
@@ -21,12 +24,28 @@ test("POST /chat can return an active run before the current turn appears in mes
   let preparedClientRequestId: string | null = null;
   let preparedUiLocale: string | null = null;
   let invokeCallCount = 0;
+  const aiMessageSentCalls: Array<Readonly<{
+    userId: string;
+    workspaceId: string;
+    runId: string;
+    subjectUserId: string;
+    guestSessionId: string | null;
+  }>> = [];
   const app = createChatRoutes({
     allowedOrigins: [],
     loadRequestContextFromRequestFn: async () => ({
       requestAuthInputs: {} as never,
       requestContext: createRequestContext(),
     }),
+    recordAiMessageSentAnalyticsFn: async (userId, workspaceId, runId, actor) => {
+      aiMessageSentCalls.push({
+        userId,
+        workspaceId,
+        runId,
+        subjectUserId: actor.subjectUserId,
+        guestSessionId: actor.guestSessionId,
+      });
+    },
     prepareChatRunFn: async (
       _userId,
       _workspaceId,
@@ -35,12 +54,15 @@ test("POST /chat can return an active run before the current turn appears in mes
       clientRequestId,
       timezone,
       uiLocale,
+      initiatingAuthIsSignedIn,
     ) => {
       preparedClientRequestId = clientRequestId;
       preparedUiLocale = uiLocale;
       assert.equal(requestedSessionId, SESSION_ONE);
       assert.equal(content.length, 1);
       assert.equal(timezone, "Europe/Madrid");
+      // A bearer transport is signed-in auth.
+      assert.equal(initiatingAuthIsSignedIn, true);
       return {
         sessionId: SESSION_ONE,
         runId: "run-1",
@@ -98,6 +120,15 @@ test("POST /chat can return an active run before the current turn appears in mes
   assert.equal(preparedClientRequestId, "client-request-1");
   assert.equal(preparedUiLocale, "de");
   assert.equal(invokeCallCount, 0);
+  // A deduplicated replay dispatches no worker and still reports the turn; the id derived from
+  // runId is what keeps storage at exactly one row.
+  assert.deepEqual(aiMessageSentCalls, [{
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    runId: "run-1",
+    subjectUserId: "user-1",
+    guestSessionId: null,
+  }]);
   assert.equal(response.headers.get("X-Chat-Request-Id"), "client-request-1");
   assert.deepEqual(await response.json(), {
     accepted: true,
@@ -130,6 +161,10 @@ test("POST /chat can return an active run before the current turn appears in mes
 });
 
 
+// Driven by a guest turn on purpose. The worker payload is workspace-scoped and keeps carrying
+// `userId`, while the analytics actor has to name the sender: a route that rebuilt the actor from
+// `userId`, or that stopped forwarding the guest session, would still satisfy every other
+// assertion here, and a guest's AI-chat activity would stop resolving onto their account.
 test("POST /chat dispatches worker without a route-supplied trace carrier", async () => {
   let workerInvocation: Readonly<{
     runId: string;
@@ -142,12 +177,28 @@ test("POST /chat dispatches worker without a route-supplied trace carrier", asyn
   }> | null = null;
   let workerInvocationIncludesTraceContext = true;
   let liveTraceContext: BackendTraceCarrier | null | undefined = undefined;
+  const aiMessageSentCalls: Array<Readonly<{
+    userId: string;
+    workspaceId: string;
+    runId: string;
+    subjectUserId: string;
+    guestSessionId: string | null;
+  }>> = [];
   const routes = createChatRoutes({
     allowedOrigins: [],
     loadRequestContextFromRequestFn: async () => ({
       requestAuthInputs: {} as never,
-      requestContext: createRequestContext(),
+      requestContext: createGuestRequestContext(),
     }),
+    recordAiMessageSentAnalyticsFn: async (userId, workspaceId, runId, actor) => {
+      aiMessageSentCalls.push({
+        userId,
+        workspaceId,
+        runId,
+        subjectUserId: actor.subjectUserId,
+        guestSessionId: actor.guestSessionId,
+      });
+    },
     prepareChatRunFn: async (
       _userId,
       _workspaceId,
@@ -163,7 +214,8 @@ test("POST /chat dispatches worker without a route-supplied trace carrier", asyn
       assert.equal(clientRequestId, "client-request-dispatch");
       assert.equal(timezone, "Europe/Madrid");
       assert.equal(uiLocale, null);
-      assert.equal(initiatingAuthIsSignedIn, true);
+      // A guest transport is not signed-in auth.
+      assert.equal(initiatingAuthIsSignedIn, false);
       return {
         sessionId: SESSION_ONE,
         runId: "run-dispatch",
@@ -244,6 +296,97 @@ test("POST /chat dispatches worker without a route-supplied trace carrier", asyn
   });
   assert.equal(workerInvocationIncludesTraceContext, false);
   assert.notEqual(liveTraceContext, undefined);
+  // Each identity field is pinned to a different value, so none of them can be satisfied by a
+  // route that rebuilt the actor out of the workspace-scoped `userId` it already had.
+  assert.deepEqual(aiMessageSentCalls, [{
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    runId: "run-dispatch",
+    subjectUserId: GUEST_SUBJECT_USER_ID,
+    guestSessionId: GUEST_SESSION_ID,
+  }]);
+});
+
+
+// The `finally` around the dispatch exists for exactly this branch: the turn is already committed
+// when the dispatch throws, so the event still has to report it. A refactor back to a plain
+// sequential await passes every other assertion in this file and drops the event on every 500.
+test("POST /chat reports the sent turn when the worker dispatch fails", async () => {
+  let invokeCallCount = 0;
+  let snapshotReadCount = 0;
+  const aiMessageSentCalls: Array<Readonly<{
+    userId: string;
+    workspaceId: string;
+    runId: string;
+    subjectUserId: string;
+    guestSessionId: string | null;
+  }>> = [];
+  const routes = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createGuestRequestContext(),
+    }),
+    recordAiMessageSentAnalyticsFn: async (userId, workspaceId, runId, actor) => {
+      aiMessageSentCalls.push({
+        userId,
+        workspaceId,
+        runId,
+        subjectUserId: actor.subjectUserId,
+        guestSessionId: actor.guestSessionId,
+      });
+    },
+    prepareChatRunFn: async () => ({
+      sessionId: SESSION_ONE,
+      runId: "run-dispatch-failed",
+      clientRequestId: "client-request-dispatch-failed",
+      runState: "running",
+      deduplicated: false,
+      shouldInvokeWorker: true,
+      initiatingAuthIsSignedIn: false,
+    }),
+    invokeChatWorkerFn: async () => {
+      invokeCallCount += 1;
+      // `invokeChatWorkerOrPersistFailure` rethrows the dispatch error unchanged once it has
+      // marked the run failed; only the message it persists carries a prefix.
+      throw new Error("worker unreachable");
+    },
+    getRecoveredChatSessionSnapshotFn: async () => {
+      snapshotReadCount += 1;
+      throw new Error("the failed dispatch should have ended the request");
+    },
+  });
+  const app = createRoutesWithHttpErrorJson();
+  app.route("/", routes);
+
+  const response = await app.request("http://localhost/chat", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId: SESSION_ONE,
+      clientRequestId: "client-request-dispatch-failed",
+      content: [{ type: "text", text: "hello" }],
+      timezone: "Europe/Madrid",
+    }),
+  });
+
+  assert.equal(invokeCallCount, 1);
+  assert.equal(snapshotReadCount, 0);
+  assert.equal(response.status, 500);
+  assert.deepEqual(await response.json(), {
+    error: "Request failed. Try again.",
+    requestId: null,
+    code: "INTERNAL_ERROR",
+  });
+  assert.deepEqual(aiMessageSentCalls, [{
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    runId: "run-dispatch-failed",
+    subjectUserId: GUEST_SUBJECT_USER_ID,
+    guestSessionId: GUEST_SESSION_ID,
+  }]);
 });
 
 
@@ -299,6 +442,7 @@ test("POST /chat without uiLocale preserves the legacy request contract", async 
       requestAuthInputs: {} as never,
       requestContext: createRequestContext(),
     }),
+    recordAiMessageSentAnalyticsFn: async () => {},
     prepareChatRunFn: async (
       _userId,
       _workspaceId,

--- a/apps/backend/src/chat/tests/routes/testSupport.ts
+++ b/apps/backend/src/chat/tests/routes/testSupport.ts
@@ -35,6 +35,29 @@ export function createRequestContextWithSelectedWorkspace(selectedWorkspaceId: s
   };
 }
 
+export const GUEST_SUBJECT_USER_ID = "guest-user-1";
+export const GUEST_SESSION_ID = "guest-session-1";
+
+/**
+ * A guest-transport request context whose three identity fields are deliberately pairwise distinct
+ * from each other and from `createRequestContext()`, so an assertion on a value a route forwarded
+ * names the field it was actually read from: a route that substitutes `userId` for `subjectUserId`,
+ * or hardcodes `guestSessionId` to null, changes an asserted value instead of passing.
+ *
+ * A real guest carries the same id in `userId` and `subjectUserId`, so never assert through this
+ * fixture that those two differ in production.
+ */
+export function createGuestRequestContext(): RequestContext {
+  return {
+    ...createRequestContext(),
+    subjectUserId: GUEST_SUBJECT_USER_ID,
+    email: null,
+    transport: "guest",
+    guestSessionId: GUEST_SESSION_ID,
+    guestPlatform: "ios",
+  };
+}
+
 export function createSnapshot(messages: ChatSessionSnapshot["messages"]): ChatSessionSnapshot {
   return {
     sessionId: SESSION_ONE,

--- a/apps/backend/src/productAnalytics/catalog.ts
+++ b/apps/backend/src/productAnalytics/catalog.ts
@@ -160,6 +160,11 @@ export const productAnalyticsEventCatalog = {
       },
     },
   },
+  ai_message_sent: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
+  },
   sync_failed: {
     serverOnly: false,
     requiresScreen: false,


### PR DESCRIPTION
AI chat was the largest unmeasured feature in the product.

**Server-derived, not client-emitted.** Every message reaches the backend, so one emission covers web, iOS and Android at once — including versions already in the stores — and it cannot be lost to a client queue. It also gives a guest an activity signal, which the identity design reads to decide whether a guest is still in use.

**One transport stores a user turn.** `POST /chat` is the only one. The live SSE path is a read-only overlay on an already-known run, and the worker executes an already-prepared run and carries no guest identity — so emitting there would lose every message whose dispatch failed.

**Guest attribution needed plumbing.** `prepareChatRun` only received a user and a workspace. A `ChatRunActor` now carries `subjectUserId` and `guestSessionId` from the request context, following the existing catalog-install actor. `subjectUserId` is the key the guest upgrade's identity link resolves to the account; `guestSessionId` only records which session the turn came from, and no attribution resolves through it.

**The `finally` is load-bearing, not stylistic.** Dispatching first keeps the analytics write off the path to generation. `invokeChatWorkerOrPersistFailure` rethrows once it has marked the run failed, so a plain call after the dispatch would drop the event on exactly the incidents that cause dispatch failures. The turn is stored and visible in history either way, so it counts.

**No gate on the deduplicated replay.** A replay derives the same event id from the same run id, and `ON CONFLICT (event_id) DO NOTHING` stores it once — at-least-once emission, exactly-once storage. Gating it would make an analytics write lost during an incident *permanently* lost, because the client's retry short-circuits and never reaches the producer again.

Accepted residual: the write still precedes the POST response, because the container freezes afterwards and this runtime has no post-response hook.

No migration: `event_name` is `TEXT` with no value constraint and the catalog is code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)