### PR TITLE
Say which screen an iOS sign-in failed on

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
@@ -453,7 +453,13 @@ struct RootTabView: View {
     private var tabRootSheets: some View {
         self.tabRootChangeHandlers
         .sheet(isPresented: self.$isGuestSignInCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard)
+            // The origin is the surface that owns the control the person tapped, not the tab the
+            // alert happens to float over. This prompt belongs to the review flow, so it stays
+            // Review: it is a distinct entry point with its own conversion, and following the
+            // visible tab would scatter its failures across the other tabs' own sign-in buttons and
+            // make all of them unreadable. The prompt's accept and snooze buttons already report
+            // `onboarding_step_completed(step: .signin)` on Review for the very same tap.
+            CloudSignInSheet(presentationContext: .standard(originSurface: .review))
                 .environment(store)
         }
         .sheet(item: self.feedbackPresentation) { presentation in

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -88,7 +88,7 @@ struct ProgressScreen: View {
             }
         }
         .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard)
+            CloudSignInSheet(presentationContext: .standard(originSurface: .progress))
                 .environment(self.store)
         }
         .sheet(isPresented: self.$isFriendInvitePresented) {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
@@ -135,7 +135,7 @@ struct AccountStatusView: View {
         .accessibilityIdentifier(UITestIdentifier.accountStatusScreen)
         .navigationTitle(aiSettingsLocalized("settings.account.status.title", "Account Status"))
         .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard)
+            CloudSignInSheet(presentationContext: .standard(originSurface: .settings))
                 .environment(store)
         }
         .alert(aiSettingsLocalized("settings.account.status.logoutAlertTitle", "Log out and clear this device?"), isPresented: self.$isLogoutConfirmationPresented) {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -142,7 +142,7 @@ struct CloudSignInSheet: View {
             .sheet(item: self.$postAuthRecoveryNeededState) { recoveryState in
                 CloudPostAuthRecoveryNeededSheet(
                     state: recoveryState,
-                    allowsLogoutAction: self.presentationContext == .standard,
+                    allowsLogoutAction: self.isStandardPresentation,
                     onClose: {
                         self.postAuthRecoveryNeededState = nil
                         self.dismiss()
@@ -159,7 +159,7 @@ struct CloudSignInSheet: View {
                     allowsCloseAction: failureState.allowsAccountExitActions
                         || self.presentationContext == .credentialRecoveryGate,
                     allowsLogoutAction: failureState.allowsAccountExitActions
-                        && self.presentationContext == .standard,
+                        && self.isStandardPresentation,
                     onRetry: {
                         self.retryPostAuthFailure(failureState)
                     },
@@ -288,6 +288,15 @@ struct CloudSignInSheet: View {
         self.store.cloudCredentialRecoveryState != nil
     }
 
+    private var isStandardPresentation: Bool {
+        switch self.presentationContext {
+        case .standard:
+            return true
+        case .credentialRecoveryGate:
+            return false
+        }
+    }
+
     private func recordActivePresentationIfNeeded() {
         guard self.hasRecordedActivePresentation == false else {
             return
@@ -295,7 +304,9 @@ struct CloudSignInSheet: View {
 
         self.hasRecordedActivePresentation = true
         self.wasCredentialRecoveryGateActiveAtPresentation = self.isCredentialRecoveryGateActive
-        self.store.beginCloudSignInSheetPresentation()
+        self.store.beginCloudSignInSheetPresentation(
+            originSurface: self.presentationContext.originSurface
+        )
     }
 
     /**
@@ -683,6 +694,6 @@ struct CloudSignInSheet: View {
 }
 
 #Preview {
-    CloudSignInSheet(presentationContext: .standard)
+    CloudSignInSheet(presentationContext: .standard(originSurface: .settings))
         .environment(FlashcardsStore())
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
@@ -22,13 +22,14 @@ struct CloudOtpSheetState: Identifiable, Hashable {
 
 @MainActor
 extension FlashcardsStore {
-    func beginCloudSignInSheetPresentation() {
+    func beginCloudSignInSheetPresentation(originSurface: AnalyticsSurface?) {
         assert(
             self.activeCloudSignInSheetCount == 0,
             "A second cloud sign-in sheet was presented while one was already on screen."
         )
         self.activeCloudSignInSheetCount += 1
         self.isCloudSignInAttemptOpen = true
+        self.cloudSignInOriginSurface = originSurface
     }
 
     func endCloudSignInSheetPresentation() {
@@ -38,6 +39,7 @@ extension FlashcardsStore {
         }
 
         self.activeCloudSignInSheetCount -= 1
+        self.cloudSignInOriginSurface = nil
     }
 
     /**
@@ -92,7 +94,7 @@ extension FlashcardsStore {
 
     private func trackCloudSignInFailed(reason: AnalyticsSignInFailureReason) {
         self.isCloudSignInAttemptOpen = false
-        Analytics.track(.signInFailed(reason: reason))
+        Analytics.track(.signInFailed(reason: reason), screen: self.cloudSignInOriginSurface)
     }
 }
 
@@ -103,9 +105,27 @@ enum CloudPostAuthRetryAction: Hashable {
     case syncOnly
 }
 
+/**
+ * Where a sign-in sheet was opened from, and with it the `screen` its `signin_failed` carries.
+ *
+ * The credential-recovery gate carries no surface on purpose: it replaces the app's root because a
+ * stored credential stopped working, so the person was on no product surface and naming one would be
+ * a lie. Every other presenter names the surface that owns the control the person tapped, out of the
+ * shared server-owned catalog, so a prompt owned by the review flow stays Review whichever tab it
+ * floats over.
+ */
 enum CloudSignInPresentationContext: Hashable {
-    case standard
+    case standard(originSurface: AnalyticsSurface)
     case credentialRecoveryGate
+
+    var originSurface: AnalyticsSurface? {
+        switch self {
+        case .standard(let originSurface):
+            return originSurface
+        case .credentialRecoveryGate:
+            return nil
+        }
+    }
 }
 
 enum CloudPostAuthSyncOperation: Hashable {

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -345,7 +345,7 @@ struct SettingsView: View {
             store.triggerCloudAccountContextRefreshIfActive(surfacesGlobalErrorMessage: false)
         }
         .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard)
+            CloudSignInSheet(presentationContext: .standard(originSurface: .settings))
                 .environment(self.store)
         }
         .sheet(isPresented: self.$isFriendInvitePresented) {

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -130,6 +130,10 @@ final class FlashcardsStore {
     @ObservationIgnored var isGuestUpgradeLocalOutboxMutationBlocked: Bool
     /// Whether the presented sign-in sheet still owes one `signin_failed`.
     @ObservationIgnored var isCloudSignInAttemptOpen: Bool
+    /// The surface the presented sign-in sheet was opened from, and the `screen` its `signin_failed`
+    /// carries. Latched at presentation because the OTP step and the abandonment report both emit
+    /// from places that no longer know the presenter.
+    @ObservationIgnored var cloudSignInOriginSurface: AnalyticsSurface?
     /// Whether a background analytics guest identity claim is already in flight. Sign-in and startup
     /// both start one, and two claims racing would send the same guest token twice.
     @ObservationIgnored var isAnalyticsGuestIdentityLinkResumeRunning: Bool
@@ -478,6 +482,7 @@ final class FlashcardsStore {
         self.isAccountDeletionRunning = false
         self.isGuestUpgradeLocalOutboxMutationBlocked = false
         self.isCloudSignInAttemptOpen = false
+        self.cloudSignInOriginSurface = nil
         self.isAnalyticsGuestIdentityLinkResumeRunning = false
         self.reportedAnalyticsGuestCredentialFailureStages = []
         self.currentVisibleTab = .review


### PR DESCRIPTION
Every iOS `signin_failed` went out with `screen: null`. The emitter never passed one and the event declares none of its own, so `declaredScreen ?? screen` resolved to nothing. Android meanwhile stamped `settings` on all of its own, including the ones raised behind the credential-recovery gate where the person is not in settings at all.

Both clients now follow one rule: `screen` names the surface that owns the control the person tapped.

| opened from | `screen` |
| --- | --- |
| settings, or the account screen inside settings | `settings` |
| the progress screen | `progress` |
| the after-review guest sign-in prompt | `review` |
| the credential-recovery gate that replaces the app root at launch | `null` |

The origin travels with the presentation context and is latched while the sheet is up. It has to be latched: the two OTP failures and the abandonment report all fire from places that no longer know who presented the sheet, and the abandonment fires during teardown. Making the context carry it also means the gate's `null` is unrepresentable as a mistake rather than something each presenter has to remember.

The after-review guest prompt reports `review` rather than the tab it floats over. It is a distinct entry point, its failures would otherwise scatter into the tabs whose own sign-in buttons those rows belong to, and the shipped `onboarding_step_completed(step: signin)` from the same tap already reports `review`.

A null `screen` stays valid: the event is declared `requiresScreen: false`, validation uses a nullish surface schema, and the column is nullable. No server change and no new surface value.

Compiled locally before merge (`xcodebuild build`, exit 0), since PR checks do not build Swift.

Not in this PR: a notification tap can tear down a sign-in sheet presented from Settings and emit two false `signin_failed(cancelled)` events while the sheet is still on screen. That is confirmed on a simulator and ships as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)