### PR TITLE
Let a signed-in account claim the guest identity that held its analytics

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -388,7 +388,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0116_guest_session_web_platform.sql
+            --require-migration 0117_guest_session_creation_idempotency.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0116_guest_session_web_platform.sql",
+      RequiredMigration: "0117_guest_session_creation_idempotency.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0116_guest_session_web_platform.sql",
+    requiredMigration: "0117_guest_session_creation_idempotency.sql",
   });
 });
 

--- a/apps/backend/src/guestAuth/identityLink/index.ts
+++ b/apps/backend/src/guestAuth/identityLink/index.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from "node:crypto";
+import { assertSubjectIsNotDeletedInExecutor } from "../../auth/deletedSubjects";
+import {
+  hasCognitoIdentityMappingForUserInExecutor,
+  loadCognitoIdentityMappingInExecutor,
+  lockCognitoIdentityLifecycleInExecutor,
+} from "../../auth/userIdentities";
+import type { DatabaseExecutor } from "../../database";
+import { insertProductAnalyticsIdentityLink } from "../../productAnalytics/writer";
+import { HttpError } from "../../shared/errors";
+import {
+  guestOwnsUpgradeTransferableDataInExecutor,
+  loadGuestSessionRecordWithUserSettingsLockInExecutor,
+  loadGuestWorkspaceIdInExecutor,
+  revokeGuestSessionInExecutor,
+} from "../store/index";
+
+function createGuestOwnsTransferableDataError(): HttpError {
+  return new HttpError(
+    409,
+    "This guest session owns data that the upgrade transfers and cannot be linked for analytics only. Convert it through /guest-auth/upgrade/complete instead.",
+    "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED",
+  );
+}
+
+function createGuestIdentityLinkAccountRequiredError(): HttpError {
+  return new HttpError(
+    409,
+    "Finish signing in to this account before linking a guest identity. Keep the guest token and retry.",
+    "GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED",
+  );
+}
+
+function createGuestIdentityLinkOtherAccountError(): HttpError {
+  return new HttpError(
+    409,
+    "This guest session already belongs to a different account and cannot be linked to the signed-in one.",
+    "GUEST_IDENTITY_LINK_OTHER_ACCOUNT",
+  );
+}
+
+/**
+ * Claims the analytics history of one guest identity for the account that is now signed in.
+ *
+ * This is the counterpart of `recordGuestUpgradeCompletedAnalytics` for the guests that never reach
+ * `/guest-auth/upgrade/complete`: a signed-out browser, and a mobile install whose guest credential
+ * exists only to authenticate analytics. Nothing is merged, created, selected or deleted here. The
+ * whole effect is one identity link plus the revoke that retires the credential the account has just
+ * replaced. That revoke is terminal for the upgrade flow, because both upgrade routes refuse a
+ * revoked token, so `docs/auth-service.md` requires callers never to send a token here that may
+ * still need `/guest-auth/upgrade/prepare` or `/guest-auth/upgrade/complete`.
+ *
+ * An unknown or already-revoked token is a successful no-op so a client retry after a lost response
+ * is safe.
+ *
+ * The account user id is resolved here, from `auth.user_identities` under the Cognito identity
+ * lifecycle lock, rather than taken from the authenticated request. Authentication reports
+ * `mapping?.userId ?? identity.userId`, so for a subject with no mapping row yet it reports the raw
+ * Cognito subject, and `prepareGuestUpgradeInExecutor` can still bind that subject to a guest user
+ * id instead. A link keyed on the wrong id is not recoverable: `analytics.identity_links` attributes
+ * an anonymous tail to the first link written for an `anonymous_id`, so a later correct link cannot
+ * displace it. `completeGuestUpgradeInExecutor` resolves the target the same way and refuses when the
+ * mapping is absent; `prepareGuestUpgradeInExecutor` does not refuse but binds the mapping itself, in
+ * both of its absent-mapping branches, which is precisely what makes `complete`'s refusal safe — it
+ * always runs second. This route has no such predecessor, so its one real precondition is that some
+ * earlier request loaded a request context for this subject: `loadAuthenticatedRequestContext` runs
+ * `ensureCognitoUserProfileInExecutor`, which binds `auth.user_identities` on every bearer or session
+ * request. Until that has happened this route refuses with `GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED`,
+ * which is retryable rather than terminal: nothing in it is wrong with the guest token, and a client
+ * that drops the token on it loses that guest's whole tail. `docs/auth-service.md` states the
+ * ordering obligation and the retry rule for the clients that call this route.
+ *
+ * The deleted-subject gate below is the same one both guest-upgrade paths take, and it is not
+ * optional here. A deleted account's client keeps a valid id token until it expires, and account
+ * deletion sweeps `analytics.identity_links` exactly once and never runs again, so a link written
+ * inside that window would be permanent and would silently break the deletion guarantee. Taking the
+ * Cognito identity lifecycle lock first is what closes the window rather than narrowing it: account
+ * deletion holds that same lock across its sweep and its tombstone write, so this transaction either
+ * runs before the sweep and has its link swept, or waits and sees the tombstone. That lock is also
+ * the one this repository requires ahead of user-settings, guest-session and workspace lifecycle
+ * locks, which is why it is taken before the guest session is loaded.
+ *
+ * The link is written before the revoke, for the reason spelled out above
+ * `recordGuestUpgradeCompletedAnalytics`: losing the link costs that guest's entire resolved
+ * history, losing the revoke costs nothing. Unlike the upgrade producer this one is not best effort
+ * and does not run after the transaction: a failed link must abort the revoke so the retry can write
+ * it again. The analytics writer commits on its own pool, so a link that lands and is then followed
+ * by a rolled-back revoke stays committed. That costs nothing as long as the client retries: the
+ * pair the link names is this guest and this account either way, and the retry conflicts on that
+ * pair, stores nothing new and completes the revoke. That is exactly the property the upgrade path
+ * cannot rely on, because a rolled-back upgrade could still end on a different account.
+ *
+ * Without that retry the orphan link is not harmless, which is why `docs/auth-service.md` makes
+ * retrying a 5xx from this route, with the guest token kept, a client obligation rather than an
+ * option. The revoke is the write most likely to be the one that misses a deadline, because the
+ * link ahead of it can consume up to ~4s of the request budget on the analytics pool: 2s of
+ * acquisition plus a 2s statement timeout. A guest session left live and unbound can still be bound
+ * to a *different* account by a later `/guest-auth/upgrade/prepare`, and `first_guest_upgrade_link`
+ * in 0115 is first-link-wins, so the orphan link would then attribute that account's whole
+ * pre-account tail to this one permanently, with no repair path.
+ */
+export async function linkGuestAnalyticsIdentityInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+  cognitoSubject: string,
+): Promise<void> {
+  await lockCognitoIdentityLifecycleInExecutor(executor, cognitoSubject);
+  await assertSubjectIsNotDeletedInExecutor(executor, cognitoSubject);
+
+  const guestSession = await loadGuestSessionRecordWithUserSettingsLockInExecutor(executor, guestToken);
+  if (guestSession === null || guestSession.revokedAt !== null) {
+    return;
+  }
+
+  const accountMapping = await loadCognitoIdentityMappingInExecutor(executor, cognitoSubject);
+  if (accountMapping === null) {
+    throw createGuestIdentityLinkAccountRequiredError();
+  }
+
+  // The guest user id is already this account, so its events resolve to the account without a link
+  // and writing one would map the identity to itself. This mirrors the bound-completion branch of
+  // recordGuestUpgradeCompletedAnalytics, and it is reached routinely: the bound branch of
+  // /guest-auth/upgrade/complete deliberately leaves the session it converts live, so a mobile
+  // install commonly holds a guest credential whose user is this very account.
+  //
+  // It is answered before the content probe below, because that probe would otherwise read the
+  // account's own workspace and refuse this state with GUEST_IDENTITY_LINK_UPGRADE_REQUIRED,
+  // telling the client to convert through a flow it has already completed. The probe's own
+  // justification does not hold here either: these rows sit behind a credential the account still
+  // reaches.
+  //
+  // The session is deliberately not revoked. This credential is the account's own, and revoking it
+  // would route a later /guest-auth/upgrade/complete retry into
+  // resolveRevokedGuestUpgradeReplayInExecutor, which finds no auth.guest_upgrade_history row for a
+  // bound completion and answers 401 GUEST_AUTH_INVALID instead of replaying it.
+  if (guestSession.userId === accountMapping.userId) {
+    return;
+  }
+
+  // Past this point the guest user id is not this account's, so a guest user that is nevertheless
+  // bound to a Cognito subject belongs to some *other* real account, and this route must not treat
+  // it as an ordinary guest. That is the same invariant the two sibling paths enforce with this same
+  // probe: rotateGuestSessionForCreationIdempotencyKeyInExecutor disarms such a row rather than hand
+  // its credential back, and deleteGuestSessionInExecutor refuses to delete it.
+  //
+  // Linking it would write anonymous_id = the other account's own user id. first_guest_upgrade_link
+  // outranks product_events.user_id in analytics.product_events_resolved and identity_links is
+  // append-only and first-link-wins, so that account's entire pre-account history would resolve to
+  // this one permanently, with no repair path; the revoke below would then retire that account's
+  // live credential, which is exactly what the same-account branch above explains must not happen.
+  // The content probe cannot stand in for this check: a bound-from-empty or analytics-only guest
+  // owns nothing, so it sails straight past.
+  //
+  // This is deliberately placed after the same-account early return above, never before it: that
+  // state is the routine post-bound-upgrade case a mobile install reaches on every call, and
+  // refusing it here would turn a documented no-op into a failure.
+  if (await hasCognitoIdentityMappingForUserInExecutor(executor, guestSession.userId)) {
+    throw createGuestIdentityLinkOtherAccountError();
+  }
+
+  // A guest that owns data the upgrade would transfer must convert through the upgrade flow, which
+  // moves that data onto the account. Revoking its session here would leave the rows behind a user
+  // no credential can reach any more, and no path recovers them. Web guests and analytics-only
+  // mobile guests own nothing, so this costs nothing on the paths that call this route.
+  const guestWorkspaceId = await loadGuestWorkspaceIdInExecutor(executor, guestSession.userId);
+  if (await guestOwnsUpgradeTransferableDataInExecutor(executor, guestSession.userId, guestWorkspaceId)) {
+    throw createGuestOwnsTransferableDataError();
+  }
+
+  // The client's own anonymous_id is not known here, so the link is keyed on the guest user id
+  // that the guest's events carried as subject_user_id, which is the shape
+  // analytics.product_events_resolved reads in its server namespace.
+  //
+  // This write runs on the analytics pool while this transaction still holds the Cognito identity
+  // lifecycle lock, the guest's org.user_settings row lock and that guest session row's own FOR
+  // UPDATE lock. No workspace lifecycle lock is held on this path.
+  // recordGuestUpgradeCompletedAnalytics documents the opposite choice for the upgrade path,
+  // and the difference is deliberate rather than an oversight. That producer runs after a
+  // committed upgrade and is best effort, so it can afford to sit outside the transaction; here
+  // the link is the entire point of the request, and a link that fails must abort the revoke so
+  // the client's retry can write it again, which is only possible from inside. The hold is bounded
+  // by the writer's own guards: assertAnalyticsPoolCapacity refuses a saturated pool instead of
+  // queueing, acquisition times out after 2s, and the write runs under a 2s statement timeout. The
+  // locks are scoped to one guest and one signing-in account, and are contended only by that same
+  // person's own guest lifecycle, upgrade or account-deletion calls, none of which is a hot path.
+  await insertProductAnalyticsIdentityLink({
+    linkId: randomUUID(),
+    anonymousId: guestSession.userId,
+    userId: accountMapping.userId,
+    source: "server_derived",
+  });
+
+  await revokeGuestSessionInExecutor(executor, guestSession.userId, guestSession.sessionId);
+}

--- a/apps/backend/src/guestAuth/index.ts
+++ b/apps/backend/src/guestAuth/index.ts
@@ -8,6 +8,9 @@ import {
   deleteGuestSessionInExecutor,
 } from "./delete/index";
 import {
+  linkGuestAnalyticsIdentityInExecutor,
+} from "./identityLink/index";
+import {
   authenticateGuestSession,
   bindGuestSessionPlatform,
   createGuestSessionInExecutor,
@@ -39,11 +42,26 @@ export {
   bindGuestSessionPlatform,
   completeGuestUpgradeInExecutor,
   deleteGuestSessionInExecutor,
+  linkGuestAnalyticsIdentityInExecutor,
   prepareGuestUpgradeInExecutor,
 };
 
-export async function createGuestSession(platform: GuestSessionPlatform | null): Promise<GuestSessionSnapshot> {
-  return unsafeTransaction(async (executor) => createGuestSessionInExecutor(executor, platform));
+export async function createGuestSession(
+  platform: GuestSessionPlatform | null,
+  creationIdempotencyKey: string | null,
+): Promise<GuestSessionSnapshot> {
+  return unsafeTransaction(
+    async (executor) => createGuestSessionInExecutor(executor, platform, creationIdempotencyKey),
+  );
+}
+
+export async function linkGuestAnalyticsIdentity(
+  guestToken: string,
+  cognitoSubject: string,
+): Promise<void> {
+  return unsafeTransaction(
+    async (executor) => linkGuestAnalyticsIdentityInExecutor(executor, guestToken, cognitoSubject),
+  );
 }
 
 export async function prepareGuestUpgrade(

--- a/apps/backend/src/guestAuth/session/index.ts
+++ b/apps/backend/src/guestAuth/session/index.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import type pg from "pg";
+import { hasCognitoIdentityMappingForUserInExecutor } from "../../auth/userIdentities";
 import type { DatabaseExecutor } from "../../database";
 import { applyUserDatabaseScopeInExecutor } from "../../database";
 import { unsafeQuery } from "../../database/unsafe";
@@ -8,8 +9,13 @@ import {
   AUTO_CREATED_WORKSPACE_NAME,
 } from "../../workspaces/types";
 import { createWorkspaceInExecutor } from "../../workspaces/create";
+import {
+  lockUserSettingsForWorkspaceLifecycleInExecutor,
+  UserSettingsRowNotFoundError,
+} from "../../workspaces/state";
 import { guestSessionPlatformColumnExistsInExecutor } from "../platformColumn";
 import { hashGuestToken } from "../shared";
+import { loadGuestWorkspaceIdInExecutor } from "../store/index";
 import type { GuestSessionPlatform, GuestSessionSnapshot } from "../types";
 
 type GuestSessionRow = Readonly<{
@@ -173,19 +179,23 @@ async function insertGuestSessionInExecutor(
   guestToken: string,
   userId: string,
   platform: GuestSessionPlatform | null,
+  creationIdempotencyKey: string | null,
 ): Promise<GuestSessionPlatform | null> {
   if (await guestSessionPlatformColumnExistsInExecutor(executor)) {
     await executor.query(
       [
         "INSERT INTO auth.guest_sessions",
-        "(session_id, session_secret_hash, user_id, platform)",
-        "VALUES ($1, $2, $3, $4)",
+        "(session_id, session_secret_hash, user_id, platform, creation_idempotency_key)",
+        "VALUES ($1, $2, $3, $4, $5)",
       ].join(" "),
-      [sessionId, hashGuestToken(guestToken), userId, platform],
+      [sessionId, hashGuestToken(guestToken), userId, platform, creationIdempotencyKey],
     );
     return platform;
   }
 
+  // The pre-0055 schema this branch exists for is also pre-0117, and a non-null key already read
+  // creation_idempotency_key before reaching here, so such a schema fails there rather than dropping
+  // the key silently on this insert.
   await executor.query(
     [
       "INSERT INTO auth.guest_sessions",
@@ -197,17 +207,188 @@ async function insertGuestSessionInExecutor(
   return null;
 }
 
+type RotatedGuestSessionRow = Readonly<{
+  session_id: string;
+  user_id: string;
+  platform: GuestSessionPlatform | null;
+}>;
+
+const liveGuestSessionForCreationIdempotencyKeySql = [
+  "SELECT session_id, user_id, platform",
+  "FROM auth.guest_sessions",
+  "WHERE creation_idempotency_key = $1 AND revoked_at IS NULL",
+].join(" ");
+
+async function loadLiveGuestSessionForCreationIdempotencyKeyInExecutor(
+  executor: DatabaseExecutor,
+  creationIdempotencyKey: string,
+  lockForUpdate: boolean,
+): Promise<RotatedGuestSessionRow | null> {
+  const result = await executor.query<RotatedGuestSessionRow>(
+    lockForUpdate
+      ? `${liveGuestSessionForCreationIdempotencyKeySql} FOR UPDATE`
+      : liveGuestSessionForCreationIdempotencyKeySql,
+    [creationIdempotencyKey],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+/**
+ * Serializes every creation attempt carrying the same idempotency key.
+ *
+ * The guest user, its workspace and the org.user_settings selection are all written before the
+ * session row exists, so a unique violation on the session insert would arrive far too late: both
+ * concurrent attempts would already own a guest identity and one of them would be unreachable
+ * forever. This is the first lock the creation path takes, ahead of the user-settings, guest-session
+ * and workspace lifecycle locks below it, and the path never takes the Cognito identity lock. No
+ * other transaction ever waits for this lock while holding one of those, because the only caller
+ * takes it before them, so it cannot sit in a lock cycle.
+ */
+async function lockGuestSessionCreationIdempotencyInExecutor(
+  executor: DatabaseExecutor,
+  creationIdempotencyKey: string,
+): Promise<void> {
+  await executor.query(
+    "SELECT pg_advisory_xact_lock(hashtextextended('auth.guest_session_creation:' || $1::text, 2::bigint))",
+    [creationIdempotencyKey],
+  );
+}
+
+/**
+ * Hands a retry back the guest identity its lost response already created, behind a new token.
+ *
+ * Only the hash of a per-attempt token is stored, so the token the lost response carried cannot be
+ * read back and cannot be returned a second time. Rotating the secret costs nothing: no client ever
+ * received the token being invalidated.
+ *
+ * Two kinds of session are deliberately never handed back, and both end in a fresh guest, so this
+ * function keeps the server's own guarantee that creating a guest session never returns an identity
+ * that belongs to a real account. That guarantee must not rest on clients that have yet to be
+ * written, which is why the second case is enforced here rather than left as a client obligation.
+ *
+ * A revoked session is not matched at all. Upgrade and deletion retire a guest credential on
+ * purpose, so a key that now names one is treated as absent.
+ *
+ * A live session whose user has since been bound to a real account is matched and disarmed: its key
+ * is cleared and this call falls through to creation. The bound branch of
+ * `/guest-auth/upgrade/complete` deliberately never revokes the guest session it converts, so after
+ * a bound upgrade that row stays live with its key intact while its `user_id` is the account's own
+ * id. Rotating it would answer a caller holding nothing but the key with a valid guest token for
+ * that account, plus whatever workspace the account currently has selected, and a key is only ever
+ * meant to buy back a guest identity, never an account's credential. The route's key format bounds
+ * the shape of a key, not who can present one, and even a key generated randomly per attempt would
+ * not make presenting one legitimate here. Treating the row as absent without clearing the key is
+ * not enough either: the row is still live, so it still occupies
+ * `idx_guest_sessions_active_creation_idempotency_key` and the insert below would violate it.
+ * Clearing only the key leaves that account's live credential
+ * untouched and retires a marker that stopped meaning "one guest creation attempt" the moment the
+ * session stopped being a guest. `deleteGuestSessionInExecutor` and
+ * `linkGuestAnalyticsIdentityInExecutor` guard the same state with the same
+ * `hasCognitoIdentityMappingForUserInExecutor` probe: on none of the three paths may a guest session
+ * whose user is already a real account be treated as an ordinary guest. Each path answers it
+ * differently only because their safe answers differ — here a fresh guest, there a refusal.
+ *
+ * The check belongs here, next to the lookup, rather than at the call site: any future lookup that
+ * resolves a session by something other than the token hash faces the same question.
+ *
+ * The two row locks are taken in the order every other guest path takes them: the guest's
+ * `org.user_settings` row first, then the `auth.guest_sessions` row. That is why the key is read
+ * once unlocked purely to learn which user to lock, exactly as
+ * `loadGuestSessionRecordWithUserSettingsLockInExecutor` and
+ * `lockGuestSessionAfterUserSettingsInExecutor` do, and re-read under `FOR UPDATE` afterwards. The
+ * advisory key lock does not make the locked re-read redundant: it only serializes other creation
+ * attempts for this key, while an upgrade, link or delete call for this same guest takes none of it
+ * and could otherwise bind or retire the user between the two reads. A row that changed identity or
+ * stopped being live in between is treated as absent and falls through to a fresh guest.
+ */
+async function rotateGuestSessionForCreationIdempotencyKeyInExecutor(
+  executor: DatabaseExecutor,
+  creationIdempotencyKey: string,
+  guestToken: string,
+): Promise<GuestSessionSnapshot | null> {
+  const unlockedRow = await loadLiveGuestSessionForCreationIdempotencyKeyInExecutor(
+    executor,
+    creationIdempotencyKey,
+    false,
+  );
+  if (unlockedRow === null) {
+    return null;
+  }
+
+  try {
+    await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, unlockedRow.user_id);
+  } catch (error) {
+    if (error instanceof UserSettingsRowNotFoundError) {
+      // auth.guest_sessions.user_id cascades from org.user_settings, so the row read above is gone
+      // too. Create a fresh guest rather than rotating a credential whose user no longer exists.
+      return null;
+    }
+
+    throw error;
+  }
+
+  const row = await loadLiveGuestSessionForCreationIdempotencyKeyInExecutor(
+    executor,
+    creationIdempotencyKey,
+    true,
+  );
+  if (
+    row === null
+    || row.session_id !== unlockedRow.session_id
+    || row.user_id !== unlockedRow.user_id
+  ) {
+    return null;
+  }
+
+  if (await hasCognitoIdentityMappingForUserInExecutor(executor, row.user_id)) {
+    await executor.query(
+      "UPDATE auth.guest_sessions SET creation_idempotency_key = NULL WHERE session_id = $1",
+      [row.session_id],
+    );
+    return null;
+  }
+
+  await executor.query(
+    "UPDATE auth.guest_sessions SET session_secret_hash = $2 WHERE session_id = $1",
+    [row.session_id, hashGuestToken(guestToken)],
+  );
+
+  return {
+    guestToken,
+    userId: row.user_id,
+    workspaceId: await loadGuestWorkspaceIdInExecutor(executor, row.user_id),
+    platform: row.platform,
+  };
+}
+
 export async function createGuestSessionInExecutor(
   executor: DatabaseExecutor,
   platform: GuestSessionPlatform | null,
+  creationIdempotencyKey: string | null,
 ): Promise<GuestSessionSnapshot> {
   // Guest session creation is intentionally always a fresh server-side
   // identity. Clients clear stored guest sessions and regenerate their local
   // installation identity on logout/account deletion before they can call
   // this again, which keeps future guest-to-linked merges scoped to the
-  // current post-reset guest account only.
-  const userId = randomUUID().toLowerCase();
+  // current post-reset guest account only. An idempotency key narrows that to
+  // one fresh identity per key, so only a retry of the very same attempt is
+  // folded back onto the identity that attempt already created, and never onto
+  // an identity that has since been bound to a real account.
   const guestToken = randomBytes(32).toString("hex");
+  if (creationIdempotencyKey !== null) {
+    await lockGuestSessionCreationIdempotencyInExecutor(executor, creationIdempotencyKey);
+    const rotatedSession = await rotateGuestSessionForCreationIdempotencyKeyInExecutor(
+      executor,
+      creationIdempotencyKey,
+      guestToken,
+    );
+    if (rotatedSession !== null) {
+      return rotatedSession;
+    }
+  }
+
+  const userId = randomUUID().toLowerCase();
   const sessionId = randomUUID().toLowerCase();
 
   await applyUserDatabaseScopeInExecutor(executor, { userId });
@@ -216,7 +397,14 @@ export async function createGuestSessionInExecutor(
     "UPDATE org.user_settings SET workspace_id = $1 WHERE user_id = $2",
     [workspaceId, userId],
   );
-  const storedPlatform = await insertGuestSessionInExecutor(executor, sessionId, guestToken, userId, platform);
+  const storedPlatform = await insertGuestSessionInExecutor(
+    executor,
+    sessionId,
+    guestToken,
+    userId,
+    platform,
+    creationIdempotencyKey,
+  );
 
   return {
     guestToken,

--- a/apps/backend/src/guestAuth/store/workspace.ts
+++ b/apps/backend/src/guestAuth/store/workspace.ts
@@ -1,5 +1,6 @@
 import {
   applyUserDatabaseScopeInExecutor,
+  applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
 } from "../../database";
 import { HttpError } from "../../shared/errors";
@@ -17,6 +18,10 @@ type WorkspaceSummaryRow = Readonly<{
   created_at: Date | string;
 }>;
 
+type GuestContentProbeRow = Readonly<{
+  has_content: boolean;
+}>;
+
 export async function loadGuestWorkspaceIdInExecutor(
   executor: DatabaseExecutor,
   guestUserId: string,
@@ -32,6 +37,59 @@ export async function loadGuestWorkspaceIdInExecutor(
   }
 
   return workspaceId;
+}
+
+/**
+ * Reports whether a guest owns anything `/guest-auth/upgrade/complete` would have to carry.
+ *
+ * The probe covers every table that upgrade transfers, not only the workspace-scoped ones, because
+ * the caller uses this to decide whether revoking a guest session would strand data and the revoke
+ * strands a row wherever it sits. Four tables are workspace-scoped and follow the merge:
+ * `content.cards`, `content.decks`, `content.review_events` and `content.media_assets`. Three carry
+ * no `workspace_id` at all and follow the guest user id through `support.transfer_guest_feedback`
+ * and `community.transfer_guest_public_profile`: `support.feedback_prompt_events`,
+ * `support.feedback_submissions` and `community.public_profiles`. A web guest cannot reach the
+ * feedback or community surfaces, but an `ios`/`android` analytics-only guest can, and it would
+ * otherwise pass a workspace-only guard with an empty workspace and lose those rows.
+ *
+ * Tombstoned rows count. A deleted card is still a row `/guest-auth/upgrade/complete` moves into the
+ * destination workspace, so the safe answer for a row that exists is that it exists.
+ *
+ * The workspace scope applied below also fixes `security.current_user_id()` to the guest, which is
+ * what the user-scoped row-level security policies on the `support` and `community` tables read, so
+ * one scope serves both halves of the probe.
+ */
+export async function guestOwnsUpgradeTransferableDataInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+  guestWorkspaceId: string,
+): Promise<boolean> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: guestUserId,
+    workspaceId: guestWorkspaceId,
+  });
+
+  const result = await executor.query<GuestContentProbeRow>(
+    [
+      "SELECT",
+      "EXISTS (SELECT 1 FROM content.cards WHERE workspace_id = $1)",
+      "OR EXISTS (SELECT 1 FROM content.decks WHERE workspace_id = $1)",
+      "OR EXISTS (SELECT 1 FROM content.review_events WHERE workspace_id = $1)",
+      "OR EXISTS (SELECT 1 FROM content.media_assets WHERE workspace_id = $1)",
+      "OR EXISTS (SELECT 1 FROM support.feedback_prompt_events WHERE user_id = $2)",
+      "OR EXISTS (SELECT 1 FROM support.feedback_submissions WHERE user_id = $2)",
+      "OR EXISTS (SELECT 1 FROM community.public_profiles WHERE user_id = $2)",
+      "AS has_content",
+    ].join(" "),
+    [guestWorkspaceId, guestUserId],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Guest content probe returned no row for workspace ${guestWorkspaceId}`);
+  }
+
+  return row.has_content;
 }
 
 export async function loadWorkspaceSummaryInExecutor(

--- a/apps/backend/src/productAnalytics/types.ts
+++ b/apps/backend/src/productAnalytics/types.ts
@@ -91,9 +91,10 @@ export type ProductAnalyticsEventRow = Readonly<{
   requestId: string | null;
 }>;
 
-// server_derived comes from the guest upgrade itself, which is the only place the backend observes
-// the pair; authenticated_client comes from an authenticated ingest request, which is a client claim
-// the server only framed.
+// server_derived comes from the two places the backend observes the pair itself: the guest upgrade,
+// and the /guest-auth/identity/link route a signed-in account calls to claim the guest identity its
+// browser or install held. authenticated_client comes from an authenticated ingest request, which is
+// a client claim the server only framed.
 export type ProductAnalyticsIdentityLinkSource = "server_derived" | "authenticated_client";
 
 // One row of analytics.identity_links. linked_at is owned by the database so no caller can date a

--- a/apps/backend/src/productAnalytics/writer.ts
+++ b/apps/backend/src/productAnalytics/writer.ts
@@ -92,12 +92,14 @@ const insertProductAnalyticsEventsSql = [
 // resolved read view lets a link claim history, and link_id keeps naming the first observation.
 //
 // source is the one column a repeat may rewrite, and only towards the server. A server_derived link
-// is something the backend watched happen during a guest upgrade, while an authenticated_client link
-// is a claim a request carried, so the pair's trust must not be decided by whichever of the two
-// happened to arrive first. Without this, a client that used a guest user id as its anonymous_id
-// could land the authenticated_client row first, and analytics.product_events_resolved reads the
-// server namespace through source = 'server_derived', so that guest's whole tail would silently stop
-// resolving to the account. 0115 grants the matching column-scoped UPDATE privilege and policy.
+// is something the backend watched happen, during a guest upgrade or in the
+// /guest-auth/identity/link route where a signed-in account claims the guest identity its browser or
+// install held, while an authenticated_client link is a claim a request carried, so the pair's trust
+// must not be decided by whichever of the two happened to arrive first. Without this, a client that
+// used a guest user id as its anonymous_id could land the authenticated_client row first, and
+// analytics.product_events_resolved reads the server namespace through source = 'server_derived', so
+// that guest's whole tail would silently stop resolving to the account. 0115 grants the matching
+// column-scoped UPDATE privilege and policy.
 const insertProductAnalyticsIdentityLinkSql = [
   "INSERT INTO analytics.identity_links (link_id, anonymous_id, user_id, source)",
   " VALUES ($1::uuid, $2::uuid, $3::uuid, $4::text)",

--- a/apps/backend/src/routes/guestAuth.test.ts
+++ b/apps/backend/src/routes/guestAuth.test.ts
@@ -23,8 +23,15 @@ type GuestAuthTestAppOptions = Readonly<{
     selection: GuestUpgradeSelection,
     capabilities: GuestUpgradeCompleteCapabilities,
   ) => Promise<GuestUpgradeCompletion>;
-  onCreateGuestSession?: (platform: GuestSessionPlatform | null) => Promise<GuestSessionSnapshot>;
+  onCreateGuestSession?: (
+    platform: GuestSessionPlatform | null,
+    idempotencyKey: string | null,
+  ) => Promise<GuestSessionSnapshot>;
   onDeleteGuestSession?: (guestToken: string) => Promise<void>;
+  onLinkGuestAnalyticsIdentity?: (
+    guestToken: string,
+    cognitoSubject: string,
+  ) => Promise<void>;
 }>;
 
 function createGuestSessionSnapshot(platform: GuestSessionPlatform | null): GuestSessionSnapshot {
@@ -70,9 +77,9 @@ function createGuestAuthTestApp(options: GuestAuthTestAppOptions): Hono<AppEnv> 
   });
   app.route("/", createGuestAuthRoutes({
     authenticateRequestFn: async () => options.authResult,
-    createGuestSessionFn: async (platform) => {
+    createGuestSessionFn: async (platform, idempotencyKey) => {
       if (options.onCreateGuestSession !== undefined) {
-        return options.onCreateGuestSession(platform);
+        return options.onCreateGuestSession(platform, idempotencyKey);
       }
 
       return createGuestSessionSnapshot(platform);
@@ -80,6 +87,9 @@ function createGuestAuthTestApp(options: GuestAuthTestAppOptions): Hono<AppEnv> 
     completeGuestUpgradeFn: options.onCompleteGuestUpgrade,
     deleteGuestSessionFn: async (guestToken) => {
       await options.onDeleteGuestSession?.(guestToken);
+    },
+    linkGuestAnalyticsIdentityFn: async (guestToken, cognitoSubject) => {
+      await options.onLinkGuestAnalyticsIdentity?.(guestToken, cognitoSubject);
     },
   }));
   return app;
@@ -176,6 +186,91 @@ test("POST /guest-auth/session creates a platform-bound web guest session", asyn
   });
 });
 
+const guestSessionIdempotencyKeyForTest = "b3f1c0d2e4a5968778695a4e3c2d1b0af9e8d7c6b5a4938271605f4e3d2c1b0a";
+
+test("POST /guest-auth/session forwards an idempotency key and defaults it to absent", async () => {
+  const receivedKeys: Array<string | null> = [];
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("none"),
+    onCreateGuestSession: async (platform, idempotencyKey) => {
+      receivedKeys.push(idempotencyKey);
+      return createGuestSessionSnapshot(platform);
+    },
+  });
+
+  const keyedResponse = await app.request("http://localhost/guest-auth/session", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ platform: "web", idempotencyKey: guestSessionIdempotencyKeyForTest }),
+  });
+  const unkeyedResponse = await app.request("http://localhost/guest-auth/session", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ platform: "web" }),
+  });
+  // Serializers that encode an unset optional field rather than omitting it send an explicit null on
+  // every no-key call, so that has to mean absent too instead of failing the shape check.
+  const nullKeyResponse = await app.request("http://localhost/guest-auth/session", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ platform: "web", idempotencyKey: null }),
+  });
+
+  assert.equal(keyedResponse.status, 200);
+  assert.equal(unkeyedResponse.status, 200);
+  assert.equal(nullKeyResponse.status, 200);
+  assert.deepEqual(receivedKeys, [guestSessionIdempotencyKeyForTest, null, null]);
+});
+
+// The key is a bearer credential for the guest identity it names, so the obviously non-random shapes
+// a client might reach for are refused at the boundary rather than stored. The check is only that
+// floor: a hex-normalised install id would pass it, which is why per-attempt randomness stays a
+// client obligation in docs/auth-service.md.
+test("POST /guest-auth/session rejects an idempotency key that is not a random token", async () => {
+  let created = false;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("none"),
+    onCreateGuestSession: async (platform) => {
+      created = true;
+      return createGuestSessionSnapshot(platform);
+    },
+  });
+
+  const rejectedKeys = [
+    // A label, a canonical install id, too little entropy, and an over-long value.
+    "creation-attempt-1",
+    "1b4e28ba-2fa1-11d2-883f-0016d3cca427",
+    "b3f1c0d2e4a59687",
+    "f".repeat(201),
+  ];
+  const responses = await Promise.all(rejectedKeys.map(async (idempotencyKey) => app.request(
+    "http://localhost/guest-auth/session",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ platform: "web", idempotencyKey }),
+    },
+  )));
+
+  for (const response of responses) {
+    assert.equal(response.status, 400);
+  }
+  assert.equal(created, false);
+  assert.deepEqual(await responses[0].json(), {
+    error: "idempotencyKey must be 32 to 200 lowercase hexadecimal characters generated randomly for one creation attempt",
+    requestId: "request-1",
+    code: "GUEST_SESSION_IDEMPOTENCY_KEY_INVALID",
+  });
+});
+
 test("POST /guest-auth/session/delete deletes a guest session with Guest authentication", async () => {
   let deletedGuestToken: string | null = null;
   const app = createGuestAuthTestApp({
@@ -246,6 +341,97 @@ test("POST /guest-auth/session/delete returns 409 for a guest session already li
     error: "Guest session is already linked to a signed-in account. Use /me/delete from that account instead.",
     requestId: "request-1",
     code: "GUEST_SESSION_DELETE_LINKED_ACCOUNT",
+  });
+});
+
+test("POST /guest-auth/identity/link links the guest identity to the signed-in account", async () => {
+  let receivedLink: Readonly<{
+    guestToken: string;
+    cognitoSubject: string;
+  }> | null = null;
+  const app = createGuestAuthTestApp({
+    authResult: {
+      ...createAuthResult("bearer"),
+      userId: "account-user",
+      subjectUserId: "account-subject",
+    },
+    onLinkGuestAnalyticsIdentity: async (guestToken, cognitoSubject) => {
+      receivedLink = { guestToken, cognitoSubject };
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/identity/link", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ guestToken: "guest-token-identity-link" }),
+  });
+
+  assert.equal(response.status, 200);
+  // The route passes the Cognito subject and nothing else: the account user id is resolved inside
+  // the writer's transaction, under the identity lifecycle lock.
+  assert.deepEqual(receivedLink, {
+    guestToken: "guest-token-identity-link",
+    cognitoSubject: "account-subject",
+  });
+  assert.deepEqual(await response.json(), { ok: true });
+});
+
+test("POST /guest-auth/identity/link rejects guest authentication", async () => {
+  let linked = false;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("guest"),
+    onLinkGuestAnalyticsIdentity: async () => {
+      linked = true;
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/identity/link", {
+    method: "POST",
+    headers: {
+      authorization: "Guest guest-token-identity-link",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ guestToken: "guest-token-identity-link" }),
+  });
+
+  assert.equal(response.status, 403);
+  assert.equal(linked, false);
+  assert.deepEqual(await response.json(), {
+    error: "Sign in before linking this guest identity.",
+    requestId: "request-1",
+    code: "GUEST_IDENTITY_LINK_HUMAN_AUTH_REQUIRED",
+  });
+});
+
+test("POST /guest-auth/identity/link reports a guest that owns data the upgrade transfers", async () => {
+  const app = createGuestAuthTestApp({
+    authResult: { ...createAuthResult("bearer"), userId: "account-user" },
+    onLinkGuestAnalyticsIdentity: async () => {
+      throw new HttpError(
+        409,
+        "This guest session owns data that the upgrade transfers and cannot be linked for analytics only. Convert it through /guest-auth/upgrade/complete instead.",
+        "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED",
+      );
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/identity/link", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ guestToken: "guest-token-identity-link" }),
+  });
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(await response.json(), {
+    error: "This guest session owns data that the upgrade transfers and cannot be linked for analytics only. Convert it through /guest-auth/upgrade/complete instead.",
+    requestId: "request-1",
+    code: "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED",
   });
 });
 

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -5,6 +5,7 @@ import {
   completeGuestUpgrade,
   createGuestSession,
   deleteGuestSession,
+  linkGuestAnalyticsIdentity,
   prepareGuestUpgrade,
   type GuestSessionPlatform,
   type GuestUpgradeCompleteCapabilities,
@@ -58,7 +59,26 @@ type GuestAuthRoutesOptions = Readonly<{
   createGuestSessionFn?: typeof createGuestSession;
   completeGuestUpgradeFn?: typeof completeGuestUpgrade;
   deleteGuestSessionFn?: typeof deleteGuestSession;
+  linkGuestAnalyticsIdentityFn?: typeof linkGuestAnalyticsIdentity;
 }>;
+
+type GuestSessionCreateRequest = Readonly<{
+  platform: GuestSessionPlatform | null;
+  idempotencyKey: string | null;
+}>;
+
+// Rotation makes this key an effective bearer credential for one guest identity: whoever presents it
+// is handed a fresh valid token for that guest's user and workspace. That only holds while the key
+// is unguessable and per attempt, so the accepted shape is the shape of a random token: lowercase
+// hex, at least 128 bits of it. The check is a floor, not a guarantee. It rejects the obviously
+// non-random values — a fixed label, a device or install id in canonical UUID form — but it cannot
+// tell a random token from the same install id with its hyphens stripped, or from any other 32-char
+// lowercase-hex constant. Per-attempt randomness and dropping the key once the attempt succeeds stay
+// client obligations, stated for the client work in `docs/auth-service.md`. The upper bound keeps
+// the column from being used as storage. Beyond this shape the backend only ever compares the value.
+const guestSessionIdempotencyKeyMinimumLength = 32;
+const guestSessionIdempotencyKeyMaximumLength = 200;
+const guestSessionIdempotencyKeyPattern = /^[0-9a-f]+$/;
 
 function parseGuestSessionPlatformValue(value: unknown): GuestSessionPlatform | null {
   if (value === undefined) {
@@ -81,12 +101,48 @@ function parseGuestSessionPlatformValue(value: unknown): GuestSessionPlatform | 
   throw new HttpError(400, "platform must be ios, android, or web", "GUEST_SESSION_PLATFORM_INVALID");
 }
 
-async function parseGuestSessionCreatePlatform(request: Request): Promise<GuestSessionPlatform | null> {
+/**
+ * Reads the optional idempotency key of one guest session creation attempt.
+ *
+ * The key is opaque: beyond the token shape asserted here it is never trimmed, parsed, echoed back
+ * or logged, because the only other thing the backend does with it is compare it. Clients must
+ * generate it from a cryptographic random source once per creation attempt and drop it once that
+ * attempt succeeds; `docs/auth-service.md` states that obligation for the client work that calls
+ * this route. The shape check narrows the room for getting that wrong — a key derived from an
+ * install id or a fixed label would be a stable, guessable credential for the guest identity it
+ * names — but it cannot enforce the obligation, because a stable value can still be hex. An absent
+ * key keeps the behaviour every shipped client relies on, which is a fresh guest identity per call.
+ */
+function parseGuestSessionIdempotencyKeyValue(value: unknown): string | null {
+  // An explicit JSON null means absent, not invalid. Serializers that encode unset optional fields
+  // rather than omitting them — kotlinx.serialization does by default — send it on every no-key
+  // call, and that path must stay the shipped-client behaviour instead of a 400.
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (
+    typeof value !== "string"
+    || value.length < guestSessionIdempotencyKeyMinimumLength
+    || value.length > guestSessionIdempotencyKeyMaximumLength
+    || !guestSessionIdempotencyKeyPattern.test(value)
+  ) {
+    throw new HttpError(
+      400,
+      `idempotencyKey must be ${guestSessionIdempotencyKeyMinimumLength} to ${guestSessionIdempotencyKeyMaximumLength} lowercase hexadecimal characters generated randomly for one creation attempt`,
+      "GUEST_SESSION_IDEMPOTENCY_KEY_INVALID",
+    );
+  }
+
+  return value;
+}
+
+async function parseGuestSessionCreateRequest(request: Request): Promise<GuestSessionCreateRequest> {
   const rawBody = await request.text();
   if (rawBody.trim() === "") {
     // Pre-1.7.0 iOS/Android clients create guest sessions with an empty body.
     // Keep this unbound legacy path until those mobile versions are no longer supported.
-    return null;
+    return { platform: null, idempotencyKey: null };
   }
 
   let parsedBody: unknown;
@@ -97,7 +153,10 @@ async function parseGuestSessionCreatePlatform(request: Request): Promise<GuestS
   }
 
   const body = expectRecord(parsedBody);
-  return parseGuestSessionPlatformValue(body.platform);
+  return {
+    platform: parseGuestSessionPlatformValue(body.platform),
+    idempotencyKey: parseGuestSessionIdempotencyKeyValue(body.idempotencyKey),
+  };
 }
 
 function parseGuestUpgradeSelection(value: unknown): GuestUpgradeSelection {
@@ -186,15 +245,47 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
   const createGuestSessionFn = options.createGuestSessionFn ?? createGuestSession;
   const completeGuestUpgradeFn = options.completeGuestUpgradeFn ?? completeGuestUpgrade;
   const deleteGuestSessionFn = options.deleteGuestSessionFn ?? deleteGuestSession;
+  const linkGuestAnalyticsIdentityFn = options.linkGuestAnalyticsIdentityFn ?? linkGuestAnalyticsIdentity;
 
   app.post("/guest-auth/session", async (context) => {
-    const platform = await parseGuestSessionCreatePlatform(context.req.raw);
-    const session = await createGuestSessionFn(platform);
+    const createRequest = await parseGuestSessionCreateRequest(context.req.raw);
+    const session = await createGuestSessionFn(createRequest.platform, createRequest.idempotencyKey);
     return context.json({
       guestToken: session.guestToken,
       userId: session.userId,
       workspaceId: session.workspaceId,
     } satisfies GuestSessionEnvelope);
+  });
+
+  // Claims a guest identity's analytics history for the account that just signed in on this browser
+  // or install. The guest token travels in the body, like the upgrade routes, because the request is
+  // authenticated as the account rather than as the guest.
+  //
+  // A `web` guest platform is accepted on purpose. The default-deny gate in
+  // server/requestContext.ts reads the credential on the request, which here is the account's, and a
+  // web guest is exactly what this route exists to claim.
+  //
+  // Like the upgrade routes, this one never loads a request context, so the 410 ACCOUNT_DELETED gate
+  // that requestContext.ts applies elsewhere is not reached here. The Cognito subject is therefore
+  // passed to the writer, which takes the identity lifecycle lock and asserts the subject is not
+  // deleted inside its own transaction.
+  app.post("/guest-auth/identity/link", async (context) => {
+    const auth = await authenticateRequestFn(toAuthRequest(extractRequestAuthInputs(context.req.raw)));
+    if (auth.transport !== "bearer" && auth.transport !== "session") {
+      throw new HttpError(
+        403,
+        "Sign in before linking this guest identity.",
+        "GUEST_IDENTITY_LINK_HUMAN_AUTH_REQUIRED",
+      );
+    }
+
+    const body = expectRecord(await parseJsonBody(context.req.raw));
+    const guestToken = expectNonEmptyString(body.guestToken, "guestToken");
+    // Only the Cognito subject is passed on. The account user id behind it is resolved inside the
+    // writer's transaction under the identity lifecycle lock, exactly as the upgrade routes resolve
+    // their target, because auth.userId falls back to the raw subject when no mapping exists yet.
+    await linkGuestAnalyticsIdentityFn(guestToken, auth.subjectUserId);
+    return context.json({ ok: true } as const);
   });
 
   app.post("/guest-auth/session/delete", async (context) => {

--- a/db/migrations/0117_guest_session_creation_idempotency.sql
+++ b/db/migrations/0117_guest_session_creation_idempotency.sql
@@ -1,0 +1,39 @@
+-- Migration status: Current / additive.
+-- Introduces: auth.guest_sessions.creation_idempotency_key, so a client that lost the response to
+--   POST /guest-auth/session can retry the same key and be handed its existing guest identity back
+--   instead of leaking a second guest user, a second workspace and a second analytics actor for one
+--   device, plus the partial unique index that holds the at-most-one-live-session-per-key invariant
+--   the creation path enforces.
+-- Schemas touched/read explicitly: auth.
+
+ALTER TABLE auth.guest_sessions
+  ADD COLUMN IF NOT EXISTS creation_idempotency_key TEXT;
+
+-- Partial for both predicates, and both are load-bearing.
+--
+-- NULL is excluded because every shipped client creates guest sessions without a key and must stay
+-- outside this constraint entirely.
+--
+-- revoked_at IS NULL is excluded because the creation path treats a revoked session for a key as
+-- absent and mints a new guest rather than resurrecting a credential that upgrade or deletion
+-- already retired. A lifetime-unique index would refuse to store that new guest's key, and the only
+-- way to keep creating would be to leave the key unstored, which silently drops the retry protection
+-- this column exists for. The predicate matches the creation path's own lookup, which is likewise
+-- restricted to live sessions, and mirrors idx_guest_sessions_active_hash from 0031.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_guest_sessions_active_creation_idempotency_key
+  ON auth.guest_sessions (creation_idempotency_key)
+  WHERE creation_idempotency_key IS NOT NULL AND revoked_at IS NULL;
+
+COMMENT ON COLUMN auth.guest_sessions.creation_idempotency_key IS
+  'Opaque client-generated key for one guest session creation attempt, sent as idempotencyKey on '
+  'POST /guest-auth/session. It is only ever compared, never parsed or logged. The route accepts it '
+  'only as 32 to 200 lowercase hexadecimal characters, which is a floor on shape, not a guarantee '
+  'of randomness: it rejects obviously non-random values such as a fixed label or an install id in '
+  'canonical UUID form, but a hyphen-stripped install id and any other 32-character lowercase-hex '
+  'constant pass it, so generating the key randomly per attempt stays a client obligation. A retry '
+  'carrying a key that still names a live guest session rotates that session''s secret and returns '
+  'the existing guest user and workspace, so a lost response cannot leave a device with two guest '
+  'identities. The key is cleared here, and a fresh guest is created instead, once the named '
+  'session''s user has been bound to a real account, because a key buys a guest token by design and '
+  'must never buy one for an account. NULL is the shipped-client shape and always creates a fresh '
+  'guest.';

--- a/docs/auth-service.md
+++ b/docs/auth-service.md
@@ -18,6 +18,57 @@ Email + OTP authentication via AWS Cognito (passwordless).
     keeps every guest surface it has today.
   - `POST /v1/guest-auth/session` and `POST /v1/guest-auth/session/delete` stay open to it: they are
     the credential's own lifecycle and authenticate outside the request-context loader.
+  - `POST /v1/guest-auth/identity/link` is authenticated as the signed-in account and takes the guest
+    token from its body, so it accepts a `web` guest. It links that guest identity to the account for
+    analytics and revokes the guest session. An unknown or already-revoked token is a successful
+    no-op, and so is a guest session that already belongs to the signed-in account after a bound
+    upgrade: that credential is neither linked nor revoked. Like the upgrade routes it does not load a
+    request context, so it applies the `410 ACCOUNT_DELETED` gate itself, and it resolves the account
+    user id from `auth.user_identities` in its own transaction rather than trusting the id on the
+    request.
+    - Client ordering obligation: the account's `auth.user_identities` row is written by the first
+      request that loads a request context after sign-in, such as `GET /v1/me`. Nothing sequences
+      that for you. Await one such call before calling this route; two requests fired in parallel
+      right after a first-ever sign-in can let the link reach the database first.
+    - Upgrade ordering obligation: never send a guest token here that may still need
+      `POST /v1/guest-auth/upgrade/prepare` or `POST /v1/guest-auth/upgrade/complete`. This route
+      revokes the guest session, and both upgrade routes refuse a revoked token with
+      `401 GUEST_AUTH_INVALID`: `prepare` rejects it outright, and `complete` looks for an
+      `auth.guest_upgrade_history` replay row and finds none for a session that was never upgraded.
+      No data is lost, because a guest that owns anything is refused below with
+      `409 GUEST_IDENTITY_LINK_UPGRADE_REQUIRED` rather than revoked, but that token's upgrade path
+      is gone. Run the upgrade flow first, or reserve this route for guest credentials that exist
+      only to authenticate analytics.
+    - `409 GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED` means exactly that ordering has not happened yet, and
+      it is retryable rather than terminal. Keep the guest token, complete a request-context call, and
+      call again. Never drop the guest token on this code: that guest's whole analytics tail goes with
+      it, permanently.
+    - `409 GUEST_IDENTITY_LINK_UPGRADE_REQUIRED` means the guest owns data the upgrade flow transfers
+      and must convert through `POST /v1/guest-auth/upgrade/complete` instead. Terminal for this
+      route; retrying it unchanged never succeeds.
+    - `409 GUEST_IDENTITY_LINK_OTHER_ACCOUNT` means the guest token names a user that is already a
+      different real account. Terminal: the client is holding a credential that is not its own and
+      should discard it rather than retry.
+    - A `5xx` must be retried, with the guest token kept. The identity link commits on the analytics
+      pool and the revoke commits with the request transaction, so a failure between them can leave
+      the link written and the guest session still live. The retry is safe — it conflicts on the
+      same guest and account pair, stores nothing new, and completes the revoke — and it is not
+      optional: a guest session left live can later be bound to a *different* account, and the
+      orphan link would then attribute that account's whole pre-account analytics tail to this one
+      permanently.
+- `POST /v1/guest-auth/session` accepts an optional `idempotencyKey`. A retry carrying a key that
+  still names a live session rotates that session's secret and returns the same guest user and
+  workspace, so a lost response cannot leave one device with two guest identities. Client contract:
+  the key must be 32 to 200 lowercase hexadecimal characters, generated from a cryptographic random
+  source once per creation attempt and dropped once that attempt succeeds. Anything outside that
+  shape is refused with `400 GUEST_SESSION_IDEMPOTENCY_KEY_INVALID`, and an omitted key or an
+  explicit JSON `null` both mean no key at all, which keeps today's behaviour of a fresh guest per
+  call. The shape check is a floor, not a guarantee: it rejects obviously non-random values such as a
+  fixed label or an install id in canonical UUID form, but a hyphen-stripped install id and any other
+  32-character lowercase-hex constant pass it. Generating the key randomly per attempt and dropping
+  it on success therefore remain client obligations, and they matter: rotation hands whoever presents
+  the key a fresh valid token for that guest's user and workspace, so a key that is stable across
+  attempts or guessable is a bearer credential for that guest identity.
 - Auth Lambda serves the auth UI/API on `auth.<domain>` and `/v1` execute-api stage paths
 - Backend Lambda verifies JWTs with `aws-jwt-verify`
 - Key files:

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -1108,6 +1108,21 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   analyticsEvents.addMethod("ANY", integration);
   analyticsEvents.addMethod("POST", integration);
 
+  // POST /guest-auth/identity/link, which lets a freshly signed-in browser or install claim the
+  // analytics history of the guest identity it held. The root {proxy+} already forwards it, so this
+  // subtree exists to keep this file in sync with the backend routes, as CLAUDE.md requires. The
+  // subtree fallbacks are restated the way the analytics, workspace and admin subtrees restate
+  // theirs, so /guest-auth/session, /guest-auth/session/delete and the upgrade routes keep being
+  // forwarded here if the root proxy ever narrows.
+  const guestAuth = restApi.root.addResource("guest-auth");
+  guestAuth.addMethod("ANY", integration);
+  guestAuth.addResource("{proxy+}").addMethod("ANY", integration);
+  const guestAuthIdentity = guestAuth.addResource("identity");
+  guestAuthIdentity.addMethod("ANY", integration);
+  const guestAuthIdentityLink = guestAuthIdentity.addResource("link");
+  guestAuthIdentityLink.addMethod("ANY", integration);
+  guestAuthIdentityLink.addMethod("POST", integration);
+
   addDirectImageIngestionApiRoutes(
     restApi,
     integration,

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0116_guest_session_web_platform.sql",
+    "0117_guest_session_creation_idempotency.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0116_guest_session_web_platform.sql"
+    && resource.Properties?.RequiredMigration === "0117_guest_session_creation_idempotency.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -98,7 +98,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
   for (const { relativePath, requiredMigration } of [
     {
       relativePath: "../../.github/workflows/aws-web-release.yml",
-      requiredMigration: "0116_guest_session_web_platform.sql",
+      requiredMigration: "0117_guest_session_creation_idempotency.sql",
     },
     {
       relativePath: "../../scripts/deploy/bootstrap.sh",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -208,7 +208,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0116_guest_session_web_platform.sql",
+    "--require-migration 0117_guest_session_creation_idempotency.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -238,7 +238,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0116_guest_session_web_platform\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0117_guest_session_creation_idempotency\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -351,7 +351,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0116_guest_session_web_platform.sql",
+      "0117_guest_session_creation_idempotency.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,


### PR DESCRIPTION
Two additions to the guest session lifecycle, both additive and unused until the web, iOS and Android callers ship.

## Idempotent creation

A lost response used to leave an unreferenced guest user, workspace and membership on the server that no client would ever present again. A client may now send a creation idempotency key; a retry carrying the same key rotates the stored secret and returns the same user and workspace instead of minting a second identity. The key is taken under an advisory lock **before any row is created**, so two concurrent retries cannot both create a guest.

The shape check is a floor, not a guarantee. It rejects a fixed label and a canonical-UUID install id, but a hyphen-stripped install id passes — so generating the key randomly per attempt stays a client obligation, and the route comment, the docs and the migration comment all say exactly that.

## The identity-link route

Lets an account claim the analytics history of the guest identity that browser or install held. It writes the `server_derived` link the resolved view reads, and revokes the guest session.

It merges no workspace — that is what the upgrade flow is for — and it **refuses a guest that owns anything the upgrade transfers**, so no data is ever stranded behind a revoked credential.

**Three states are refused rather than linked, because a wrong first link is permanent.** `identity_links` attributes an anonymous tail to the *first* link for a pair, so misattribution has no repair path:

- a guest whose user is already a bound account is never linked to a different account;
- a subject with no account mapping is refused, rather than linked to a raw Cognito subject that may later become somebody else's guest user id;
- a guest that is already this account is a no-op that neither links nor revokes, since revoking it would make a later upgrade retry answer 401.

## Why link-before-revoke

The two writes cannot share a transaction — the analytics writer commits on its own pool. A lost link costs that guest's whole resolved history; a lost revoke costs nothing. So the link is the write that survives when only one does, and the docs require a client to retry a `5xx` and keep its guest token, because an orphaned link with a live session is the one state that can later attribute one account's history to another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)