### PR TITLE
Say which screen an Android sign-in failed on

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -54,6 +54,8 @@ internal fun CloudCredentialRecoveryGateContainer(
             syncRepository = appGraph.syncRepository,
             messageController = appGraph.appMessageBus,
             analytics = appGraph.analytics,
+            // The gate replaces the app's root at launch, so no product surface opened this sign-in.
+            originSurface = null,
             applicationContext = context.applicationContext
         )
     )

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -681,7 +681,13 @@ fun FlashcardsApp(
                     GuestSignInAfterReviewPromptDialog(
                         onSignIn = {
                             appGraph.guestSignInAfterReviewPromptController.acceptPrompt()
-                            navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                            // The prompt belongs to the review flow, so `review` is its origin no
+                            // matter which tab the dialog happened to be drawn over.
+                            navController.navigate(
+                                route = SettingsAccountSignInEmailDestination.createRoute(
+                                    origin = AnalyticsSurface.REVIEW
+                                )
+                            )
                         },
                         onLater = {
                             appGraph.guestSignInAfterReviewPromptController.dismissForLater()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ai/AiNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ai/AiNavGraph.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.data.local.ai.diagnostics.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.feature.ai.AiCardHandoffResult
 import com.flashcardsopensourceapp.feature.ai.AiRoute
@@ -124,7 +125,9 @@ internal fun NavGraphBuilder.registerAiNavGraph(
             onCancelStreaming = aiViewModel::cancelStreaming,
             onNewChat = aiViewModel::clearConversation,
             onOpenAccountStatus = {
-                navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                navController.navigate(
+                    route = SettingsAccountSignInEmailDestination.createRoute(origin = AnalyticsSurface.AI)
+                )
             },
             onDismissErrorMessage = aiViewModel::dismissErrorMessage,
             onDismissAlert = aiViewModel::dismissAlert,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/progress/ProgressNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/progress/ProgressNavGraph.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.app.navigation.ProgressDestination
 import com.flashcardsopensourceapp.app.navigation.ProgressNavigationTarget
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsLeaderboardParticipationDestination
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationViewModel
 import com.flashcardsopensourceapp.feature.friendinvite.createFriendInvitationViewModelFactory
 import com.flashcardsopensourceapp.feature.progress.ProgressRoute
@@ -65,7 +66,9 @@ internal fun NavGraphBuilder.registerProgressNavGraph(
             onClearFriendInvitationFailure = friendInvitationViewModel::clearFriendInvitationFailure,
             onFriendInvitationShared = friendInvitationViewModel::markFriendInvitationShared,
             onOpenSignIn = {
-                navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                navController.navigate(
+                    route = SettingsAccountSignInEmailDestination.createRoute(origin = AnalyticsSurface.PROGRESS)
+                )
             },
             onOpenLeaderboardSettings = {
                 navController.navigate(route = SettingsLeaderboardParticipationDestination.route)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -10,13 +10,16 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.R
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudPostAuthRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInCodeRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInEmailRoute
@@ -33,10 +36,17 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
     coroutineScope: CoroutineScope
 ) {
     navigation(
-        startDestination = SettingsAccountSignInEmailDestination.route,
+        startDestination = SettingsAccountSignInEmailDestination.routePattern,
         route = SettingsAccountAuthGraph.route
     ) {
-        composable(route = SettingsAccountSignInEmailDestination.route) { backStackEntry ->
+        composable(
+            route = SettingsAccountSignInEmailDestination.routePattern,
+            arguments = listOf(navArgument(name = SettingsAccountSignInEmailDestination.originArgument) {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            })
+        ) { backStackEntry ->
             val context = LocalContext.current
             val technicalErrorDialogTitle = stringResource(id = R.string.technical_error_dialog_default_title)
             val technicalErrorDialogMessage = stringResource(id = R.string.technical_error_dialog_default_message)
@@ -51,6 +61,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                     syncRepository = appGraph.syncRepository,
                     messageController = appGraph.appMessageBus,
                     analytics = appGraph.analytics,
+                    originSurface = signInOriginSurface(authGraphBackStackEntry = authGraphBackStackEntry),
                     applicationContext = context.applicationContext
                 )
             )
@@ -108,6 +119,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                     syncRepository = appGraph.syncRepository,
                     messageController = appGraph.appMessageBus,
                     analytics = appGraph.analytics,
+                    originSurface = signInOriginSurface(authGraphBackStackEntry = authGraphBackStackEntry),
                     applicationContext = context.applicationContext
                 )
             )
@@ -156,6 +168,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                     syncRepository = appGraph.syncRepository,
                     messageController = appGraph.appMessageBus,
                     analytics = appGraph.analytics,
+                    originSurface = signInOriginSurface(authGraphBackStackEntry = authGraphBackStackEntry),
                     applicationContext = context.applicationContext
                 )
             )
@@ -211,6 +224,25 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
             )
         }
     }
+}
+
+/**
+ * The surface that opened this sign-in rides in as a query argument on the graph's start
+ * destination, and Navigation copies a destination's arguments onto the parent graph's back stack
+ * entry, so the `SettingsAccountAuthGraph` entry carries it too.
+ *
+ * Reading it from that entry — the single `CloudSignInViewModel` store owner — rather than from
+ * each destination is what keeps all three steps on one value: the view model is built once per
+ * graph entry, so whichever step composes first would otherwise decide the origin for the rest,
+ * including a process-death restore that lands on the code step.
+ *
+ * An absent or unrecognised value stays `null`, which is what `signin_failed` reports when no
+ * product surface opened the sign-in.
+ */
+private fun signInOriginSurface(authGraphBackStackEntry: NavBackStackEntry): AnalyticsSurface? {
+    val originWireValue: String? = authGraphBackStackEntry.arguments
+        ?.getString(SettingsAccountSignInEmailDestination.originArgument)
+    return AnalyticsSurface.entries.firstOrNull { surface -> surface.wireValue == originWireValue }
 }
 
 @Composable

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.R
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.feature.settings.account.AccountDangerZoneRoute
 import com.flashcardsopensourceapp.feature.settings.account.AccountLegalRoute
 import com.flashcardsopensourceapp.feature.settings.account.AccountOpenSourceRoute
@@ -47,7 +48,9 @@ internal fun NavGraphBuilder.registerSettingsAccountNavGraph(
         AccountStatusRoute(
             uiState = uiState,
             onOpenSignIn = {
-                navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                navController.navigate(
+                    route = SettingsAccountSignInEmailDestination.createRoute(origin = AnalyticsSurface.SETTINGS)
+                )
             },
             onSyncNow = {
                 coroutineScope.launch {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
@@ -1,5 +1,7 @@
 package com.flashcardsopensourceapp.app.navigation.settings
 
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
+
 internal data object SettingsRootGraph {
     const val route: String = "settings/root"
 }
@@ -100,8 +102,22 @@ data object SettingsAccountStatusDestination {
     const val route: String = "settings/account-status"
 }
 
+/**
+ * Start destination of [SettingsAccountAuthGraph]. It lives under a `settings/` path but is opened
+ * from settings, the progress screen, the AI screen and the after-review guest prompt alike, so the
+ * surface that owns the tapped control rides along as an optional query argument and ends up on the
+ * graph's back stack entry, which is where `signin_failed` reads it from.
+ *
+ * [route] stays the bare path: it is what the route-prefix checks in `FlashcardsApp` match on.
+ */
 data object SettingsAccountSignInEmailDestination {
     const val route: String = "settings/account/sign-in"
+    const val originArgument: String = "origin"
+    const val routePattern: String = "$route?$originArgument={$originArgument}"
+
+    fun createRoute(origin: AnalyticsSurface): String {
+        return "$route?$originArgument=${origin.wireValue}"
+    }
 }
 
 data object SettingsAccountSignInCodeDestination {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -28,6 +28,7 @@ import com.flashcardsopensourceapp.app.navigation.AppPackageInfo
 import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.app.notifications.loadNotificationDiagnosticsUiState
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.core.ui.AppTechnicalError
 import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationDialog
 import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationShareEffect
@@ -128,7 +129,9 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
                     }
 
                     SettingsFriendInviteAvailability.SIGN_IN_REQUIRED -> {
-                        navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                        navController.navigate(
+                            route = SettingsAccountSignInEmailDestination.createRoute(origin = AnalyticsSurface.SETTINGS)
+                        )
                     }
 
                     SettingsFriendInviteAvailability.LOADING -> Unit
@@ -355,7 +358,9 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
                 appGraph.appMessageBus.showMessage(
                     message = manageSignInMessage
                 )
-                navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                navController.navigate(
+                    route = SettingsAccountSignInEmailDestination.createRoute(origin = AnalyticsSurface.SETTINGS)
+                )
             },
             onRetryLastWorkspaceAction = {
                 currentWorkspaceViewModel.retryLastWorkspaceActionAsync()

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.ViewModelProvider
 import com.flashcardsopensourceapp.core.observability.analytics.Analytics
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
@@ -189,6 +190,7 @@ fun createCloudSignInViewModelFactory(
     syncRepository: SyncRepository,
     messageController: TransientMessageController,
     analytics: Analytics,
+    originSurface: AnalyticsSurface?,
     applicationContext: Context
 ): ViewModelProvider.Factory {
     return com.flashcardsopensourceapp.feature.settings.cloud.signIn.createCloudSignInViewModelFactory(
@@ -196,6 +198,7 @@ fun createCloudSignInViewModelFactory(
         syncRepository = syncRepository,
         messageController = messageController,
         analytics = analytics,
+        originSurface = originSurface,
         applicationContext = applicationContext
     )
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -73,11 +73,17 @@ private val cloudVerifyCodeUserCorrectableErrorCodes: Set<String> = setOf(
     "OTP_VERIFY_FAILED"
 )
 
+/**
+ * [originSurface] is the product surface the person opened this sign-in from, and it is what
+ * `signin_failed` reports. The credential-recovery gate replaces the app's root at launch instead
+ * of opening from a surface, so it passes `null` rather than naming one.
+ */
 class CloudSignInViewModel(
     private val cloudAccountRepository: CloudAccountRepository,
     private val syncRepository: SyncRepository,
     private val messageController: TransientMessageController,
     private val analytics: Analytics,
+    private val originSurface: AnalyticsSurface?,
     private val strings: SettingsStringResolver
 ) : ViewModel() {
     private val draftState = MutableStateFlow(
@@ -574,7 +580,7 @@ class CloudSignInViewModel(
         analytics.track(
             event = AnalyticsEvent.SignInFailed(
                 reason = reason,
-                screen = AnalyticsSurface.SETTINGS
+                screen = originSurface
             )
         )
     }
@@ -998,6 +1004,7 @@ fun createCloudSignInViewModelFactory(
     syncRepository: SyncRepository,
     messageController: TransientMessageController,
     analytics: Analytics,
+    originSurface: AnalyticsSurface?,
     applicationContext: Context
 ): ViewModelProvider.Factory {
     return viewModelFactory {
@@ -1007,6 +1014,7 @@ fun createCloudSignInViewModelFactory(
                 syncRepository = syncRepository,
                 messageController = messageController,
                 analytics = analytics,
+                originSurface = originSurface,
                 strings = createSettingsStringResolver(context = applicationContext)
             )
         }

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.settings
 
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.core.observability.analytics.NoOpAnalytics
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
@@ -50,6 +51,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -117,6 +119,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -161,6 +164,7 @@ class CloudSignInViewModelTest {
             syncRepository = syncRepository,
             messageController = TransientMessageController { message -> messages += message },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -243,6 +247,7 @@ class CloudSignInViewModelTest {
             syncRepository = syncRepository,
             messageController = TransientMessageController { message -> messages += message },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -309,6 +314,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -357,6 +363,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { message -> messages.add(message) },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -407,6 +414,7 @@ class CloudSignInViewModelTest {
             syncRepository = syncRepository,
             messageController = TransientMessageController { message -> messages += message },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -456,6 +464,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -507,6 +516,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -558,6 +568,7 @@ class CloudSignInViewModelTest {
             syncRepository = syncRepository,
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -606,6 +617,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -659,6 +671,7 @@ class CloudSignInViewModelTest {
             syncRepository = syncRepository,
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -712,6 +725,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -753,6 +767,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -787,6 +802,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -830,6 +846,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -867,6 +884,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -906,6 +924,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {
@@ -960,6 +979,7 @@ class CloudSignInViewModelTest {
             syncRepository = FakeSyncRepository(),
             messageController = TransientMessageController { },
             analytics = NoOpAnalytics,
+            originSurface = AnalyticsSurface.SETTINGS,
             strings = strings
         )
         val uiStateCollection = backgroundScope.async {


### PR DESCRIPTION
Android stamped `AnalyticsSurface.SETTINGS` on every `signin_failed`. The sign-in screens do live under a settings route, but six controls navigate to them — three in settings, one on the progress screen, one on the AI screen, and the guest prompt shown after a review — and the credential-recovery gate builds the same view model while replacing the app's root, where the person is not in settings at all.

This is the Android half of a contract iOS now follows too: `screen` names the surface that owns the control the person tapped.

| opened from | `screen` |
| --- | --- |
| settings, the account screen, the friend-invite prompt | `settings` |
| the progress screen | `progress` |
| the AI screen | `ai` |
| the after-review guest sign-in prompt | `review` |
| the credential-recovery gate | `null` |

The origin rides in as a navigation argument on the auth graph and is read back off the **graph's** own back stack entry, not the destination's. That is load-bearing: one `CloudSignInViewModel` is scoped to the whole graph, so a per-destination value would keep whichever step composed first — including a process-death restore that lands straight on the code step. The argument was chosen over reading the previous back stack entry because it survives that restore and a deep link, where the previous entry does not.

The after-review prompt reports `review` rather than the tab it was drawn over. It is a distinct entry point, its failures would otherwise scatter into the tabs whose own sign-in buttons those rows belong to, and the shipped `onboarding_step_completed(step: signin)` from the same tap already reports `review` on iOS.

`screen_viewed` is unaffected: the route mapper matches on the `settings/` prefix, which the query-bearing route still has. A null `screen` stays valid — the event is `requiresScreen: false` and the column is nullable — so no server change and no new surface value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)