### PR TITLE
Reap web guest identities that never became an account

### DIFF
--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-web-guest-reaper.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-web-guest-reaper.ts
@@ -1,0 +1,256 @@
+import type { Handler } from "aws-lambda";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  wrapBackendHandler,
+} from "../../observability/sentry";
+
+initializeBackendSentry("web-guest-reaper");
+
+type WebGuestReaperEvent = Readonly<{
+  batchSize?: unknown;
+  maxPages?: unknown;
+}>;
+
+type WebGuestReaperResponse = Readonly<{
+  ok: true;
+  batchSize: number;
+  maxPages: number;
+  inactivityThresholdDays: number;
+  inactiveBefore: string;
+  pagesScanned: number;
+  candidatesExamined: number;
+  deleted: number;
+  skipped: number;
+  skippedWorkspaceHasContent: number;
+  skippedWorkspaceNotSoleOwned: number;
+  skippedWorkspaceMissing: number;
+  skippedNoLongerCandidate: number;
+  interrupted: number;
+  failed: number;
+  finished: boolean;
+}>;
+
+type WebGuestReaperRuntime = Readonly<{
+  reapInactiveWebGuests: typeof import("../../guestAuth/reaper").reapInactiveWebGuests;
+}>;
+
+// One daily invocation walks up to scheduledBatchSize * scheduledMaxPages guests, which has to stay
+// comfortably above the rate signed-out browsers mint web guest rows; a run that cannot keep up
+// returns finished: false rather than silently capping. The Lambda deadline, not this product, is
+// the real bound on a slow run.
+const scheduledBatchSize = 500;
+const scheduledMaxPages = 5;
+const maximumBatchSize = 2_000;
+const maximumMaxPages = 100;
+// Held back from the deadline handed to the run so the completion record below still gets written
+// after the loop returns. It covers finalization only: the run keeps its own reserve for each unit
+// of work it starts, so no scan or guest transaction is begun that could still be running when this
+// reserve starts.
+const finalizationReserveMs = 10_000;
+
+let webGuestReaperRuntimePromise: Promise<WebGuestReaperRuntime> | null = null;
+
+async function createWebGuestReaperRuntime(): Promise<WebGuestReaperRuntime> {
+  const { reapInactiveWebGuests } = await import("../../guestAuth/reaper");
+  return {
+    reapInactiveWebGuests,
+  };
+}
+
+function getWebGuestReaperRuntime(): Promise<WebGuestReaperRuntime> {
+  if (webGuestReaperRuntimePromise === null) {
+    webGuestReaperRuntimePromise = createWebGuestReaperRuntime();
+  }
+
+  return webGuestReaperRuntimePromise;
+}
+
+export function calculateWebGuestReaperDeadlineAtMs(nowMs: number, remainingTimeMs: number): number {
+  if (
+    !Number.isSafeInteger(nowMs)
+    || nowMs < 1
+    || !Number.isSafeInteger(remainingTimeMs)
+    || remainingTimeMs < 0
+  ) {
+    throw new RangeError("Web guest reaper deadline inputs must be non-negative safe integers.");
+  }
+
+  return nowMs + Math.max(0, remainingTimeMs - finalizationReserveMs);
+}
+
+function readOptionalIntegerField(
+  event: WebGuestReaperEvent,
+  fieldName: "batchSize" | "maxPages",
+): number | null {
+  const value = event[fieldName];
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`${fieldName} must be an integer when provided`);
+  }
+
+  return value;
+}
+
+function resolveBoundedInteger(
+  value: number | null,
+  fallbackValue: number,
+  fieldName: "batchSize" | "maxPages",
+  maximumValue: number,
+): number {
+  const resolvedValue = value ?? fallbackValue;
+  if (resolvedValue < 1 || resolvedValue > maximumValue) {
+    throw new Error(`${fieldName} must be between 1 and ${maximumValue}`);
+  }
+
+  return resolvedValue;
+}
+
+function createReaperRequest(event: WebGuestReaperEvent): Readonly<{
+  batchSize: number;
+  maxPages: number;
+}> {
+  return {
+    batchSize: resolveBoundedInteger(
+      readOptionalIntegerField(event, "batchSize"),
+      scheduledBatchSize,
+      "batchSize",
+      maximumBatchSize,
+    ),
+    maxPages: resolveBoundedInteger(
+      readOptionalIntegerField(event, "maxPages"),
+      scheduledMaxPages,
+      "maxPages",
+      maximumMaxPages,
+    ),
+  };
+}
+
+function createFailureDetails(
+  request: Readonly<{ batchSize: number; maxPages: number }> | null,
+  error: Error,
+): Readonly<{
+  batchSize: number | null;
+  maxPages: number | null;
+  message: string;
+}> {
+  return {
+    batchSize: request?.batchSize ?? null,
+    maxPages: request?.maxPages ?? null,
+    message: error.message,
+  };
+}
+
+const webGuestReaperHandler: Handler<WebGuestReaperEvent, WebGuestReaperResponse> = async (
+  event,
+  context,
+) => {
+  const observationScope = createBackendObservationScope(
+    "web-guest-reaper",
+    context.awsRequestId ?? null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  let request: Readonly<{ batchSize: number; maxPages: number }> | null = null;
+  try {
+    request = createReaperRequest(event);
+    const runtime = await getWebGuestReaperRuntime();
+    const result = await runtime.reapInactiveWebGuests(
+      {
+        batchSize: request.batchSize,
+        maxPages: request.maxPages,
+        deadlineAtMs: calculateWebGuestReaperDeadlineAtMs(
+          Date.now(),
+          context.getRemainingTimeInMillis(),
+        ),
+      },
+      observationScope,
+    );
+
+    addBackendBreadcrumb({
+      action: "web_guest_reaper_completed",
+      scope: observationScope,
+      details: {
+        batchSize: request.batchSize,
+        maxPages: request.maxPages,
+        inactivityThresholdDays: result.inactivityThresholdDays,
+        inactiveBeforeUtc: result.inactiveBefore,
+        pagesScanned: result.pagesScanned,
+        candidatesExamined: result.candidatesExamined,
+        deleted: result.deleted,
+        skipped: result.skipped,
+        skippedWorkspaceHasContent: result.skippedWorkspaceHasContent,
+        skippedWorkspaceNotSoleOwned: result.skippedWorkspaceNotSoleOwned,
+        skippedWorkspaceMissing: result.skippedWorkspaceMissing,
+        skippedNoLongerCandidate: result.skippedNoLongerCandidate,
+        interrupted: result.interrupted,
+        failed: result.failed,
+        scanFailed: result.scanFailed,
+        finished: result.finished,
+      },
+    });
+
+    // A candidate scan that throws is caught by the run so the record above still reports the
+    // guests it had already deleted permanently, but the invocation must not end cleanly:
+    // WebGuestReaperLambdaErrorAlarm is the stated reason the deferred auth.guest_sessions
+    // (platform, created_at) index is safe to defer, and the unindexed scan outgrowing the
+    // reporting role's 30s statement_timeout is exactly the failure it has to see. The staleness
+    // alarm cannot stand in for it, because an errored invocation still counts in Invocations.
+    if (result.scanFailed) {
+      throw new Error(`Web guest reaper stopped on a failed candidate scan after ${result.pagesScanned} scanned pages, having deleted ${result.deleted} guests and failed on ${result.failed}`);
+    }
+
+    // Every guest is deleted in its own transaction, so the batch completes even when one guest
+    // fails. The run still has to report failure, otherwise a guest that fails on every invocation
+    // is invisible outside its own warning record. A run that only ran out of time reports
+    // interrupted rather than failed, so it does not reach this throw. Both the schedule's retry
+    // policy and the function's own async retry attempts are pinned to 0 for exactly this throw: a
+    // destructive job must not be replayed against the same poison candidate, and the failure
+    // reaches an operator through the Lambda error alarm instead.
+    if (result.failed > 0) {
+      throw new Error(`Web guest reaper failed to delete ${result.failed} of ${result.candidatesExamined} examined guests`);
+    }
+
+    return {
+      ok: true,
+      batchSize: request.batchSize,
+      maxPages: request.maxPages,
+      inactivityThresholdDays: result.inactivityThresholdDays,
+      inactiveBefore: result.inactiveBefore,
+      pagesScanned: result.pagesScanned,
+      candidatesExamined: result.candidatesExamined,
+      deleted: result.deleted,
+      skipped: result.skipped,
+      skippedWorkspaceHasContent: result.skippedWorkspaceHasContent,
+      skippedWorkspaceNotSoleOwned: result.skippedWorkspaceNotSoleOwned,
+      skippedWorkspaceMissing: result.skippedWorkspaceMissing,
+      skippedNoLongerCandidate: result.skippedNoLongerCandidate,
+      interrupted: result.interrupted,
+      failed: result.failed,
+      finished: result.finished,
+    };
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "web_guest_reaper_failed",
+      error: normalizedError,
+      scope: observationScope,
+      details: createFailureDetails(request, normalizedError),
+    });
+    throw error;
+  }
+};
+
+export const handler = wrapBackendHandler(webGuestReaperHandler);

--- a/apps/backend/src/guestAuth/reaper/index.ts
+++ b/apps/backend/src/guestAuth/reaper/index.ts
@@ -1,0 +1,757 @@
+import type pg from "pg";
+import {
+  applyWorkspaceDatabaseScopeInExecutor,
+  runDatabaseOperationsWithDeadline,
+  DatabaseDeadlineExceededError,
+  type DatabaseExecutor,
+  type SqlValue,
+} from "../../database";
+import {
+  DatabaseCommitOutcomeUnknownError,
+  getDatabaseErrorFields,
+} from "../../database/transient";
+import { unsafeTransaction } from "../../database/unsafe";
+import { withReportingReadOnlyTransaction } from "../../admin/reportingDb";
+import {
+  captureBackendWarning,
+  normalizeCaughtError,
+  type BackendObservationScope,
+} from "../../observability/sentry";
+import { toIsoString } from "../shared";
+import {
+  deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor,
+  deleteUserSettingsInExecutor,
+  loadGuestWorkspaceIdOrNullInExecutor,
+} from "../store/index";
+
+/**
+ * Permanent removal of web guest identities that never became an account and stopped being seen.
+ *
+ * A web guest is an analytics credential a signed-out browser mints on its first interaction. It is
+ * refused on every authenticated surface except analytics ingest, so its auto-created workspace is
+ * empty by construction and the four rows it owns only accumulate. `ios` and `android` guests own a
+ * real offline workspace and can be upgraded into an account, so they are deliberately never
+ * candidates here, and neither is the `NULL` platform that pre-1.7.0 mobile clients still write.
+ *
+ * `auth.guest_sessions.last_seen_at` is not a liveness signal: no code path ever updates it and it
+ * always equals `created_at`. Liveness is the newest server clock reading on the guest's
+ * `analytics.product_events` rows, falling back to when its newest session was created if it
+ * produced no events at all.
+ */
+
+const webGuestInactivityThresholdDays = 90;
+
+const minimumBatchSize = 1;
+const maximumBatchSize = 2_000;
+const minimumMaxPages = 1;
+const maximumMaxPages = 100;
+const serverDerivedIdentityLinkSource = "server_derived";
+// auth.guest_sessions.user_id is TEXT while analytics.product_events.user_id and
+// analytics.identity_links.anonymous_id are UUID. A guest id that is not a UUID can match no
+// analytics row at all, so it resolves to NULL instead of failing the whole batch on a cast error.
+const guestUserIdUuidPattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
+// Microsecond precision with an explicit UTC offset, which is what a timestamptz actually stores
+// and what makes the keyset walk exact when the value is sent back as the cursor.
+const cursorTimestampFormat = 'YYYY-MM-DD"T"HH24:MI:SS.USOF';
+// The workspace_seed replica is written by workspace bootstrap itself, in the same transaction as
+// org.workspaces, so it is present in every workspace and is never a sign of guest activity.
+const bootstrapWorkspaceReplicaActorKind = "workspace_seed";
+// The two SQLSTATEs a guest that ran out of its own budget surfaces as. `database/deadline.ts`
+// configures both server-side timeouts before every statement: a `statement_timeout` of the guest
+// transaction's remaining budget minus a 250ms rollback reserve, and a `lock_timeout` one
+// millisecond under it. `57014` (query_canceled) is what a guest that spends that budget *running*
+// a statement raises, shortly before the JavaScript-side deadline could fire. `55P03`
+// (lock_not_available) is what a guest that spends it *waiting* for a lock raises a millisecond
+// earlier: the `FOR UPDATE` in loadGuestWorkspaceIdOrNullInExecutor, or the `pg_advisory_xact_lock`
+// deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor takes. Both mean the same thing here - the
+// server stopped this guest because its budget was gone, the transaction is aborted and rolled
+// back, and nothing was deleted - so both are the run running out of time, not a guest that failed.
+const guestBudgetExhaustedSqlStates: ReadonlySet<string> = new Set(["57014", "55P03"]);
+
+type WebGuestReaperCursor = Readonly<{
+  latestSessionCreatedAt: string;
+  guestUserId: string;
+}> | null;
+
+type WebGuestReaperCandidate = Readonly<{
+  guestUserId: string;
+  analyticsUserId: string | null;
+  latestSessionCreatedAt: string;
+  lastActiveAt: string;
+}>;
+
+type WebGuestReaperSkipReason =
+  | "workspace_has_content"
+  | "workspace_not_sole_owned"
+  | "workspace_missing"
+  | "no_longer_a_candidate";
+
+type WebGuestReaperCandidateOutcome =
+  | Readonly<{ outcome: "deleted"; workspaceId: string }>
+  | Readonly<{ outcome: "skipped"; workspaceId: string | null; reason: WebGuestReaperSkipReason }>;
+
+export type WebGuestReaperRequest = Readonly<{
+  batchSize: number;
+  maxPages: number;
+  deadlineAtMs: number;
+}>;
+
+export type WebGuestReaperResult = Readonly<{
+  inactivityThresholdDays: number;
+  inactiveBefore: string;
+  pagesScanned: number;
+  candidatesExamined: number;
+  deleted: number;
+  skipped: number;
+  skippedWorkspaceHasContent: number;
+  skippedWorkspaceNotSoleOwned: number;
+  skippedWorkspaceMissing: number;
+  skippedNoLongerCandidate: number;
+  interrupted: number;
+  failed: number;
+  // The run stopped on a candidate scan that threw. Everything the run already deleted is counted
+  // in the fields above, and the entrypoint still turns this flag into a thrown error.
+  scanFailed: boolean;
+  finished: boolean;
+}>;
+
+type WebGuestReaperCandidateRow = Readonly<{
+  guest_user_id: string;
+  analytics_user_id: string | null;
+  latest_session_created_at: string;
+  last_active_at: Date | string;
+}>;
+
+type GuestWorkspaceContentPresenceRow = Readonly<{
+  has_content: boolean;
+}>;
+
+type WebGuestStillReapableRow = Readonly<{
+  still_reapable: boolean;
+}>;
+
+type ReportingQueryExecutor = Readonly<{
+  query<Row extends pg.QueryResultRow>(
+    text: string,
+    params: ReadonlyArray<SqlValue>,
+  ): Promise<pg.QueryResult<Row>>;
+}>;
+
+// Each guest is reaped in its own transaction with its own deadline, so a guest that has to be
+// skipped or that fails cannot roll back the rest of the batch and cannot stall the run either.
+// A guest transaction is started only when this whole budget is still available: starting one with
+// whatever is left makes the deadline fire mid-transaction, which is a run that ran out of time
+// rather than a guest that failed.
+const guestDeadlineMs = 15_000;
+// The candidate scan is bounded only by the reporting role's own 30s statement_timeout (migration
+// 0044), so a page is started only when that much of the run budget is still left. Without the
+// reserve, a scan begun just before the deadline runs past the entrypoint's finalization reserve
+// and hard-times-out the Lambda, which loses the whole web_guest_reaper_completed record. The
+// reserve covers the whole scan only because a scan is attempted exactly once; see loadCandidates.
+const candidateScanBudgetMs = 30_000;
+
+function requireIntegerInRange(
+  value: number,
+  fieldName: string,
+  minimumValue: number,
+  maximumValue: number,
+): number {
+  if (!Number.isInteger(value) || value < minimumValue || value > maximumValue) {
+    throw new Error(`${fieldName} must be an integer between ${minimumValue} and ${maximumValue}`);
+  }
+
+  return value;
+}
+
+function calculateWebGuestInactiveBefore(nowMs: number): Date {
+  return new Date(nowMs - webGuestInactivityThresholdDays * 24 * 60 * 60 * 1_000);
+}
+
+function mapCandidateRow(row: WebGuestReaperCandidateRow): WebGuestReaperCandidate {
+  return {
+    guestUserId: row.guest_user_id,
+    analyticsUserId: row.analytics_user_id,
+    // Kept exactly as PostgreSQL rendered it, microseconds included: it is fed straight back as the
+    // keyset cursor and a JS Date would floor it to milliseconds first. See the query below.
+    latestSessionCreatedAt: row.latest_session_created_at,
+    lastActiveAt: toIsoString(row.last_active_at),
+  };
+}
+
+function createCursorFromCandidate(candidate: WebGuestReaperCandidate): WebGuestReaperCursor {
+  return {
+    latestSessionCreatedAt: candidate.latestSessionCreatedAt,
+    guestUserId: candidate.guestUserId,
+  };
+}
+
+/**
+ * Reads across every guest, so it runs as the read-only reporting role: row level security scopes
+ * the runtime role's own view of `org` and `content` to one user at a time. The reporting role
+ * carries a 30s `statement_timeout` of its own (migration `0044`), which is what bounds this scan.
+ *
+ * The page is a keyset walk over `(latest_session_created_at, guest_user_id)` rather than a bare
+ * `LIMIT`: a guest that is skipped for good, such as one whose workspace turned out to hold
+ * content, would otherwise sit at the head of the ordering and consume a slot of every future run.
+ *
+ * `rowLimit` is the SQL `LIMIT`, not the page size: the caller asks for one row past the page it
+ * intends to process so that a full page can be told apart from a page that exhausted the
+ * candidates.
+ */
+async function loadWebGuestReaperCandidatesInExecutor(
+  executor: ReportingQueryExecutor,
+  inactiveBefore: Date,
+  rowLimit: number,
+  cursor: WebGuestReaperCursor,
+): Promise<ReadonlyArray<WebGuestReaperCandidate>> {
+  const result = await executor.query<WebGuestReaperCandidateRow>(
+    [
+      "WITH stale_web_guest_sessions AS (",
+      "SELECT",
+      "guest_sessions.user_id AS guest_user_id,",
+      "MAX(guest_sessions.created_at) AS latest_session_created_at",
+      "FROM auth.guest_sessions AS guest_sessions",
+      // Mobile guests are out of scope by product decision, not by oversight: ios and android
+      // guests own a syncable workspace and an upgrade path, and NULL is what pre-1.7.0 mobile
+      // clients still write, so neither may ever reach the deletion loop below.
+      "WHERE guest_sessions.platform = 'web'",
+      "AND guest_sessions.created_at < $1::timestamptz",
+      "GROUP BY guest_sessions.user_id",
+      "),",
+      "stale_web_guests AS (",
+      "SELECT",
+      "sessions.guest_user_id,",
+      "sessions.latest_session_created_at,",
+      "CASE",
+      `WHEN sessions.guest_user_id ~ '${guestUserIdUuidPattern}'`,
+      "THEN sessions.guest_user_id::uuid",
+      "END AS analytics_user_id",
+      "FROM stale_web_guest_sessions AS sessions",
+      // Deleting org.user_settings cascades every session the guest owns, so a guest that also
+      // holds a mobile session, or a web session newer than the threshold, is not a candidate.
+      "WHERE NOT EXISTS (",
+      "SELECT 1",
+      "FROM auth.guest_sessions AS other_sessions",
+      "WHERE other_sessions.user_id = sessions.guest_user_id",
+      "AND (",
+      "other_sessions.platform IS DISTINCT FROM 'web'",
+      "OR other_sessions.created_at >= $1::timestamptz",
+      ")",
+      ")",
+      ")",
+      "SELECT",
+      "guests.guest_user_id,",
+      "guests.analytics_user_id,",
+      // Rendered as text with microseconds and an explicit offset rather than returned as a
+      // timestamptz: the value comes straight back as the keyset cursor below, and a driver-mapped
+      // JS Date would floor it to milliseconds, which moves the cursor slightly backwards and lets
+      // the boundary guest of a page be returned again on the next one.
+      `to_char(guests.latest_session_created_at, '${cursorTimestampFormat}') AS latest_session_created_at,`,
+      "COALESCE(latest_event.last_seen_at, guests.latest_session_created_at) AS last_active_at",
+      "FROM stale_web_guests AS guests",
+      // One indexed lookup per candidate through idx_product_events_user_id (migration 0115), so
+      // the event table is never scanned. The driving aggregate above has no such support:
+      // auth.guest_sessions carries only (user_id, created_at DESC) and the active-token hash
+      // index (migration 0031), so every run reads the whole session table, bounded only by the
+      // reporting role's 30s statement_timeout. A (platform, created_at) index is what would make
+      // it a range scan.
+      "LEFT JOIN LATERAL (",
+      // occurred_at is the skew-corrected client clock and can sit up to 30 days before the server
+      // ever saw the batch, so it alone would let a guest look older than it is. ingested_at is the
+      // documented server-clock checkpoint, and the later of the two is "when the server last saw
+      // anything from this guest", which is what the 90 days is meant to measure.
+      "SELECT GREATEST(MAX(events.occurred_at), MAX(events.ingested_at)) AS last_seen_at",
+      "FROM analytics.product_events AS events",
+      "WHERE events.user_id = guests.analytics_user_id",
+      ") AS latest_event ON TRUE",
+      // A server-derived identity link is the only record that this guest became an account, so its
+      // absence is what "never signed in" means.
+      "WHERE NOT EXISTS (",
+      "SELECT 1",
+      "FROM analytics.identity_links AS identity_links",
+      "WHERE identity_links.anonymous_id = guests.analytics_user_id",
+      "AND identity_links.source = $2",
+      ")",
+      "AND COALESCE(latest_event.last_seen_at, guests.latest_session_created_at) < $1::timestamptz",
+      "AND (",
+      "$4::timestamptz IS NULL",
+      "OR (guests.latest_session_created_at, guests.guest_user_id) > ($4::timestamptz, $5::text)",
+      ")",
+      "ORDER BY guests.latest_session_created_at ASC, guests.guest_user_id ASC",
+      "LIMIT $3",
+    ].join(" "),
+    [
+      inactiveBefore,
+      serverDerivedIdentityLinkSource,
+      rowLimit,
+      cursor?.latestSessionCreatedAt ?? null,
+      cursor?.guestUserId ?? null,
+    ],
+  );
+
+  return result.rows.map(mapCandidateRow);
+}
+
+/**
+ * Re-asserts the candidate rule inside the deletion transaction.
+ *
+ * Candidates are selected once per page as the reporting role and then deleted one at a time, so a
+ * guest that produced an event, signed in, or opened a new session between its selection and its
+ * own turn would otherwise be deleted on stale evidence, and the deletion is permanent. The runtime
+ * role reads both analytics tables under `USING (true)` policies (migration `0114`) and
+ * `auth.guest_sessions` has no row level security, so the whole rule is available here, and
+ * `idx_product_events_user_id` plus `idx_guest_sessions_user_created` serve both lookups.
+ *
+ * This narrows the window, it does not close it. The `FOR UPDATE` the caller already holds on
+ * `org.user_settings` pins nothing read here: analytics ingest inserts into
+ * `analytics.product_events` without touching that row, and the transaction is READ COMMITTED, so a
+ * guest that becomes active between this re-check and the delete below is still deleted. The
+ * residual window is the few milliseconds those statements take, and reaching it needs a guest that
+ * was dormant for 90 days to come back inside exactly that window, so it is accepted rather than
+ * locked against.
+ */
+async function webGuestIsStillReapableInExecutor(
+  executor: DatabaseExecutor,
+  candidate: WebGuestReaperCandidate,
+  inactiveBefore: Date,
+): Promise<boolean> {
+  const result = await executor.query<WebGuestStillReapableRow>(
+    [
+      "SELECT (",
+      "NOT EXISTS (",
+      "SELECT 1",
+      "FROM analytics.identity_links AS identity_links",
+      "WHERE identity_links.anonymous_id = $2::uuid",
+      "AND identity_links.source = $3",
+      ")",
+      "AND NOT EXISTS (",
+      "SELECT 1",
+      "FROM analytics.product_events AS events",
+      "WHERE events.user_id = $2::uuid",
+      "AND GREATEST(events.occurred_at, events.ingested_at) >= $4::timestamptz",
+      ")",
+      "AND NOT EXISTS (",
+      "SELECT 1",
+      "FROM auth.guest_sessions AS guest_sessions",
+      "WHERE guest_sessions.user_id = $1",
+      "AND (",
+      "guest_sessions.platform IS DISTINCT FROM 'web'",
+      "OR guest_sessions.created_at >= $4::timestamptz",
+      ")",
+      ")",
+      ") AS still_reapable",
+    ].join(" "),
+    [
+      candidate.guestUserId,
+      candidate.analyticsUserId,
+      serverDerivedIdentityLinkSource,
+      inactiveBefore,
+    ],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Web guest liveness re-check returned no row for guest ${candidate.guestUserId}`);
+  }
+
+  return row.still_reapable;
+}
+
+/**
+ * Deleting `org.workspaces` cascades far past the four content tables a card lives in, so the probe
+ * covers every cascading child a pristine guest workspace has no row in. Three cascading children
+ * are deliberately absent: `org.workspace_memberships`, `sync.workspace_sync_metadata` and
+ * `sync.hot_changes` are written by workspace bootstrap itself, so a row in them proves nothing.
+ * `sync.workspace_replicas` is bootstrapped too, which is why only a non-seed actor counts; every
+ * sync push, AI chat and upload claim mints one of those first, so it also stands in for
+ * `content.media_upload_session_creation_claims`. That table must not be added here as a
+ * belt-and-braces check: migration `0100` ends with
+ * `REVOKE ALL ON TABLE content.media_upload_session_creation_claims FROM PUBLIC, backend_app,
+ * auth_app, reporting_readonly` and no later migration grants it back, so `backend_app` holds no
+ * privilege on it at all and a direct probe raises `permission denied` for every candidate rather
+ * than reading empty, which would mark every guest failed and stop all deletion.
+ */
+async function guestWorkspaceHasContentInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+  guestWorkspaceId: string,
+): Promise<boolean> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: guestUserId,
+    workspaceId: guestWorkspaceId,
+  });
+  const result = await executor.query<GuestWorkspaceContentPresenceRow>(
+    [
+      "SELECT (",
+      "EXISTS (SELECT 1 FROM content.cards WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM content.decks WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM content.review_events WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM content.media_assets WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM content.media_upload_sessions WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM content.generated_media_promotion_jobs WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM ai.chat_sessions WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM sync.applied_operations_current WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (SELECT 1 FROM sync.catalog_package_install_idempotency WHERE workspace_id = $1::uuid)",
+      "OR EXISTS (",
+      "SELECT 1 FROM sync.workspace_replicas",
+      "WHERE workspace_id = $1::uuid AND actor_kind <> $2",
+      ")",
+      ") AS has_content",
+    ].join(" "),
+    [guestWorkspaceId, bootstrapWorkspaceReplicaActorKind],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Guest workspace content probe returned no row for workspace ${guestWorkspaceId}`);
+  }
+
+  return row.has_content;
+}
+
+async function reapWebGuestInExecutor(
+  executor: DatabaseExecutor,
+  candidate: WebGuestReaperCandidate,
+  inactiveBefore: Date,
+): Promise<WebGuestReaperCandidateOutcome> {
+  // org.user_settings.workspace_id is ON DELETE SET NULL from org.workspaces (migration 0001), so a
+  // guest with no selected workspace is reachable. It has nothing this job can delete safely, and
+  // treating it as a failure would make one such row fail the run every night forever.
+  const guestWorkspaceId = await loadGuestWorkspaceIdOrNullInExecutor(executor, candidate.guestUserId);
+  if (guestWorkspaceId === null) {
+    return { outcome: "skipped", workspaceId: null, reason: "workspace_missing" };
+  }
+
+  const stillReapable = await webGuestIsStillReapableInExecutor(executor, candidate, inactiveBefore);
+  if (!stillReapable) {
+    return { outcome: "skipped", workspaceId: guestWorkspaceId, reason: "no_longer_a_candidate" };
+  }
+
+  // A web guest workspace is empty by construction. Content here means an invariant broke
+  // elsewhere, and that has to stay visible rather than be deleted along with the guest.
+  if (await guestWorkspaceHasContentInExecutor(executor, candidate.guestUserId, guestWorkspaceId)) {
+    return { outcome: "skipped", workspaceId: guestWorkspaceId, reason: "workspace_has_content" };
+  }
+
+  const deletedWorkspace = await deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor(
+    executor,
+    candidate.guestUserId,
+    guestWorkspaceId,
+  );
+  if (!deletedWorkspace) {
+    return { outcome: "skipped", workspaceId: guestWorkspaceId, reason: "workspace_not_sole_owned" };
+  }
+
+  // Cascades org.workspace_memberships, auth.guest_sessions and auth.guest_ai_monthly_usage. The
+  // analytics schema holds no foreign key into org, so the guest's events and identity links
+  // survive untouched, which is deliberate.
+  //
+  // This cascade is wider than the workspace probe above: org.user_settings is also the parent of
+  // auth.user_identities, support.feedback_prompt_events and support.feedback_submissions, the
+  // community public profile, friend invitation and friendship tables, auth.agent_api_keys,
+  // auth.oauth_connections and progress.user_active_review_days, plus the two ON DELETE SET NULL
+  // children migration 0058 added, content.review_events.reviewed_by_user_id and
+  // community.public_review_activity_facts.reviewed_by_user_id. None of them is probed, and none
+  // needs one, because a row in any of them belongs either to a user that authored a review event
+  // or to a user that was admitted on an authenticated surface other than analytics ingest, and a
+  // web guest can obtain neither.
+  //
+  // Do not shorten that to "written only from an authenticated HTTP surface": these tables also
+  // have non-HTTP writers, and both of them stand on review authorship rather than on a request.
+  // progress.user_active_review_days is written by the scheduled backfill in
+  // progress/activeReviewDays/activeReviewDaysBackfill.ts, and
+  // community.public_review_activity_facts by migration 0058 itself, each only for users who
+  // already have content.review_events rows. A web guest has none: authoring one needs a sync push,
+  // and the default-deny gate in server/requestContext.ts admits a web guest on analytics ingest
+  // alone, with guest upgrade refused separately in guestAuth/upgrade/index.ts, and analytics
+  // ingest writes only into the analytics schema. auth.user_identities is excluded twice over: it
+  // accepts only provider_type = 'cognito' (migration 0031), so a row there means the guest signed
+  // in, which the identity-link rule already excludes. The guest's user id is a server-minted
+  // randomUUID that is never handed to another actor, so no other user's rows can carry it either.
+  // A new writer of any of these tables has to be checked against the review-authorship arm above,
+  // not only against the surface gate.
+  await deleteUserSettingsInExecutor(executor, candidate.guestUserId);
+  return { outcome: "deleted", workspaceId: guestWorkspaceId };
+}
+
+/**
+ * Deliberately not wrapped in `withTransientDatabaseRetry`, unlike the neighbouring scheduled jobs.
+ *
+ * The transient set covers exactly the mid-query connection terminations an RDS failover or reboot
+ * produces (`57P01`, `57P02`, `08006`, `ECONNRESET`), and one of those can arrive most of the way
+ * through a scan. `withReportingReadOnlyTransaction` builds its pool with no
+ * `connectionTimeoutMillis` and issues its statements with no `query_timeout`, so a retried attempt
+ * is bounded only by the reporting role's server-side 30s and, while the instance is unreachable,
+ * by the OS TCP connect timeout. Retrying would therefore let a page begun with exactly
+ * `candidateScanBudgetMs` left run past `request.deadlineAtMs`, through the entrypoint's
+ * finalization reserve, and into a Lambda hard timeout that loses the whole
+ * `web_guest_reaper_completed` record - the loss the reserve exists to prevent.
+ *
+ * The daily schedule is the retry instead: the run is idempotent and the next run walks the same
+ * candidates. The caller catches the failure rather than letting it escape, so a scan that throws
+ * costs the run its remaining pages but not the record of the guests it already deleted; it still
+ * reaches an operator through `WebGuestReaperLambdaErrorAlarm`, because the entrypoint throws on
+ * the `scanFailed` flag once that record is written.
+ */
+async function loadCandidates(
+  inactiveBefore: Date,
+  rowLimit: number,
+  cursor: WebGuestReaperCursor,
+): Promise<ReadonlyArray<WebGuestReaperCandidate>> {
+  return withReportingReadOnlyTransaction(async (client) => {
+    const executor: ReportingQueryExecutor = {
+      query<Row extends pg.QueryResultRow>(
+        text: string,
+        params: ReadonlyArray<SqlValue>,
+      ): Promise<pg.QueryResult<Row>> {
+        return client.query<Row>(text, params as Array<unknown>);
+      },
+    };
+    return loadWebGuestReaperCandidatesInExecutor(executor, inactiveBefore, rowLimit, cursor);
+  });
+}
+
+/**
+ * Separates a guest the run simply ran out of time on from a guest that actually failed.
+ *
+ * `DatabaseDeadlineExceededError` covers only the deadline that lapses in JavaScript: a pool
+ * checkout, or a gap between statements. It is not how a guest transaction is usually stopped.
+ * `database/deadline.ts` runs `configureTransactionTimeouts` before every statement and sets a
+ * server-side `statement_timeout` of the remaining budget minus a 250ms rollback reserve, plus a
+ * `lock_timeout` a millisecond under that, so an overrunning guest is normally stopped by
+ * PostgreSQL roughly 250ms before `deadlineAtMs`, while `Date.now()` is still short of it - the raw
+ * SQLSTATE then propagates unconverted, because neither code is in the transient set
+ * `toDatabaseBoundaryError` converts. Which of the two it is turns only on what the guest was doing
+ * when the budget ran out - `57014` for a statement that ran too long, `55P03` for one that waited
+ * too long on a lock - and both leave the transaction aborted, so all three stops rolled back and
+ * deleted nothing, and all three are the run running out of time on this guest rather than a guest
+ * that failed. See guestBudgetExhaustedSqlStates.
+ *
+ * `DatabaseCommitOutcomeUnknownError` is deliberately excluded. `executeCommit` raises it when the
+ * COMMIT itself times out client-side, where the guest may or may not have been deleted, and an
+ * unconfirmed outcome on a destructive operation has to reach a human through the failure path.
+ */
+function isGuestDeadlineInterruption(error: unknown): boolean {
+  if (error instanceof DatabaseCommitOutcomeUnknownError) {
+    return false;
+  }
+  if (error instanceof DatabaseDeadlineExceededError) {
+    return true;
+  }
+
+  const { sqlState } = getDatabaseErrorFields(error);
+  return sqlState !== null && guestBudgetExhaustedSqlStates.has(sqlState);
+}
+
+async function reapCandidate(
+  candidate: WebGuestReaperCandidate,
+  inactiveBefore: Date,
+  deadlineAtMs: number,
+): Promise<WebGuestReaperCandidateOutcome> {
+  return runDatabaseOperationsWithDeadline(
+    deadlineAtMs,
+    () => unsafeTransaction((executor) => reapWebGuestInExecutor(executor, candidate, inactiveBefore)),
+  );
+}
+
+/**
+ * Every warning below is written from inside the page loop, at a point where guests may already
+ * have been permanently deleted. A throw out of the capture path would escape
+ * `reapInactiveWebGuests` and discard every count for those deletions along with `pagesScanned` and
+ * `finished`, which is the same loss the scan-failure catch in the loop exists to prevent.
+ * `recordCandidateFailure` is the sharpest case: it sits in the loop's own `catch`, so nothing
+ * around it catches anything it throws. Mirrors the guard `database/transient.ts` puts around its
+ * own retry breadcrumb.
+ */
+function captureReaperWarningWithoutThrowing(capture: () => void): void {
+  try {
+    capture();
+  } catch {
+    // Observability must not interrupt a run that is permanently deleting rows.
+  }
+}
+
+function recordCandidateSkip(
+  candidate: WebGuestReaperCandidate,
+  workspaceId: string | null,
+  reason: WebGuestReaperSkipReason,
+  observationScope: BackendObservationScope,
+): void {
+  captureReaperWarningWithoutThrowing(() => {
+    captureBackendWarning({
+      action: "web_guest_reaper_candidate_skipped",
+      message: "Web guest reaper left one inactive guest in place.",
+      scope: observationScope,
+      details: {
+        guestUserId: candidate.guestUserId,
+        workspaceId,
+        reason,
+        lastActiveAtUtc: candidate.lastActiveAt,
+      },
+    });
+  });
+}
+
+function recordCandidateFailure(
+  candidate: WebGuestReaperCandidate,
+  observationScope: BackendObservationScope,
+  error: unknown,
+): void {
+  captureReaperWarningWithoutThrowing(() => {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendWarning({
+      action: "web_guest_reaper_candidate_failed",
+      message: "Web guest reaper failed to delete one inactive guest.",
+      scope: observationScope,
+      details: {
+        guestUserId: candidate.guestUserId,
+        lastActiveAtUtc: candidate.lastActiveAt,
+        errorClass: normalizedError.name,
+        errorMessage: normalizedError.message,
+      },
+    });
+  });
+}
+
+function recordScanFailure(
+  pagesScanned: number,
+  observationScope: BackendObservationScope,
+  error: unknown,
+): void {
+  captureReaperWarningWithoutThrowing(() => {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendWarning({
+      action: "web_guest_reaper_scan_failed",
+      message: "Web guest reaper stopped a run on a failed candidate scan.",
+      scope: observationScope,
+      details: {
+        pagesScanned,
+        errorClass: normalizedError.name,
+        errorMessage: normalizedError.message,
+      },
+    });
+  });
+}
+
+function createEmptyResult(inactiveBefore: Date): WebGuestReaperResult {
+  return {
+    inactivityThresholdDays: webGuestInactivityThresholdDays,
+    inactiveBefore: inactiveBefore.toISOString(),
+    pagesScanned: 0,
+    candidatesExamined: 0,
+    deleted: 0,
+    skipped: 0,
+    skippedWorkspaceHasContent: 0,
+    skippedWorkspaceNotSoleOwned: 0,
+    skippedWorkspaceMissing: 0,
+    skippedNoLongerCandidate: 0,
+    interrupted: 0,
+    failed: 0,
+    scanFailed: false,
+    finished: false,
+  };
+}
+
+function addSkip(result: WebGuestReaperResult, reason: WebGuestReaperSkipReason): WebGuestReaperResult {
+  return {
+    ...result,
+    skipped: result.skipped + 1,
+    skippedWorkspaceHasContent: result.skippedWorkspaceHasContent
+      + (reason === "workspace_has_content" ? 1 : 0),
+    skippedWorkspaceNotSoleOwned: result.skippedWorkspaceNotSoleOwned
+      + (reason === "workspace_not_sole_owned" ? 1 : 0),
+    skippedWorkspaceMissing: result.skippedWorkspaceMissing
+      + (reason === "workspace_missing" ? 1 : 0),
+    skippedNoLongerCandidate: result.skippedNoLongerCandidate
+      + (reason === "no_longer_a_candidate" ? 1 : 0),
+  };
+}
+
+/**
+ * Walks the candidate ordering page by page until it runs out of candidates, out of pages, or out
+ * of time. `finished` is the saturation signal: a run that returns `false` left candidates behind,
+ * which is the difference between "web guests are no longer accumulating" and "they are being
+ * minted faster than this schedule reaps them", and no other emitted counter can tell those apart.
+ */
+export async function reapInactiveWebGuests(
+  request: WebGuestReaperRequest,
+  observationScope: BackendObservationScope,
+): Promise<WebGuestReaperResult> {
+  const batchSize = requireIntegerInRange(request.batchSize, "batchSize", minimumBatchSize, maximumBatchSize);
+  const maxPages = requireIntegerInRange(request.maxPages, "maxPages", minimumMaxPages, maximumMaxPages);
+  const inactiveBefore = calculateWebGuestInactiveBefore(Date.now());
+  let result = createEmptyResult(inactiveBefore);
+  let cursor: WebGuestReaperCursor = null;
+
+  for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+    // The candidate scan is the slowest statement in the run, so the deadline is checked before
+    // paying for another one rather than only between guests, and a page is started only with a
+    // full scan budget left rather than with whatever remains.
+    if (request.deadlineAtMs - Date.now() < candidateScanBudgetMs) {
+      return result;
+    }
+
+    // One row past the page is read and never processed. It is the cheapest exact answer to "were
+    // candidates left behind": a page that comes back full says nothing on its own, so a candidate
+    // count that is an exact multiple of batchSize would make the last page of a run that also used
+    // its last maxPages look saturated while nothing at all remained, and raise
+    // WebGuestReaperSaturatedAlarm on a run that did its whole job.
+    let page: ReadonlyArray<WebGuestReaperCandidate>;
+    try {
+      page = await loadCandidates(inactiveBefore, batchSize + 1, cursor);
+    } catch (error) {
+      // Everything earlier pages deleted is already permanent, so a scan that throws must not carry
+      // those counts out with it: the run stops here and still reports what it deleted, skipped and
+      // failed, with finished left false so WebGuestReaperSaturatedAlarm sees the candidates left
+      // behind. The invocation still has to fail - WebGuestReaperLambdaErrorAlarm is the stated
+      // reason the (platform, created_at) index is safe to defer, and an unindexed scan outgrowing
+      // the reporting role's 30s statement_timeout has to surface as an errored invocation - so the
+      // entrypoint throws on scanFailed after emitting the completion record.
+      recordScanFailure(result.pagesScanned, observationScope, error);
+      return { ...result, scanFailed: true };
+    }
+
+    const hasMoreCandidates = page.length > batchSize;
+    const candidates = hasMoreCandidates ? page.slice(0, batchSize) : page;
+    result = { ...result, pagesScanned: result.pagesScanned + 1 };
+
+    for (const [candidateIndex, candidate] of candidates.entries()) {
+      if (request.deadlineAtMs - Date.now() < guestDeadlineMs) {
+        return { ...result, interrupted: candidates.length - candidateIndex };
+      }
+
+      const guestDeadlineAtMs = Date.now() + guestDeadlineMs;
+      cursor = createCursorFromCandidate(candidate);
+      try {
+        const outcome = await reapCandidate(candidate, inactiveBefore, guestDeadlineAtMs);
+        result = { ...result, candidatesExamined: result.candidatesExamined + 1 };
+        if (outcome.outcome === "skipped") {
+          recordCandidateSkip(candidate, outcome.workspaceId, outcome.reason, observationScope);
+          result = addSkip(result, outcome.reason);
+          continue;
+        }
+
+        result = { ...result, deleted: result.deleted + 1 };
+      } catch (error) {
+        // A guest budget that runs out inside the guest's own transaction rolled that transaction
+        // back and deleted nothing, so the run simply ran out of time on this guest. Counting it as
+        // a failure would send a normal deadline stop to the Lambda error alarm, because the
+        // entrypoint turns any failed guest into a thrown error.
+        if (isGuestDeadlineInterruption(error)) {
+          return { ...result, interrupted: candidates.length - candidateIndex };
+        }
+
+        recordCandidateFailure(candidate, observationScope, error);
+        result = {
+          ...result,
+          candidatesExamined: result.candidatesExamined + 1,
+          failed: result.failed + 1,
+        };
+      }
+    }
+
+    if (!hasMoreCandidates) {
+      return { ...result, finished: true };
+    }
+  }
+
+  return result;
+}

--- a/apps/backend/src/guestAuth/store/workspace.ts
+++ b/apps/backend/src/guestAuth/store/workspace.ts
@@ -17,16 +17,30 @@ type WorkspaceSummaryRow = Readonly<{
   created_at: Date | string;
 }>;
 
-export async function loadGuestWorkspaceIdInExecutor(
+/**
+ * Locks the guest's `org.user_settings` row and returns its selected workspace, or `null` when the
+ * guest has none. `workspace_id` is `ON DELETE SET NULL` from `org.workspaces` (migration `0001`),
+ * so a guest without one is reachable and is not automatically an error: a caller that has to
+ * survive it, such as the web guest reaper, treats it as its own outcome instead of throwing.
+ */
+export async function loadGuestWorkspaceIdOrNullInExecutor(
   executor: DatabaseExecutor,
   guestUserId: string,
-): Promise<string> {
+): Promise<string | null> {
   await applyUserDatabaseScopeInExecutor(executor, { userId: guestUserId });
   const result = await executor.query<GuestWorkspaceRow>(
     "SELECT workspace_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE",
     [guestUserId],
   );
-  const workspaceId = result.rows[0]?.workspace_id ?? null;
+
+  return result.rows[0]?.workspace_id ?? null;
+}
+
+export async function loadGuestWorkspaceIdInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+): Promise<string> {
+  const workspaceId = await loadGuestWorkspaceIdOrNullInExecutor(executor, guestUserId);
   if (workspaceId === null) {
     throw new Error("Guest user is missing selected workspace");
   }

--- a/apps/backend/src/observability/sentry/events/common.ts
+++ b/apps/backend/src/observability/sentry/events/common.ts
@@ -9,6 +9,7 @@ export type BackendService =
   | "community-leaderboard-snapshot"
   | "streak-leaderboard-snapshot"
   | "progress-active-days-backfill"
+  | "web-guest-reaper"
   | "generated-media-promotion"
   | "multipart-completion-reconciliation"
   | "migration";

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -127,6 +127,11 @@ export type {
   ProgressActiveDaysBackfillFailureDetails,
   StreakLeaderboardSnapshotFailureDetails,
   StreakLeaderboardSnapshotGeneratedDetails,
+  WebGuestReaperCandidateFailureDetails,
+  WebGuestReaperCandidateSkippedDetails,
+  WebGuestReaperCompletedDetails,
+  WebGuestReaperFailureDetails,
+  WebGuestReaperScanFailureDetails,
 } from "./operations";
 
 export type BackendBreadcrumbEvent =

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -188,6 +188,84 @@ export type ProgressActiveDaysBackfillFailureDetails = Readonly<{
   message: string;
 }>;
 
+/**
+ * The one record the web guest reaper emits per run. `candidatesExamined` is the denominator the
+ * other counters are read against: `deleted` plus `skipped` plus `failed` equals it, while
+ * `interrupted` counts the candidates the run loaded but could not settle before its deadline,
+ * including one whose own transaction ran out of time and rolled back. The `skipped*` counters are
+ * the reasons, and each skipped guest also carries its own `web_guest_reaper_candidate_skipped`
+ * record with its id, because most skips mean the invariant that a web guest workspace stays empty
+ * broke somewhere else.
+ *
+ * `finished` is the saturation signal and the one field to alert on: `false` means the run stopped
+ * on `maxPages` or on its deadline with candidates still waiting, so web guest rows are being
+ * minted faster than this schedule reaps them and the accumulation the job exists to stop is still
+ * running. No count on its own can distinguish that from a run that simply had a busy day, and such
+ * a run is a successful invocation with no errors, so neither Lambda alarm sees it:
+ * `WebGuestReaperSaturatedAlarm` in `infra/aws/lib/monitoring.ts` is the metric filter that does.
+ *
+ * `scanFailed` separates the two ways a run can end with `finished: false`. It means the run
+ * stopped because a candidate scan threw, so the counters above cover only the pages it got
+ * through, and its own `web_guest_reaper_scan_failed` record carries the error. Such a run reports
+ * `finished: false` as well, because candidates really were left behind, so it raises the
+ * saturation alarm too; it is also an errored invocation, because the entrypoint throws on this
+ * flag after emitting this record.
+ */
+export type WebGuestReaperCompletedDetails = Readonly<{
+  batchSize: number;
+  maxPages: number;
+  inactivityThresholdDays: number;
+  inactiveBeforeUtc: string;
+  pagesScanned: number;
+  candidatesExamined: number;
+  deleted: number;
+  skipped: number;
+  skippedWorkspaceHasContent: number;
+  skippedWorkspaceNotSoleOwned: number;
+  skippedWorkspaceMissing: number;
+  skippedNoLongerCandidate: number;
+  interrupted: number;
+  failed: number;
+  scanFailed: boolean;
+  finished: boolean;
+}>;
+
+export type WebGuestReaperCandidateSkippedDetails = Readonly<{
+  guestUserId: string;
+  workspaceId: string | null;
+  reason:
+    | "workspace_has_content"
+    | "workspace_not_sole_owned"
+    | "workspace_missing"
+    | "no_longer_a_candidate";
+  lastActiveAtUtc: string;
+}>;
+
+export type WebGuestReaperCandidateFailureDetails = Readonly<{
+  guestUserId: string;
+  lastActiveAtUtc: string;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+/**
+ * Why a run ended early with `scanFailed: true`. It is a warning rather than an exception because
+ * the run itself continues to its completion record, which reports what it already deleted; the
+ * entrypoint's `web_guest_reaper_failed` exception follows immediately after and is what the Lambda
+ * error alarm sees.
+ */
+export type WebGuestReaperScanFailureDetails = Readonly<{
+  pagesScanned: number;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type WebGuestReaperFailureDetails = Readonly<{
+  batchSize: number | null;
+  maxPages: number | null;
+  message: string;
+}>;
+
 export type GeneratedMediaPromotionBatchDetails = Readonly<{
   maximumJobs: number; claimed: number; applied: number; ambiguous: number;
   failed: number; interrupted: number; leaseLost: number; rescheduled: number;
@@ -419,6 +497,7 @@ export type OperationsBreadcrumbEvent =
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
+  | EventByAction<"web_guest_reaper_completed", WebGuestReaperCompletedDetails>
   | EventByAction<"generated_media_promotion_batch_completed", GeneratedMediaPromotionBatchDetails>
   | EventByAction<"media_blob_cleanup_batch_completed", MediaBlobCleanupBatchDetails>
   | EventByAction<"media_blob_cleanup_retry", MediaBlobCleanupRetryDetails>
@@ -450,6 +529,18 @@ export type OperationsWarningEvent =
   | (EventByAction<
     "progress_active_days_backfill_candidate_failed",
     ProgressActiveDaysBackfillCandidateFailureDetails
+  > & Readonly<{ message: string }>)
+  | (EventByAction<
+    "web_guest_reaper_candidate_skipped",
+    WebGuestReaperCandidateSkippedDetails
+  > & Readonly<{ message: string }>)
+  | (EventByAction<
+    "web_guest_reaper_candidate_failed",
+    WebGuestReaperCandidateFailureDetails
+  > & Readonly<{ message: string }>)
+  | (EventByAction<
+    "web_guest_reaper_scan_failed",
+    WebGuestReaperScanFailureDetails
   > & Readonly<{ message: string }>);
 
 export type OperationsExceptionEvent =
@@ -461,6 +552,9 @@ export type OperationsExceptionEvent =
     error: Error;
   }>)
   | (EventByAction<"progress_active_days_backfill_failed", ProgressActiveDaysBackfillFailureDetails> & Readonly<{
+    error: Error;
+  }>)
+  | (EventByAction<"web_guest_reaper_failed", WebGuestReaperFailureDetails> & Readonly<{
     error: Error;
   }>)
   | (EventByAction<"generated_media_promotion_batch_failed", GeneratedMediaPromotionBatchDetails> & Readonly<{

--- a/infra/aws/lib/ci-cd.ts
+++ b/infra/aws/lib/ci-cd.ts
@@ -16,6 +16,7 @@ export interface CiCdProps {
   communityLeaderboardSnapshotFn: lambda.IFunction;
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
+  webGuestReaperFn: lambda.IFunction;
   catalogDumpFn: lambda.IFunction;
   migrationFn: lambda.IFunction;
   generatedMediaPromotionScheduleArn: string;
@@ -176,6 +177,12 @@ export function ciCd(scope: Construct, props: CiCdProps): void {
     sid: "InvokeProgressActiveDaysBackfillLambda",
     actions: ["lambda:InvokeFunction"],
     resources: [props.progressActiveDaysBackfillFn.functionArn],
+  }));
+
+  cdkDeployStatements.push(new iam.PolicyStatement({
+    sid: "InvokeWebGuestReaperLambda",
+    actions: ["lambda:InvokeFunction"],
+    resources: [props.webGuestReaperFn.functionArn],
   }));
 
   cdkDeployStatements.push(new iam.PolicyStatement({

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -26,6 +26,7 @@ import {
 import { communityLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfillScheduleHours } from "./scheduled-jobs/progress-active-days-backfill";
+import { webGuestReaperScheduleHours } from "./scheduled-jobs/web-guest-reaper";
 import { addProductAnalyticsMonitoring } from "./product-analytics-monitoring";
 
 const restApiNoTrafficEvaluationPeriods = 4;
@@ -35,6 +36,7 @@ const certificateExpiryAlarmThresholdDays = 45;
 const communityLeaderboardSnapshotStaleEvaluationPeriods = 2;
 const streakLeaderboardSnapshotStaleEvaluationPeriods = 2;
 const progressActiveDaysBackfillStaleEvaluationPeriods = 2;
+const webGuestReaperStaleEvaluationPeriods = 2;
 
 export interface MonitoringProps {
   alertEmail: string;
@@ -57,6 +59,9 @@ export interface MonitoringProps {
   communityLeaderboardSnapshotFn: lambda.IFunction;
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
+  // Concrete `lambda.Function` for the same reason as the two above: the saturation metric filter
+  // reads `.logGroup`.
+  webGuestReaperFn: lambda.Function;
   generatedMediaPromotionFn: lambda.IFunction;
   multipartCompletionReconciliationFn: lambda.Function;
   catalogDumpFn: lambda.IFunction;
@@ -84,6 +89,12 @@ const multipartCompletionReconciliationFailureMetricNamespace: string =
 const multipartCompletionReconciliationFailureMetricName: string =
   "FailedJobs";
 export const multipartCompletionReconciliationFailureMetricValue: string =
+  "1";
+const webGuestReaperSaturationMetricNamespace: string =
+  "FlashcardsOpenSourceApp/WebGuestReaper";
+const webGuestReaperSaturationMetricName: string =
+  "SaturatedRuns";
+const webGuestReaperSaturationMetricValue: string =
   "1";
 
 function createAuthApiAccessLog5xxFilterPattern(): logs.IFilterPattern {
@@ -113,6 +124,17 @@ logs.IFilterPattern {
       "=",
       "multipart_completion_reconciliation_job_terminally_failed",
     ),
+  );
+}
+
+export function createWebGuestReaperSaturationFilterPattern(): logs.IFilterPattern {
+  return logs.FilterPattern.all(
+    logs.FilterPattern.stringValue(
+      "$.message.action",
+      "=",
+      "web_guest_reaper_completed",
+    ),
+    logs.FilterPattern.booleanValue("$.message.finished", false),
   );
 }
 
@@ -560,6 +582,78 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
       "Progress active review days backfill Lambda has not run for two consecutive hours, " +
       "so known-timezone users may keep missing active-day materialization",
     treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+  }), alertTopic);
+
+  // The reaper permanently deletes org.user_settings and org.workspaces rows once a day, so a run
+  // that throws every night has to reach the alert topic rather than only Sentry. This alarm is
+  // also what makes the deferred auth.guest_sessions (platform, created_at) index safe to defer: if
+  // the unindexed candidate scan ever grows past the reporting role's 30s statement_timeout, the
+  // query errors, the entrypoint rethrows, and the reaper stops deleting anything until the index
+  // lands. That is an errored invocation, which is exactly what this alarm sees, and it is why the
+  // error alarm must stay in place while the index is deferred. The staleness alarm below cannot
+  // stand in for it: Lambda counts an errored invocation in Invocations like any other, so the run
+  // count stays at one per day and a job that fails every night never looks stale.
+  notifyAlertTopic(new cloudwatch.Alarm(scope, "WebGuestReaperLambdaErrorAlarm", {
+    metric: props.webGuestReaperFn.metricErrors({
+      period: cdk.Duration.minutes(15),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "Web guest reaper Lambda had errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }), alertTopic);
+
+  // A schedule that quietly stops firing emits nothing at all, which no error metric can show.
+  notifyAlertTopic(new cloudwatch.Alarm(scope, "WebGuestReaperStaleAlarm", {
+    metric: props.webGuestReaperFn.metricInvocations({
+      period: cdk.Duration.hours(webGuestReaperScheduleHours),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+    evaluationPeriods: webGuestReaperStaleEvaluationPeriods,
+    datapointsToAlarm: webGuestReaperStaleEvaluationPeriods,
+    alarmDescription:
+      "Web guest reaper Lambda has not run for two consecutive days, " +
+      "so never-converted web guest identities are accumulating again",
+    treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+  }), alertTopic);
+
+  // A run that stops on maxPages or on its deadline with candidates still waiting is a successful
+  // invocation with no errors, so neither alarm above sees it while web guest rows keep
+  // accumulating - the exact failure this job exists to prevent. The run reports that state as
+  // finished: false on its one completion record, and this is what watches it. One saturated run is
+  // enough to alarm: it means that day's candidates were not all reaped. Raising the entrypoint's
+  // batchSize or maxPages only helps a run that still stops on its page limit; once a real backlog
+  // exists the run is deadline-bound instead, because 500 x 5 per-guest transactions of about six
+  // round trips each do not fit the reaper Lambda's five-minute timeout, and raising either knob
+  // then changes nothing. The other two levers are that Lambda's timeout and memorySize in
+  // lib/scheduled-jobs/web-guest-reaper.ts, and the deferred auth.guest_sessions
+  // (platform, created_at) index.
+  const webGuestReaperSaturationMetricFilter = new logs.MetricFilter(
+    scope,
+    "WebGuestReaperSaturationMetricFilter",
+    {
+      logGroup: props.webGuestReaperFn.logGroup,
+      filterPattern: createWebGuestReaperSaturationFilterPattern(),
+      metricNamespace: webGuestReaperSaturationMetricNamespace,
+      metricName: webGuestReaperSaturationMetricName,
+      metricValue: webGuestReaperSaturationMetricValue,
+      defaultValue: 0,
+    },
+  );
+  notifyAlertTopic(new cloudwatch.Alarm(scope, "WebGuestReaperSaturatedAlarm", {
+    metric: webGuestReaperSaturationMetricFilter.metric({
+      period: cdk.Duration.hours(webGuestReaperScheduleHours),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription:
+      "Web guest reaper finished a run with candidates still waiting, " +
+      "so never-converted web guest identities are being minted faster than the schedule reaps them",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }), alertTopic);
 
   notifyAlertTopic(new cloudwatch.Alarm(scope, "GeneratedMediaPromotionLambdaErrorAlarm", {

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -32,6 +32,7 @@ export interface OutputsProps {
   communityLeaderboardSnapshotFunction: lambda.IFunction;
   streakLeaderboardSnapshotFunction: lambda.IFunction;
   progressActiveDaysBackfillFunction: lambda.IFunction;
+  webGuestReaperFunction: lambda.IFunction;
   catalogDumpBucket: s3.IBucket;
   catalogDumpDistribution: cloudfront.Distribution;
   catalogDumpFunction: lambda.IFunction;
@@ -192,6 +193,11 @@ export function outputs(scope: Construct, props: OutputsProps): void {
   new cdk.CfnOutput(scope, "ProgressActiveDaysBackfillFunctionName", {
     value: props.progressActiveDaysBackfillFunction.functionName,
     description: "Lambda function name for Progress active review days backfill",
+  });
+
+  new cdk.CfnOutput(scope, "WebGuestReaperFunctionName", {
+    value: props.webGuestReaperFunction.functionName,
+    description: "Lambda function name for the never-converted web guest reaper",
   });
 
   new cdk.CfnOutput(scope, "CatalogDumpBucketName", {

--- a/infra/aws/lib/scheduled-jobs/web-guest-reaper.test.ts
+++ b/infra/aws/lib/scheduled-jobs/web-guest-reaper.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+  webGuestReaperScheduleExpression,
+  webGuestReaperScheduleHours,
+} from "./web-guest-reaper";
+import { createWebGuestReaperSaturationFilterPattern } from "../monitoring";
+
+function readLibSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("web guest reaper is scheduled daily", () => {
+  assert.equal(webGuestReaperScheduleHours, 24);
+  assert.equal(webGuestReaperScheduleExpression, "cron(30 4 * * ? *)");
+});
+
+test("web guest reaper construct creates the daily schedule and Lambda", () => {
+  const source = readLibSource("lib/scheduled-jobs/web-guest-reaper.ts");
+
+  assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "WebGuestReaperHandler"/);
+  assert.match(
+    source,
+    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-web-guest-reaper\.ts"\)/,
+  );
+  assert.match(source, /DB_SECRET_ARN: props\.backendDbSecret\.secretArn/);
+  assert.match(source, /REPORTING_DB_SECRET_ARN: props\.reportingDbSecret\.secretArn/);
+  assert.match(source, /props\.backendDbSecret\.grantRead\(reaperFunction\)/);
+  assert.match(source, /props\.reportingDbSecret\.grantRead\(reaperFunction\)/);
+  assert.match(source, /new scheduler\.CfnSchedule\(scope, "WebGuestReaperDailySchedule"/);
+  assert.match(source, /scheduleExpression: webGuestReaperScheduleExpression/);
+  assert.match(source, /new iam\.Role\(scope, "WebGuestReaperSchedulerRole"/);
+  assert.match(source, /actions: \["lambda:InvokeFunction"\]/);
+});
+
+// The entrypoint turns one failed candidate into a Lambda error and the job deletes production rows
+// permanently, so it must never be replayed: the default retry behaviour would re-run a destructive
+// job against the same poison candidate many times inside one day. Whether EventBridge Scheduler
+// invokes a Lambda target asynchronously is not established here, and if it does, the schedule's
+// retry policy alone leaves Lambda's own async retries in charge, so both are pinned.
+test("web guest reaper pins both scheduler and Lambda async retries off", () => {
+  const source = readLibSource("lib/scheduled-jobs/web-guest-reaper.ts");
+
+  assert.match(source, /retryPolicy: \{ maximumRetryAttempts: 0 \}/);
+  assert.match(source, /reaperFunction\.configureAsyncInvoke\(\{ retryAttempts: 0 \}\)/);
+});
+
+test("stack wires the web guest reaper function into monitoring, ci-cd, and outputs", () => {
+  const source = readLibSource("lib/stack.ts");
+
+  assert.match(source, /const webGuestReaperResult = webGuestReaper\(this, \{/);
+  assert.match(source, /backendDbSecret: dbResult\.backendDbSecret,/);
+  assert.match(source, /reportingDbSecret: dbResult\.reportingDbSecret,/);
+  assert.match(source, /webGuestReaperFn: webGuestReaperResult\.reaperFunction,/);
+  assert.match(source, /webGuestReaperFunction: webGuestReaperResult\.reaperFunction,/);
+});
+
+test("monitoring alarms cover web guest reaper errors and staleness", () => {
+  const source = readLibSource("lib/monitoring.ts");
+
+  assert.match(source, /new cloudwatch\.Alarm\(scope, "WebGuestReaperLambdaErrorAlarm"/);
+  assert.match(source, /props\.webGuestReaperFn\.metricErrors\(/);
+  assert.match(source, /new cloudwatch\.Alarm\(scope, "WebGuestReaperStaleAlarm"/);
+  assert.match(source, /props\.webGuestReaperFn\.metricInvocations\(/);
+  assert.match(source, /period: cdk\.Duration\.hours\(webGuestReaperScheduleHours\)/);
+  assert.match(source, /comparisonOperator: cloudwatch\.ComparisonOperator\.LESS_THAN_THRESHOLD/);
+  assert.match(source, /treatMissingData: cloudwatch\.TreatMissingData\.BREACHING/);
+});
+
+// A saturated run is a successful invocation with no errors, so neither alarm above sees it and the
+// completion record's finished flag is the only signal that guests were left behind.
+test("monitoring alarms on a web guest reaper run that left candidates behind", () => {
+  const source = readLibSource("lib/monitoring.ts");
+  const pattern = createWebGuestReaperSaturationFilterPattern().logPatternString;
+
+  assert.match(pattern, /\$\.message\.action = "web_guest_reaper_completed"/);
+  assert.match(pattern, /\$\.message\.finished IS FALSE/);
+  assert.match(source, /"WebGuestReaperSaturationMetricFilter"/);
+  assert.match(source, /logGroup: props\.webGuestReaperFn\.logGroup/);
+  assert.match(source, /new cloudwatch\.Alarm\(scope, "WebGuestReaperSaturatedAlarm"/);
+});
+
+test("ci-cd grants the release workflow permission to invoke the web guest reaper Lambda", () => {
+  const source = readLibSource("lib/ci-cd.ts");
+
+  assert.match(source, /sid: "InvokeWebGuestReaperLambda"/);
+  assert.match(source, /resources: \[props\.webGuestReaperFn\.functionArn\]/);
+});

--- a/infra/aws/lib/scheduled-jobs/web-guest-reaper.ts
+++ b/infra/aws/lib/scheduled-jobs/web-guest-reaper.ts
@@ -1,0 +1,157 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as scheduler from "aws-cdk-lib/aws-scheduler";
+import { Construct } from "constructs";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
+import { backendStructuredLoggingProps } from "../backend-lambda-logging";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
+
+export interface WebGuestReaperProps {
+  vpc: ec2.Vpc;
+  lambdaSg: ec2.SecurityGroup;
+  db: rds.DatabaseInstance;
+  backendDbSecret: cdk.aws_secretsmanager.Secret;
+  reportingDbSecret: cdk.aws_secretsmanager.ISecret;
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
+}
+
+export interface WebGuestReaperResult {
+  reaperFunction: lambdaNodejs.NodejsFunction;
+}
+
+export const webGuestReaperScheduleHours = 24;
+export const webGuestReaperScheduleExpression = "cron(30 4 * * ? *)";
+
+const lambdaBundling: lambdaNodejs.BundlingOptions = {
+  minify: true,
+  sourceMap: true,
+  commandHooks: {
+    beforeBundling: () => [],
+    beforeInstall: () => [],
+    afterBundling: (_inputDir: string, outputDir: string) => [
+      `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+      createSentrySourceMapUploadCommand(outputDir),
+    ],
+  },
+};
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function addOptionalSentryEnvironment(
+  scope: Construct,
+  fn: lambdaNodejs.NodejsFunction,
+  props: WebGuestReaperProps,
+): void {
+  if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
+    return;
+  }
+  if (
+    !hasConfiguredValue(props.sentryEnvironment) ||
+    !hasConfiguredValue(props.sentryRelease) ||
+    !hasConfiguredValue(props.sentryTracesSampleRate)
+  ) {
+    throw new Error("sentryEnvironment, sentryRelease, and sentryTracesSampleRate are required when sentryDsnSecretArn is configured");
+  }
+
+  const tracesSampleRate = Number(props.sentryTracesSampleRate);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+
+  const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope,
+    "WebGuestReaperSentryDsnSecret",
+    props.sentryDsnSecretArn,
+  );
+  secret.grantRead(fn);
+  fn.addEnvironment("SENTRY_DSN", secret.secretValue.unsafeUnwrap());
+  fn.addEnvironment("SENTRY_ENVIRONMENT", props.sentryEnvironment);
+  fn.addEnvironment("SENTRY_RELEASE", props.sentryRelease);
+  fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
+}
+
+/**
+ * Daily removal of web guest identities that never became an account and have been inactive for 90
+ * days. The candidate scan reads across every guest, which row level security only allows the
+ * read-only reporting role, while the deletions run as the backend_app runtime role, so this job
+ * needs both database secrets.
+ */
+export function webGuestReaper(scope: Construct, props: WebGuestReaperProps): WebGuestReaperResult {
+  const reaperFunction = new lambdaNodejs.NodejsFunction(scope, "WebGuestReaperHandler", {
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-web-guest-reaper.ts"),
+    handler: "handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+    timeout: cdk.Duration.minutes(5),
+    memorySize: 512,
+    ...backendStructuredLoggingProps,
+    vpc: props.vpc,
+    vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+    securityGroups: [props.lambdaSg],
+    ...backendNodejsProjectPaths,
+    bundling: lambdaBundling,
+    environment: {
+      NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
+      DB_SECRET_ARN: props.backendDbSecret.secretArn,
+      REPORTING_DB_SECRET_ARN: props.reportingDbSecret.secretArn,
+      DB_HOST: props.db.dbInstanceEndpointAddress,
+      DB_NAME: "flashcards",
+    },
+  });
+
+  props.backendDbSecret.grantRead(reaperFunction);
+  props.reportingDbSecret.grantRead(reaperFunction);
+  addOptionalSentryEnvironment(scope, reaperFunction, props);
+
+  // Pinned because the alternative cannot be ruled out here, not because the invocation type is
+  // known: whether EventBridge Scheduler invokes a Lambda target asynchronously is not something
+  // this repository can establish, and if it does, Lambda's own async retry configuration - two
+  // extra attempts by default - is what replays a failed invocation, while the schedule's
+  // retryPolicy below bounds only Scheduler's own delivery retries. This job turns a single failed
+  // candidate into a Lambda error and permanently deletes production rows, so a poison candidate
+  // must not be re-processed twice more on the day it fails, and pinning both is what guarantees
+  // that either way. Under a synchronous invocation this EventInvokeConfig is simply never
+  // consulted; it sets no maxEventAge and adds no destination or dead-letter queue, so pinning it
+  // costs nothing. The failure is reported through WebGuestReaperLambdaErrorAlarm and the next
+  // day's run picks the work up again.
+  reaperFunction.configureAsyncInvoke({ retryAttempts: 0 });
+
+  const schedulerInvokeRole = new iam.Role(scope, "WebGuestReaperSchedulerRole", {
+    assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
+  });
+  schedulerInvokeRole.addToPolicy(new iam.PolicyStatement({
+    actions: ["lambda:InvokeFunction"],
+    resources: [reaperFunction.functionArn],
+  }));
+
+  new scheduler.CfnSchedule(scope, "WebGuestReaperDailySchedule", {
+    description: "Delete never-converted web guest identities inactive for 90 days, once a day",
+    flexibleTimeWindow: { mode: "OFF" },
+    scheduleExpression: webGuestReaperScheduleExpression,
+    scheduleExpressionTimezone: "UTC",
+    state: "ENABLED",
+    target: {
+      arn: reaperFunction.functionArn,
+      input: "{}",
+      roleArn: schedulerInvokeRole.roleArn,
+      // Pinned rather than left to the EventBridge Scheduler default, which retries a failing
+      // target many times inside the same day. This bounds Scheduler's own delivery retries only;
+      // the function's async retry attempts are pinned to 0 above because the invocation type is
+      // not established here, and only pinning both guarantees the one-invocation-per-day bound
+      // this destructive job is designed around.
+      retryPolicy: { maximumRetryAttempts: 0 },
+    },
+  });
+
+  return {
+    reaperFunction,
+  };
+}

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -23,6 +23,7 @@ import { globalMetrics } from "./scheduled-jobs/global-metrics";
 import { communityLeaderboard } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboard } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfill } from "./scheduled-jobs/progress-active-days-backfill";
+import { webGuestReaper } from "./scheduled-jobs/web-guest-reaper";
 import { publicEndpointHeartbeat } from "./scheduled-jobs/public-endpoint-heartbeat";
 import {
   generatedMediaPromotion,
@@ -245,6 +246,14 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       reportingDbSecret: dbResult.reportingDbSecret,
       ...sentryContext,
     });
+    const webGuestReaperResult = webGuestReaper(this, {
+      vpc: net.vpc,
+      lambdaSg: net.lambdaSg,
+      db: dbResult.db,
+      backendDbSecret: dbResult.backendDbSecret,
+      reportingDbSecret: dbResult.reportingDbSecret,
+      ...sentryContext,
+    });
     publicEndpointHeartbeat(this, { baseDomain });
     const mediaAssetsResult = mediaAssets(this, {
       baseDomain,
@@ -386,6 +395,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     });
     addDatabaseMigrationDependency(api.backendFn, migrationGate);
     addDatabaseMigrationDependency(api.directImageIngestionFn, migrationGate);
+    addDatabaseMigrationDependency(webGuestReaperResult.reaperFunction, migrationGate);
     const web = webApp(this, {
       baseDomain,
       webCertificateArnUsEast1,
@@ -414,6 +424,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       communityLeaderboardSnapshotFn: communityLeaderboardResult.snapshotFunction,
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
+      webGuestReaperFn: webGuestReaperResult.reaperFunction,
       generatedMediaPromotionFn: generatedMediaPromotionResult.promotionFunction,
       multipartCompletionReconciliationFn:
         multipartCompletionReconciliationResult.reconciliationFunction,
@@ -435,6 +446,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       communityLeaderboardSnapshotFn: communityLeaderboardResult.snapshotFunction,
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
+      webGuestReaperFn: webGuestReaperResult.reaperFunction,
       catalogDumpFn: catalogDumpResult.dumpFunction,
       migrationFn,
       generatedMediaPromotionScheduleArn:
@@ -472,6 +484,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       communityLeaderboardSnapshotFunction: communityLeaderboardResult.snapshotFunction,
       streakLeaderboardSnapshotFunction: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFunction: progressActiveDaysBackfillResult.backfillFunction,
+      webGuestReaperFunction: webGuestReaperResult.reaperFunction,
       catalogDumpBucket: catalogDumpResult.bucket,
       catalogDumpDistribution: catalogDumpResult.distribution,
       catalogDumpFunction: catalogDumpResult.dumpFunction,


### PR DESCRIPTION
A signed-out browser that interacts once mints a permanent user, workspace, membership and guest session. Nothing removed them, so the rows grew with unique visitors. A daily job now deletes the ones that never converted and have shown no activity for 90 days.

**Only `platform = 'web'` is a candidate.** Mobile guests are deliberately never reaped. A web guest is refused on every authenticated surface except analytics ingest, so its workspace is empty by construction — and `web` became a legal guest platform only days ago, which makes this job **inert for months after deploy**.

**Liveness is read from analytics**, never from `guest_sessions.last_seen_at`, which no code path maintains and which always equals `created_at`. The threshold is `GREATEST(occurred_at, ingested_at)`, because the clock-skew correction lets `occurred_at` run up to 60 days behind server time — so `occurred_at` alone would reap a guest the server heard from more recently than 90 days ago.

**The scan and the delete use different roles.** The candidate scan runs as `reporting_readonly`, whose row-level security lets it cross guests and whose statement timeout bounds it. Each deletion runs in its own transaction as `backend_app` and **re-asserts the whole rule before acting**, since the scan and the delete are minutes apart and the delete is irreversible. Deletion reuses the existing guest-delete primitives rather than new statements.

**It refuses to delete a guest that owns anything, and says so**, since reaching that branch means an invariant broke elsewhere. The probe covers the tables a workspace can hold, deliberately excluding the four written for *every* workspace at bootstrap — probing those would have refused every guest, silently, on a job that is inert for months anyway.

**Failure is observable.** An error alarm, a staleness alarm, and a saturation alarm for a run that stops with candidates still waiting. The error alarm is why the missing index on the driving predicate is safe to defer. A run that only ran out of time reports `interrupted` rather than `failed`, and a scan failure still emits its completion record *before* throwing — so an operator always learns what was permanently deleted.

No migration: `backend_app` already holds the required privileges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)