### PR TITLE
Carry a web visitor's signed-out analytics into the account they create

### DIFF
--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -291,6 +291,35 @@ function isDropOnlyBatch(events: ReadonlyArray<QueuedAnalyticsEvent>): boolean {
   return events.every((event) => event.wireEvent.eventName === "analytics_events_dropped");
 }
 
+/**
+ * Notified when the ingest endpoint refuses the guest credential itself rather than the batch. The
+ * owner of that credential lives outside analytics, so it registers here instead of being imported:
+ * it already depends on this module to publish the identity it issues.
+ */
+let guestCredentialRefusalHandler: (() => void) | null = null;
+
+export function registerAnalyticsGuestCredentialRefusalHandler(handler: () => void): () => void {
+  guestCredentialRefusalHandler = handler;
+  return (): void => {
+    if (guestCredentialRefusalHandler === handler) {
+      guestCredentialRefusalHandler = null;
+    }
+  };
+}
+
+/**
+ * Whether the refusal was of the credential rather than of what was sent. For a guest that means the
+ * session is gone server-side — deleted by the reaper, or revoked by the identity link — and every
+ * later batch on it is refused identically, on this load and on every load that republishes the
+ * stored envelope.
+ */
+function isGuestCredentialRefusal(
+  statusCode: number,
+  credential: AnalyticsRequestCredential,
+): boolean {
+  return credential.kind === "guest" && (statusCode === 401 || statusCode === 410);
+}
+
 async function handleDeliveryFailure(
   error: unknown,
   events: ReadonlyArray<QueuedAnalyticsEvent>,
@@ -304,6 +333,14 @@ async function handleDeliveryFailure(
   }
 
   const statusCode = error instanceof ApiError ? error.statusCode : 0;
+
+  if (isGuestCredentialRefusal(statusCode, credential)) {
+    try {
+      guestCredentialRefusalHandler?.();
+    } catch {
+      // Delivery keeps its own course either way; the events stay queued below.
+    }
+  }
 
   // 400 and 413 refuse the whole batch and carry no per-event report. Resending the same bytes fails
   // identically forever, so the batch is split until a single poison event is isolated and dropped.
@@ -502,17 +539,18 @@ function claimQueueOwner(userId: string): void {
         // owner is somebody else and rotates it. An unreadable guest identity leaves `guestOwnerId`
         // null and rotates, which undercounts rather than risking a merge of two people.
         //
-        // What keeping it buys is exactly one thing: `analytics.product_events` then carries the
-        // same raw `anonymous_id` on the guest's tail and on the account's rows, so the two sides
-        // can be joined directly on that column. It does not resolve the guest into the account in
-        // `analytics.product_events_resolved`, and this item does not deliver that. A guest batch
-        // writes no identity link at all (`routes/productAnalytics.ts` derives one only for the
-        // bearer and session transports), and the `authenticated_client` link the account writes
-        // later joins `first_anonymous_link`, which sits third in the `actor_id` COALESCE and so
-        // only reaches rows whose `user_id` is NULL. Guest rows carry the guest user id, so their
-        // `actor_id` keeps naming the guest. Only a `server_derived` link on `subject_user_id`
-        // redirects them, and that is written solely by the guest-upgrade machinery, which the web
-        // app deliberately never calls.
+        // What keeping it buys here is one thing: `analytics.product_events` then carries the same
+        // raw `anonymous_id` on the guest's tail and on the account's rows, so the two sides can be
+        // joined directly on that column. It is not what resolves the guest into the account in
+        // `analytics.product_events_resolved`. A guest batch writes no identity link at all
+        // (`routes/productAnalytics.ts` derives one only for the bearer and session transports), and
+        // the `authenticated_client` link the account writes later joins `first_anonymous_link`,
+        // which sits third in the `actor_id` COALESCE and so only reaches rows whose `user_id` is
+        // NULL. Guest rows carry the guest user id, so their `actor_id` keeps naming the guest. Only
+        // a `server_derived` link on `subject_user_id` redirects them, and `webGuestIdentityLink.ts`
+        // writes one at sign-in through `POST /guest-auth/identity/link`. That is a separate,
+        // retried background task, so this exception still has to stand on its own: it decides
+        // `anonymous_id` on a load where the link may not have landed yet, or may never land.
         if (claim.replacedOwnerId === null || claim.replacedOwnerId !== guestOwnerId) {
           resetAnalyticsIdentity();
         }
@@ -591,6 +629,20 @@ export function setAnalyticsConfirmedOwner(
   } catch {
     // The gate is already shut; a failure here can only cost delivery, never misattribute an event.
   }
+}
+
+/**
+ * The account the session layer has published as this browser's analytics owner, or null while none
+ * is published — before the first verified session, after `reset()` tore one down, and whenever the
+ * owner is a guest rather than an account.
+ *
+ * It exists for background work that was started for one account and must not finish under another:
+ * this is the one place the app names, module-side and synchronously, who the current credential
+ * belongs to. `setAnalyticsConfirmedOwner` is the only writer, so a reader here sees the switch the
+ * moment the session layer publishes it rather than when React state reaches a component.
+ */
+export function readAnalyticsSessionOwnerId(): string | null {
+  return confirmedOwnerCredential?.kind === "session" ? confirmedOwnerId : null;
 }
 
 /** Records the surface stamped onto every event that does not declare its own. */

--- a/apps/web/src/analytics/index.ts
+++ b/apps/web/src/analytics/index.ts
@@ -1,5 +1,7 @@
 export {
   flush,
+  readAnalyticsSessionOwnerId,
+  registerAnalyticsGuestCredentialRefusalHandler,
   reset,
   setAnalyticsConfirmedOwner,
   setAnalyticsGuestOwnerId,

--- a/apps/web/src/analytics/observation.ts
+++ b/apps/web/src/analytics/observation.ts
@@ -96,6 +96,15 @@ export function reportAnalyticsSustainedDeliveryFailure(statusCode: number): voi
 }
 
 /**
+ * The guest identity this browser measured under could not be bound to the account that signed in.
+ * The server sees the refusal, but not that the client gave up on it, and the cost is invisible in
+ * the data: that person's signed-out tail stays attributed to the guest.
+ */
+export function reportAnalyticsGuestIdentityLinkFailure(statusCode: number | null): void {
+  captureOnceInSession("analytics_guest_identity_link_failed", null, statusCode);
+}
+
+/**
  * The local queue failing to open, write, or read back is invisible everywhere else. Keyed by
  * operation so each distinct failure is still reported once, while a store that is unusable for the
  * whole session — a private window, blocked site data, an exhausted quota — reports a handful of

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -33,6 +33,7 @@ export type {
 } from "./api/endpoints/analytics";
 export {
   createWebGuestSession,
+  linkWebGuestIdentity,
 } from "./api/endpoints/guestAuth";
 export type {
   WebGuestSessionEnvelope,

--- a/apps/web/src/api/endpoints/guestAuth.ts
+++ b/apps/web/src/api/endpoints/guestAuth.ts
@@ -3,16 +3,24 @@ import {
   type WebGuestSessionEnvelope,
 } from "../../apiContracts/guestAuth";
 import { parseContractResponse } from "../transport/response";
-import { requestGuestJson, skipAuthRecoveryWithoutNetworkRetry } from "../transport/transport";
+import {
+  requestGuestJson,
+  requestJson,
+  skipAuthRecoveryWithTransientNetworkRetry,
+  skipAuthRecoveryWithoutNetworkRetry,
+} from "../transport/transport";
 
 /**
  * Budget for the single attempt this call makes. Without it a hung fetch never settles and the
  * caller's one attempt for this page load is parked in flight for the rest of it, measuring nothing.
  * Long enough that an ordinary slow network still succeeds, because a request that times out may
- * have created the server-side rows anyway and a later interaction that retries then mints a second
- * set nothing will ever read.
+ * have created the server-side rows anyway and only the caller's persisted `idempotencyKey` makes a
+ * later attempt return that same guest rather than a second one.
  */
 const createWebGuestSessionTimeoutMs = 10 * 1000;
+
+/** Bounds the background task; the caller retries on its own schedule after a failure. */
+const linkWebGuestIdentityTimeoutMs = 10 * 1000;
 
 /**
  * Creates a guest session bound to the web platform.
@@ -22,23 +30,42 @@ const createWebGuestSessionTimeoutMs = 10 * 1000;
  * signed-out browser has no way to get. Auth recovery is skipped for the same reason — a signed-out
  * visitor must never be redirected to sign in because analytics wanted an identity.
  *
- * It is also sent exactly once, never retried. The route has no idempotency key: every call writes a
- * guest user, a workspace, a membership and the session row, and nothing removes them. A connection
- * dropped after the server committed is indistinguishable from one dropped before it, so a transient
- * retry mints a second permanent set of rows from one interaction — the same failure the timeout
- * above exists to bound, reached by a different route. Not creating the rows is always the cheaper
- * mistake here, and it costs nothing durable: `webGuestSession.ts` re-arms after its own retry delay,
- * so a genuinely transient failure gets another chance from the next interaction, and the events
- * wait in the local queue under their 14-day TTL until it does.
+ * The transport still sends it exactly once. A connection dropped after the server committed is
+ * indistinguishable from one dropped before it, and what makes the repeat safe is not the transport
+ * but `idempotencyKey`: a key that still names a live session rotates that session's secret and
+ * returns the same guest user and workspace instead of writing a second permanent set of rows. Only
+ * the caller knows whether it is replaying the same creation attempt, so it owns both the key and
+ * the retry — `webGuestSession.ts` persists the key, re-arms after its own retry delay, and replays
+ * it from the next interaction, while the events wait in the local queue under their 14-day TTL.
  */
-export async function createWebGuestSession(): Promise<WebGuestSessionEnvelope> {
+export async function createWebGuestSession(idempotencyKey: string): Promise<WebGuestSessionEnvelope> {
   return parseContractResponse(
     await requestGuestJson("/guest-auth/session", {
       method: "POST",
-      body: JSON.stringify({ platform: "web" }),
+      body: JSON.stringify({ platform: "web", idempotencyKey }),
       signal: AbortSignal.timeout(createWebGuestSessionTimeoutMs),
     }, null, skipAuthRecoveryWithoutNetworkRetry),
     "POST /guest-auth/session",
     parseWebGuestSessionResponse,
   );
+}
+
+/**
+ * Binds one guest identity to the account that is now signed in, for analytics only, and revokes the
+ * guest session. Nothing is merged, created, selected or deleted.
+ *
+ * It is authenticated as the account rather than as the guest, so it goes out on the shared browser
+ * session and carries the guest token in its body. Auth recovery is skipped because no analytics
+ * work may redirect a person to sign in; the caller runs it right after `GET /me`, which is both the
+ * CSRF load this session request needs and the request-context call the route requires to have
+ * happened first. Transport retries are safe here, unlike on creation: a repeat conflicts on the
+ * same guest and account pair, stores nothing new, and completes a revoke that an earlier attempt
+ * may have left behind.
+ */
+export async function linkWebGuestIdentity(guestToken: string): Promise<void> {
+  await requestJson("/guest-auth/identity/link", {
+    method: "POST",
+    body: JSON.stringify({ guestToken }),
+    signal: AbortSignal.timeout(linkWebGuestIdentityTimeoutMs),
+  }, skipAuthRecoveryWithTransientNetworkRetry);
 }

--- a/apps/web/src/appData/session/guest/WebGuestSessionLifecycle.tsx
+++ b/apps/web/src/appData/session/guest/WebGuestSessionLifecycle.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
+import { registerAnalyticsGuestCredentialRefusalHandler } from "../../../analytics";
 import {
+  discardRefusedWebGuestSession,
   registerWebGuestOwnerForAnalytics,
   requestWebGuestSessionOnInteraction,
 } from "./webGuestSession";
@@ -50,6 +52,11 @@ export function WebGuestSessionLifecycle(): null {
     // earlier guest visit is recognised as the same person continuing on this browser.
     registerWebGuestOwnerForAnalytics();
   }, []);
+
+  // The ingest endpoint is the only place that finds out a guest session no longer exists on the
+  // server. Without this the browser would republish the same dead envelope on every later load and
+  // stay unmeasured for good.
+  useEffect(() => registerAnalyticsGuestCredentialRefusalHandler(discardRefusedWebGuestSession), []);
 
   useEffect(() => {
     function handleInteraction(event: Event): void {

--- a/apps/web/src/appData/session/guest/webGuestIdentityLink.ts
+++ b/apps/web/src/appData/session/guest/webGuestIdentityLink.ts
@@ -1,0 +1,290 @@
+import {
+  ApiError,
+  getOptionalSession,
+  linkWebGuestIdentity,
+  type WebGuestSessionEnvelope,
+} from "../../../api";
+import { readAnalyticsSessionOwnerId } from "../../../analytics";
+import { readStoredAnalyticsEnabled } from "../../../analytics/identity";
+import { reportAnalyticsGuestIdentityLinkFailure } from "../../../analytics/observation";
+import { waitForDelay } from "../lifecycle/workspaceLifecycleHelpers";
+import {
+  markWebGuestSessionLinkAccount,
+  readStoredWebGuestSession,
+  readWebGuestIdentityGeneration,
+  readWebGuestSessionLinkAccountId,
+  resetWebGuestSession,
+} from "./webGuestSession";
+
+/**
+ * Hands the guest identity this browser measured under to the account that has just signed in, so
+ * the visitor's analytics history follows them into it.
+ *
+ * Nothing here may block, delay or fail sign-in: the caller starts it and walks away, and every
+ * failure ends as one report and a swallowed error. What it may not do is give up quietly on a
+ * failure the route calls retryable, which is why the retry rules below are as explicit as the
+ * route's own.
+ */
+
+/** Attempts one sign-in spends before leaving the rest to the next app start. */
+const maximumLinkAttemptCount = 4;
+const linkRetryBaseDelayMs = 1000;
+/**
+ * The ceiling for any single wait, a served `Retry-After` included, and the top step of the local
+ * ladder. This whole loop is a background task inside a page load that can end at any moment, so a
+ * `Retry-After` of minutes would not be honoured — it would park every remaining attempt past the
+ * load that could have run them, turning a retryable refusal into no retry at all. Capping costs
+ * nothing: the envelope is kept, and the next app start picks the work back up.
+ */
+const linkRetryMaxDelayMs = 4 * linkRetryBaseDelayMs;
+
+/**
+ * `retryable` is a refusal that says nothing about this guest token, so the token is kept.
+ * `account_row_missing` is the same, plus the one precondition a client can actually satisfy.
+ * `unconvergeable` is a refusal no repeat of these same bytes converges on, but which says nothing
+ * about the token either, so the loop stops and the token is still kept.
+ * `terminal` is a refusal of the token itself, which is therefore dropped with it.
+ */
+type GuestIdentityLinkVerdict =
+  | "retryable"
+  | "account_row_missing"
+  | "unconvergeable"
+  | "terminal";
+
+/**
+ * The refusals that are about this guest token rather than about the moment it was sent. Only these
+ * drop it, because only these stay true of the token itself on every later attempt.
+ */
+const terminalGuestIdentityLinkCodes: ReadonlySet<string> = new Set([
+  // The guest owns data the upgrade flow transfers. A web guest should never reach it — it is an
+  // analytics credential that can never own anything, and there is deliberately no upgrade flow here
+  // to convert it through — and repeating the call unchanged never succeeds.
+  "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED",
+  // The token names a user that is already a different real account: not this browser's to link.
+  "GUEST_IDENTITY_LINK_OTHER_ACCOUNT",
+  // The account this browser just signed into has been deleted.
+  "ACCOUNT_DELETED",
+]);
+
+function readGuestIdentityLinkVerdict(error: unknown): GuestIdentityLinkVerdict {
+  // Not a refusal from the route at all — a timed-out or aborted request, most often.
+  if (error instanceof ApiError === false) {
+    return "retryable";
+  }
+
+  if (error.code !== null && terminalGuestIdentityLinkCodes.has(error.code)) {
+    return "terminal";
+  }
+
+  if (error.code === "GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED") {
+    return "account_row_missing";
+  }
+
+  // A status the route's error contract does not name at all. A body it refuses is a defect in this
+  // client and the same bytes fail identically, so repeating is pointless — but the token is kept
+  // regardless, because a `400` says nothing about the guest it names. Dropping it is irreversible
+  // and loses that visitor's whole analytics tail; keeping it costs one stored envelope that the next
+  // identity boundary clears anyway. An `ApiNetworkError` raised while reading a `400` body carries
+  // the real status too, and belongs on this branch rather than on a retry of the same refusal.
+  if (error.statusCode === 400) {
+    return "unconvergeable";
+  }
+
+  // Everything else is kept and repeated. A `429 ANALYTICS_WRITER_BUSY` wrote nothing. A `5xx` may
+  // have committed the link on the analytics pool and then lost the revoke with the request
+  // transaction, leaving a guest session live that a *different* account can later bind — which
+  // would attribute that account's whole pre-account tail to this one, permanently. A transport
+  // failure, or a browser session that lapsed between `/me` and here, says nothing about the guest
+  // token either. Repeating is safe in all of them: the route conflicts on the same guest and
+  // account pair, stores nothing new, and completes the revoke.
+  return "retryable";
+}
+
+function readGuestIdentityLinkStatusCode(error: unknown): number | null {
+  return error instanceof ApiError ? error.statusCode : null;
+}
+
+/** Only the analytics writer's own `429` carries `Retry-After`; everything else backs off locally. */
+function createLinkRetryDelayMs(attemptCount: number, error: unknown): number {
+  const retryAfterMs = error instanceof ApiError ? error.retryAfterMs : null;
+  const requestedDelayMs = retryAfterMs ?? linkRetryBaseDelayMs * 2 ** (attemptCount - 1);
+  return Math.min(requestedDelayMs, linkRetryMaxDelayMs);
+}
+
+/**
+ * Drops the envelope, but only while it is still the one this task captured. This runs as a
+ * background task with awaits in it, and a drop crossing meanwhile could otherwise take out a guest
+ * identity that belongs to whoever is on this browser by then.
+ */
+function dropStoredWebGuestSession(guestToken: string): void {
+  if (readStoredWebGuestSession()?.guestToken !== guestToken) {
+    return;
+  }
+
+  resetWebGuestSession();
+}
+
+async function runGuestIdentityLink(
+  guestToken: string,
+  capturedIdentityGeneration: number,
+  accountUserId: string,
+): Promise<void> {
+  for (let attemptCount = 1; attemptCount <= maximumLinkAttemptCount; attemptCount += 1) {
+    // The one thing this task may never do is offer a captured guest to an account it did not
+    // belong to. The route binds the token in the body to whoever the browser session is *now*, into
+    // an append-only, first-link-wins table with no repair path, so a browser that changed hands
+    // since the capture would hand one person's signed-out tail to another, permanently.
+    //
+    // Both halves are checked before every attempt rather than once at the start: the loop spans
+    // awaits, and either one changing inside it matters just as much as before it. The generation
+    // catches every drop this module made, and only those — `readWebGuestIdentityGeneration`
+    // documents the storage sweep it cannot see. The published owner catches the case it cannot
+    // — a second account signing in from another tab replaces the shared session cookie
+    // immediately, while this tab only observes it on focus, on visibility, or on its 60s
+    // revalidate, and this loop can live for tens of seconds inside that lag. `getOptionalSession()`
+    // below would even re-cache the new account's CSRF token for it. Giving up here undercounts a
+    // single cross-identity sign-in, which is the same trade the analytics queue claim already makes
+    // rather than risk merging two people.
+    if (
+      readWebGuestIdentityGeneration() !== capturedIdentityGeneration
+      || readAnalyticsSessionOwnerId() !== accountUserId
+    ) {
+      return;
+    }
+
+    try {
+      await linkWebGuestIdentity(guestToken);
+      // The route revoked the guest session, so the envelope is now a dead credential. Dropping it
+      // here rather than at the identity boundary is what stops a later signed-out load from
+      // republishing it as the analytics owner and posting batches nothing will accept.
+      dropStoredWebGuestSession(guestToken);
+      return;
+    } catch (error) {
+      const verdict = readGuestIdentityLinkVerdict(error);
+      if (verdict === "terminal") {
+        // No retry can make this token linkable, so it is dropped rather than carried forward.
+        dropStoredWebGuestSession(guestToken);
+        reportAnalyticsGuestIdentityLinkFailure(readGuestIdentityLinkStatusCode(error));
+        return;
+      }
+
+      if (verdict === "unconvergeable" || attemptCount === maximumLinkAttemptCount) {
+        // The envelope is deliberately left in place. Neither refusal was about this guest token,
+        // and dropping the token on one of those loses this visitor's whole analytics tail
+        // permanently — or worse, strands a live guest session with a link already written for it.
+        // Every app start reads the envelope back and retries after its own `GET /me`. What keeps a
+        // kept envelope from reaching a different account is the account stamp written before the
+        // first attempt: within this load the two guards above hold, and across loads — where the
+        // generation restarts at zero and the IndexedDB record the sign-in path detects switches
+        // from may be gone — the stamp is what refuses it.
+        reportAnalyticsGuestIdentityLinkFailure(readGuestIdentityLinkStatusCode(error));
+        return;
+      }
+
+      await waitForDelay(createLinkRetryDelayMs(attemptCount, error));
+      if (verdict === "account_row_missing") {
+        // The route resolves the account from `auth.user_identities`, which the first request that
+        // loads a request context after sign-in writes. The caller already awaited one, so reaching
+        // this means the row is still absent, and repeating the link alone would be refused
+        // identically forever: another request context is the documented remedy, not an
+        // optimisation. It never redirects to sign in and it never throws on a 401.
+        //
+        // It also answers, live and from the server, who the browser session names right now, which
+        // is the very question the published owner can only answer as of this tab's last look. This
+        // call re-caches that account's CSRF token on its way through, so the remaining attempts
+        // would carry the new account's credential fully formed; a different account here therefore
+        // ends the loop rather than starting the next attempt.
+        //
+        // Which is why the loop's own guard is re-run here as well, immediately before the one
+        // request in this loop it does not already precede: this point sits a failed round trip and
+        // up to `linkRetryMaxDelayMs` past that check, and a CSRF token re-cached for an owner that
+        // has moved since is not one this browser's queued work should be handed.
+        if (
+          readWebGuestIdentityGeneration() !== capturedIdentityGeneration
+          || readAnalyticsSessionOwnerId() !== accountUserId
+        ) {
+          return;
+        }
+
+        // Deliberately uncontained: this rethrows everything that is not a `401`, so a `5xx` or a
+        // transport failure on the remedy ends the ladder instead of costing it one attempt. That
+        // lands on the same outcome as exhausting it — the envelope and its stamp are kept, the
+        // caller's `catch` reports the failure, and the next app start retries from the top.
+        const currentSession = await getOptionalSession();
+        if (currentSession !== null && currentSession.userId !== accountUserId) {
+          return;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Starts the link for a guest envelope captured before sign-in, and returns immediately.
+ *
+ * Pass the envelope read before any identity-boundary cleanup ran, together with the generation read
+ * beside it, and the account the verified session names. The first two are load-bearing in opposite
+ * directions: reading early is what keeps the token available at all, because the cleanup clears the
+ * stored one — and the generation is what makes reading early safe, because an early read also
+ * survives the boots where that cleanup fires because a *different* person now holds this browser.
+ * Nothing is linked once the generation has moved on.
+ *
+ * The account closes the door neither of them can. A guest may be bound to exactly one account,
+ * once, so an envelope that outlived an earlier unfinished link is already spoken for; the
+ * generation cannot say so, because it is in-memory and starts at zero on every load. Across loads
+ * the only detector of a changed account is the IndexedDB cloud-settings record, and a browser that
+ * loses it while keeping `localStorage` — the store both the envelope and this stamp live in — sees
+ * no boundary at all. So the account the envelope was offered to is stored beside it, and an
+ * envelope offered to somebody else is dropped here rather than re-offered.
+ */
+export function linkWebGuestIdentityInBackground(
+  guestSession: WebGuestSessionEnvelope | null,
+  capturedIdentityGeneration: number,
+  accountUserId: string,
+): void {
+  // The same opt-out that stops `resolveWebGuestSession` before it mints an identity stops this
+  // before it spends one. The link writes an append-only, first-link-wins row with no repair path,
+  // so it is the most permanent backend write on this path and the least defensible one to make for
+  // somebody who declined measurement — and the switch outlives every local data wipe, so the
+  // visitor who minted a guest and only then opted out still arrives here. The envelope and its
+  // stamp are left alone rather than dropped: `resolveWebGuestSession` refuses to republish or mint
+  // while the switch is off, so the envelope sits inert, and keeping it is what lets the tail still
+  // be linked if analytics is turned back on before the next identity boundary.
+  if (readStoredAnalyticsEnabled() === false) {
+    return;
+  }
+
+  if (guestSession === null) {
+    return;
+  }
+
+  // This runs inside the sign-in path, which no analytics work may fail. Everything below already
+  // swallows its own storage errors; the wrapper is what keeps that a property of this call rather
+  // than of the functions it happens to use today.
+  try {
+    // Checked before the stamp is read or written: once the generation has moved the stored envelope
+    // is no longer the captured one, and both operations would be describing somebody else's.
+    if (readWebGuestIdentityGeneration() !== capturedIdentityGeneration) {
+      return;
+    }
+
+    const offeredAccountUserId = readWebGuestSessionLinkAccountId();
+    if (offeredAccountUserId !== null && offeredAccountUserId !== accountUserId) {
+      // This envelope was spent on another account and can never be linked again. Dropping it now
+      // is also what retires the stamp: the pair never survives its own first mismatch, so it
+      // cannot become a permanently unlinkable envelope that every later load republishes as the
+      // analytics owner. The cost is one visitor's signed-out tail, which is the undercount this
+      // codebase prefers to a misattribution.
+      dropStoredWebGuestSession(guestSession.guestToken);
+      return;
+    }
+
+    markWebGuestSessionLinkAccount(guestSession.guestToken, accountUserId);
+    void runGuestIdentityLink(guestSession.guestToken, capturedIdentityGeneration, accountUserId)
+      .catch((error: unknown): void => {
+        reportAnalyticsGuestIdentityLinkFailure(readGuestIdentityLinkStatusCode(error));
+      });
+  } catch {
+    // The link is lost for this load; the envelope is kept and the next app start picks it back up.
+  }
+}

--- a/apps/web/src/appData/session/guest/webGuestSession.ts
+++ b/apps/web/src/appData/session/guest/webGuestSession.ts
@@ -22,13 +22,16 @@ import { hasLoggedInCookie } from "../activation/warmStart";
  * guest platform by default on every authenticated backend surface — sync, chat and its AI quota,
  * guest upgrade, every account surface — and analytics ingest is the only route that opts in.
  *
- * The stored session is deliberately not cleared when the person signs in. It is the record that
- * lets the analytics client recognise, on the next page load, that the queue's previous owner was
- * this browser's own guest rather than a different account — which is what keeps `anonymous_id`
- * alive across the sign-in, so the guest's tail and the account's rows carry the same raw
- * `anonymous_id` in `analytics.product_events` and can be joined on it. It does not resolve the
- * guest into the account in `analytics.product_events_resolved`; `analytics/client.ts` documents
- * why, at the rotation exception that decides it.
+ * The stored session survives the sign-in itself and is dropped only once
+ * `POST /guest-auth/identity/link` has bound it to the account server-side, or answered that it
+ * never can be. Until then it is the record that lets the analytics client recognise that the
+ * queue's previous owner was this browser's own guest rather than a different account, which is what
+ * keeps `anonymous_id` alive across the boundary so the guest's tail and the account's rows carry
+ * the same raw `anonymous_id` in `analytics.product_events`. The link is what additionally resolves
+ * the guest into the account in `analytics.product_events_resolved`; `webGuestIdentityLink.ts` owns
+ * that call and its retry rules. An envelope kept across loads by an unfinished link carries the
+ * account it was offered to beside it, because a guest may be bound to exactly one account and
+ * nothing else survives a reload to say which.
  *
  * Every real identity boundary drops it: `resetWebGuestSession` removes it synchronously alongside
  * the analytics reset, and the key also carries the `flashcards-` prefix that
@@ -38,6 +41,20 @@ import { hasLoggedInCookie } from "../activation/warmStart";
 const guestSessionStorageKey = "flashcards-web-guest-session";
 /** Carries the `flashcards-` prefix too, so a probe left behind by a crash is swept like the rest. */
 const guestSessionStorageProbeKey = "flashcards-web-guest-session-probe";
+/**
+ * The creation idempotency key, kept beside the envelope rather than inside it: it exists only while
+ * no envelope does, and it is dropped the moment one arrives.
+ */
+const guestSessionIdempotencyKeyStorageKey = "flashcards-web-guest-session-idempotency-key";
+/**
+ * The account the stored envelope has already been offered to for linking, kept beside the envelope
+ * for the same reason the idempotency key is: it describes one envelope and is meaningless without
+ * it. `resetWebGuestSession` drops it with the envelope, so it can never outlive what it describes.
+ */
+const guestSessionLinkAccountStorageKey = "flashcards-web-guest-session-link-account";
+/** 16 random bytes, which the route's 32-to-200 lowercase-hex shape accepts at its lower bound. */
+const guestSessionIdempotencyKeyByteCount = 16;
+const guestSessionIdempotencyKeyPattern = /^[0-9a-f]{32,200}$/u;
 
 /** A failed attempt must not turn a click-happy visitor into a burst of session requests. */
 const guestSessionRetryDelayMs = 30 * 1000;
@@ -47,9 +64,9 @@ type WebGuestSessionState = "idle" | "requesting" | "settled";
 let state: WebGuestSessionState = "idle";
 let retryNotBeforeMs = 0;
 /**
- * Bumped by every identity boundary. A request captures it before it starts, so work that began
- * before the boundary can neither store nor publish the identity it obtained under the person who
- * has since left.
+ * Advanced by every `resetWebGuestSession()` — see `readWebGuestIdentityGeneration` for what that
+ * does and does not cover. A request captures it before it starts, so work that began before a reset
+ * can neither store nor publish an identity that is no longer this browser's.
  */
 let identityGeneration = 0;
 /**
@@ -169,7 +186,11 @@ function toWebGuestSession(value: unknown): WebGuestSessionEnvelope | null {
   return { guestToken, userId };
 }
 
-function readStoredWebGuestSession(): WebGuestSessionEnvelope | null {
+/**
+ * The guest identity this browser holds, if any. Read it before any identity-boundary cleanup runs:
+ * that cleanup clears the envelope, and the sign-in link needs the token it carries.
+ */
+export function readStoredWebGuestSession(): WebGuestSessionEnvelope | null {
   const storedValue = readBrowserStorageItem(guestSessionStorageKey);
   if (storedValue === null) {
     return null;
@@ -180,6 +201,119 @@ function readStoredWebGuestSession(): WebGuestSessionEnvelope | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * A monotonic count of the drops this module performed. Every `resetWebGuestSession()` advances it,
+ * which covers each identity boundary, an ingest refusal of the credential, and a finished or
+ * refused link — several of those fire for the same visitor, so this is deliberately not a count of
+ * identity boundaries.
+ *
+ * Only the unequal direction is a fact consumers may rely on. Anything that captures a guest
+ * envelope and then does asynchronous work with it captures this number beside it, and a capture
+ * that reads unequal here is stale and must be dropped, never used: the envelope it names is no
+ * longer the envelope in storage, and may not be in storage at all.
+ *
+ * An equal read proves nothing, and reading it as "the envelope is unchanged" is the mistake to
+ * avoid. `clearAllLocalBrowserData` sweeps every `flashcards-` key — the envelope, the idempotency
+ * key and the link-account stamp among them — and never touches this counter, and the account
+ * deletion gate calls that sweep with no `resetWebGuestSession()` in front of it, so storage can
+ * empty while this number stands still. That is why every storage operation here re-reads the stored
+ * token rather than trusting an equal generation, and why the link task carries an account assertion
+ * of its own instead of inferring the account from this.
+ */
+export function readWebGuestIdentityGeneration(): number {
+  return identityGeneration;
+}
+
+/**
+ * The account this browser's stored guest envelope has already been offered to, if any.
+ *
+ * A guest identity may be bound to exactly one account, in an append-only, first-link-wins table
+ * with no repair path, so an envelope that survived an unfinished link is no longer offerable to
+ * whoever signs in next: it is a specific person's signed-out tail, already claimed for a specific
+ * account. Nothing else on this browser can say so on a later page load — the identity generation is
+ * in-memory and starts at zero on every load, and the cloud-settings record the sign-in path detects
+ * account switches from lives in IndexedDB, which can be lost while `localStorage` survives.
+ */
+export function readWebGuestSessionLinkAccountId(): string | null {
+  const storedValue = readBrowserStorageItem(guestSessionLinkAccountStorageKey);
+  if (storedValue === null || storedValue.trim() === "") {
+    return null;
+  }
+
+  return storedValue;
+}
+
+/**
+ * Records the account an envelope is being offered to, before the offer is made rather than after it
+ * is answered: a `5xx` may commit the link and lose the revoke, and a tab closed mid-retry runs no
+ * completion path at all, so an envelope that is still in storage afterwards must already carry the
+ * account it was spent on.
+ *
+ * Guarded on the stored envelope still being the one that is being offered, so that this can only
+ * ever describe what is actually in storage: a stamp written over a dropped envelope would outlive
+ * it and refuse the next visitor's. Two paths retire it — `resetWebGuestSession`, and the
+ * `flashcards-` prefix sweep in `clearAllLocalBrowserData` — and each takes the envelope in the same
+ * pass, which is what keeps the two from outliving each other.
+ *
+ * The write itself may be silently lost: `writeBrowserStorageItem` swallows a full quota or a
+ * private-mode refusal, and the caller offers the envelope whether or not the stamp landed. The
+ * asymmetry with `persistWebGuestSession`'s read-back is deliberate. There a lost write mints a
+ * second permanent guest user, workspace and membership; here it only falls back to the server's own
+ * first-link-wins rule, under which the same guest offered to a second account writes a losing
+ * append-only row rather than a wrong binding. The cost is an undercounted tail, never a
+ * misattributed one.
+ */
+export function markWebGuestSessionLinkAccount(guestToken: string, accountUserId: string): void {
+  if (readStoredWebGuestSession()?.guestToken !== guestToken) {
+    return;
+  }
+
+  writeBrowserStorageItem(guestSessionLinkAccountStorageKey, accountUserId);
+}
+
+/**
+ * Stores the envelope and reports whether it can actually be read back.
+ *
+ * The read-back is not a repeat of `canPersistWebGuestSession()`. That probe ran before the creation
+ * request, several awaits earlier, and `writeBrowserStorageItem` swallows its own failure, so a quota
+ * that filled up in between leaves this browser holding no envelope at all — silently. It is what
+ * decides whether the idempotency key may be released, and releasing it over an envelope that was
+ * never stored is exactly the second permanent guest user, workspace and membership the key exists to
+ * prevent.
+ */
+function persistWebGuestSession(guestSession: WebGuestSessionEnvelope): boolean {
+  writeBrowserStorageItem(guestSessionStorageKey, JSON.stringify(guestSession));
+  return readStoredWebGuestSession()?.guestToken === guestSession.guestToken;
+}
+
+function createGuestSessionIdempotencyKey(): string {
+  const randomBytes = new Uint8Array(guestSessionIdempotencyKeyByteCount);
+  crypto.getRandomValues(randomBytes);
+  return Array.from(randomBytes, (byte: number): string => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * The key for the creation attempt that is currently open, generating one when none is.
+ *
+ * It is reused across attempts on purpose: a response lost after the server committed leaves this
+ * browser with no envelope and a live guest session, and replaying the same key rotates that
+ * session's secret and returns the same guest instead of minting a second permanent set of rows. It
+ * must never be derived from an install id, a device id, or anything else stable — rotation hands
+ * whoever presents the key a fresh valid token for that guest, so a predictable key is a bearer
+ * credential for the identity behind it. A stored value that is not the shape the route accepts is
+ * not this module's, and is replaced rather than sent.
+ */
+function readGuestSessionIdempotencyKey(): string {
+  const storedValue = readBrowserStorageItem(guestSessionIdempotencyKeyStorageKey);
+  if (storedValue !== null && guestSessionIdempotencyKeyPattern.test(storedValue)) {
+    return storedValue;
+  }
+
+  const idempotencyKey = createGuestSessionIdempotencyKey();
+  writeBrowserStorageItem(guestSessionIdempotencyKeyStorageKey, idempotencyKey);
+  return idempotencyKey;
 }
 
 /**
@@ -277,25 +411,35 @@ async function resolveWebGuestSession(requestGeneration: number): Promise<void> 
     return;
   }
 
-  const guestSession = await createWebGuestSession();
+  const guestSession = await createWebGuestSession(readGuestSessionIdempotencyKey());
   // An identity boundary crossed while the request was in flight. This guest belongs to nobody on
   // this browser now, so it is neither stored nor published; the next interaction starts over.
   if (requestGeneration !== identityGeneration) {
     return;
   }
 
-  writeBrowserStorageItem(guestSessionStorageKey, JSON.stringify(guestSession));
+  // The key is released only once the envelope is provably readable again. The creation attempt
+  // succeeding is not enough on its own: a browser left with neither envelope nor key mints a second
+  // permanent guest user, workspace and membership on its next attempt, which is the one outcome the
+  // key exists to prevent. Where the envelope did persist the key has done its job and keeping it
+  // would leave a credential that can rotate this guest's token lying in `localStorage` for no
+  // purpose. Publishing happens either way: this load is measured even when nothing about it can be
+  // remembered for the next one.
+  if (persistWebGuestSession(guestSession)) {
+    removeBrowserStorageItem(guestSessionIdempotencyKeyStorageKey);
+  }
+
   publishWebGuestOwner(guestSession);
 }
 
 /**
- * Drops this browser's guest identity at an identity boundary.
+ * Drops this browser's guest identity.
  *
- * Synchronous, and called next to `reset()` in the analytics client rather than left to the
- * `flashcards-` prefix sweep in `clearAllLocalBrowserData`. That sweep runs several awaits later and
- * is skipped entirely when the IndexedDB recovery guard fires first, and until the key is gone an
- * interaction inside that window would read the outgoing person's guest session back out of storage
- * and publish it as the confirmed owner for the rest of the page load.
+ * At an identity boundary it is synchronous, and called next to `reset()` in the analytics client
+ * rather than left to the `flashcards-` prefix sweep in `clearAllLocalBrowserData`. That sweep runs
+ * several awaits later and is skipped entirely when the IndexedDB recovery guard fires first, and
+ * until the key is gone an interaction inside that window would read the outgoing person's guest
+ * session back out of storage and publish it as the confirmed owner for the rest of the page load.
  *
  * The module state goes back to idle with it: this browser now holds no guest identity, so a later
  * interaction by a signed-out visitor may obtain a fresh one, exactly as it would on a new load.
@@ -306,15 +450,48 @@ export function resetWebGuestSession(): void {
     state = "idle";
     retryNotBeforeMs = 0;
     removeBrowserStorageItem(guestSessionStorageKey);
+    // The key goes with the envelope. It names a creation attempt made for the person who is
+    // leaving, and replaying it for the next one would hand them that guest's identity.
+    removeBrowserStorageItem(guestSessionIdempotencyKeyStorageKey);
+    // So does the account the envelope was offered to: it describes an envelope that no longer
+    // exists. A stamp left behind would outlive its envelope and refuse a later, unrelated one, so
+    // the two only ever leave together — here, and in the `flashcards-` prefix sweep.
+    removeBrowserStorageItem(guestSessionLinkAccountStorageKey);
   } catch {
     // Identity-boundary cleanup must not fail because the guest record could not be removed.
   }
 }
 
 /**
- * Obtains and publishes the guest identity, at most once per browser load and once more after each
- * identity boundary. Returns immediately: the request runs in the background, because no user action
- * may be blocked, delayed, or failed by anything analytics needs.
+ * Drops a guest identity the ingest endpoint has refused as a credential — a `401` or a `410`, which
+ * for a guest means the session no longer exists server-side. Without this the envelope is
+ * republished on every later load and the browser measures nothing for good.
+ *
+ * It goes through `resetWebGuestSession` so the generation counter and the storage keys stay
+ * consistent, and then closes the module for the rest of this load. Returning to idle is right for
+ * an identity boundary, where a new person may obtain a guest of their own, and wrong here: a
+ * refused credential is the same visitor, and re-arming would put minting on a path a repeating
+ * refusal can drive, one permanent guest user, workspace and membership per interaction. The rest of
+ * this load goes unmeasured and the next one mints a fresh guest, which is the trade
+ * `requestWebGuestSessionOnInteraction` already documents.
+ */
+export function discardRefusedWebGuestSession(): void {
+  try {
+    resetWebGuestSession();
+    state = "settled";
+  } catch {
+    // Nothing on the analytics delivery path may surface as an uncaught error.
+  }
+}
+
+/**
+ * Obtains and publishes the guest identity, at most once per browser load and once more each time
+ * `resetWebGuestSession()` puts this module back to idle. That is every identity boundary, and also
+ * the link paths that drop a spent envelope — a finished link, a terminal refusal — which re-arm on
+ * a load that is signed in by then, where `hasVerifiedBrowserSession()` stops the mint before it
+ * starts. `discardRefusedWebGuestSession` is the one drop that deliberately does not re-arm.
+ * Returns immediately: the request runs in the background, because no user action may be blocked,
+ * delayed, or failed by anything analytics needs.
  *
  * Settling once per load is the bound that keeps server-side rows finite, and it is kept even though
  * it has a cost: if the published identity is invalidated later in the same load — the session

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -31,7 +31,12 @@ import {
   buildLinkingReadyCloudSettings,
   resolveLocalDataCleanupReasonForVerifiedSession,
 } from "../cloud/workspaceSessionCloud";
-import { registerWebSessionOwnerPublisher } from "../guest/webGuestSession";
+import { linkWebGuestIdentityInBackground } from "../guest/webGuestIdentityLink";
+import {
+  readStoredWebGuestSession,
+  readWebGuestIdentityGeneration,
+  registerWebSessionOwnerPublisher,
+} from "../guest/webGuestSession";
 import {
   createSessionAccountSwitchError,
   hasLoggedOutMarker,
@@ -160,6 +165,17 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     setSessionTechnicalError(null);
     setTechnicalError(null);
 
+    // Read before any of the identity-boundary cleanup below can clear it. This is the guest
+    // identity this browser measured under while signed out, and the link at the end of a verified
+    // sign-in is the only thing that carries its analytics history into the account.
+    //
+    // The generation is captured with it, because reading early also survives the boots where that
+    // cleanup fires for the worst reason there is: a confirmed account switch or an unknown reauth
+    // owner, where the envelope belongs to the person who left rather than to the one signing in.
+    // The link refuses to run once this number has moved on.
+    const storedGuestSession = readStoredWebGuestSession();
+    const storedGuestIdentityGeneration = readWebGuestIdentityGeneration();
+
     try {
       if (hasLoggedOutMarker()) {
         await clearConfirmedUserScopedState("logout_marker");
@@ -245,6 +261,17 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       // or discard; until it is published nothing is sent, which is why it is only reached once the
       // session is verified and any user-scoped cleanup has already run.
       setAnalyticsConfirmedOwner(currentSession.userId, { kind: "session" });
+      // Started after the owner publish above, and never awaited: the queue claim reads this
+      // browser's guest id to decide whether `anonymous_id` survives the sign-in, and no user action
+      // may be blocked, delayed or failed by an analytics call. `getSession()` above is also the
+      // request-context call the route requires to have run first, and the account it verified is
+      // passed along so the link can assert, on every attempt and on every later load, that it is
+      // still binding the envelope to the account it started for.
+      linkWebGuestIdentityInBackground(
+        storedGuestSession,
+        storedGuestIdentityGeneration,
+        currentSession.userId,
+      );
       setSessionVerificationState("verified");
     } catch (error) {
       const normalizedError = normalizeCaughtError(error);
@@ -360,6 +387,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             return false;
           }
 
+          // No guest link here, deliberately. A different account now holds this browser, so any
+          // envelope still stored was the previous person's: `clearConfirmedUserScopedState` above
+          // dropped it and advanced the guest identity generation, which also stops a link started
+          // by `initialize` from binding it to the account being published on this line.
           setAnalyticsConfirmedOwner(currentSession.userId, { kind: "session" });
           setSessionVerificationState("verified");
           setSessionErrorMessage("");

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -732,7 +732,8 @@ export type AnalyticsDeliveryWarningDetails = Readonly<{
     | "analytics_queue_ttl_expired"
     | "analytics_queue_discarded_on_reset"
     | "analytics_batch_invalid"
-    | "analytics_delivery_unavailable";
+    | "analytics_delivery_unavailable"
+    | "analytics_guest_identity_link_failed";
   count: number | null;
   statusCode: number | null;
 }>;


### PR DESCRIPTION
A visitor measured before signing up kept their tail on the guest identity, joinable only by hand. The sign-in path now claims it through the identity-link route, so it resolves to the account in the reporting view instead.

**Getting this wrong is permanent.** Identity links are append-only and first-link-wins, so a guest bound to the wrong account can never be rebound. Three guards keep that from happening:

- the **account** signed in when the envelope was captured is re-asserted before every attempt, so a second account signing in from another tab cannot inherit the first one's tail;
- the module's **guest generation** is re-read on the same schedule, so an identity boundary mid-ladder stops the claim;
- an envelope kept for a later retry is **stamped with the account it was offered to**, because across app starts nothing else can tell that the browser changed hands — the boundary check reads cloud settings from IndexedDB while the envelope lives in `localStorage`, and the recovery path can empty one without the other.

**A retryable answer keeps the guest token, always.** Dropping it is the one irreversible loss on this path, and a `5xx` can leave the link written while the guest session is still live — which a later sign-in by someone else would turn into a permanent misattribution. So `409 ACCOUNT_REQUIRED`, `429` and `5xx` retry with the token kept, `400` stops without dropping it, and only the terminal codes clear.

**An opted-out visitor reaches the backend on no path here.** The link is the most permanent write this client makes and the opt-out outlives local data wipes, so it is checked before anything is read or written.

**An ingest refusal now clears the stored guest**, so a browser whose session was deleted server-side mints a fresh one on its next load rather than republishing a dead credential and going silent forever. Guest creation carries an idempotency key, released only after the envelope is read back from storage, so a silent write failure replays onto the same guest instead of minting a second one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)