### PR TITLE
Index the scan the web guest reaper drives off

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -388,7 +388,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0117_guest_session_creation_idempotency.sql
+            --require-migration 0118_guest_sessions_platform_created_at_index.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0117_guest_session_creation_idempotency.sql",
+      RequiredMigration: "0118_guest_sessions_platform_created_at_index.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0117_guest_session_creation_idempotency.sql",
+    requiredMigration: "0118_guest_sessions_platform_created_at_index.sql",
   });
 });
 

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-web-guest-reaper.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-web-guest-reaper.ts
@@ -203,11 +203,20 @@ const webGuestReaperHandler: Handler<WebGuestReaperEvent, WebGuestReaperResponse
     });
 
     // A candidate scan that throws is caught by the run so the record above still reports the
-    // guests it had already deleted permanently, but the invocation must not end cleanly:
-    // WebGuestReaperLambdaErrorAlarm is the stated reason the deferred auth.guest_sessions
-    // (platform, created_at) index is safe to defer, and the unindexed scan outgrowing the
-    // reporting role's 30s statement_timeout is exactly the failure it has to see. The staleness
-    // alarm cannot stand in for it, because an errored invocation still counts in Invocations.
+    // guests it had already deleted permanently, but the invocation must not end cleanly: a run
+    // whose scan throws reaps nothing from that page on, and an errored invocation is what carries
+    // that to the alert topic, through WebGuestReaperLambdaErrorAlarm. Other signals do see the
+    // failure, and none of them replaces the throw. WebGuestReaperSaturatedAlarm fires too,
+    // because the record above carries finished: false, but its alarmDescription reads that state
+    // as web guests being minted faster than the schedule reaps them, which misdiagnoses a scan
+    // that failed; the error alarm is what names it correctly. recordScanFailure's
+    // web_guest_reaper_scan_failed warning is written to this Lambda's own log group before it is
+    // sent to Sentry, and the reaper is created with backendStructuredLoggingProps, so it lands
+    // there as a JSON record addressable at $.message.action - the same handle the saturation
+    // metric filter uses on the completion record. A scan-failure-specific alarm is therefore a
+    // metric filter away and needs no new emission; until some filter selects that action, the
+    // warning reaches no alert topic on its own. The staleness alarm cannot stand in either,
+    // because an errored invocation still counts in Invocations.
     if (result.scanFailed) {
       throw new Error(`Web guest reaper stopped on a failed candidate scan after ${result.pagesScanned} scanned pages, having deleted ${result.deleted} guests and failed on ${result.failed}`);
     }

--- a/apps/backend/src/guestAuth/reaper/index.ts
+++ b/apps/backend/src/guestAuth/reaper/index.ts
@@ -250,11 +250,11 @@ async function loadWebGuestReaperCandidatesInExecutor(
       "COALESCE(latest_event.last_seen_at, guests.latest_session_created_at) AS last_active_at",
       "FROM stale_web_guests AS guests",
       // One indexed lookup per candidate through idx_product_events_user_id (migration 0115), so
-      // the event table is never scanned. The driving aggregate above has no such support:
-      // auth.guest_sessions carries only (user_id, created_at DESC) and the active-token hash
-      // index (migration 0031), so every run reads the whole session table, bounded only by the
-      // reporting role's 30s statement_timeout. A (platform, created_at) index is what would make
-      // it a range scan.
+      // the event table is never scanned. The driving aggregate above now has
+      // idx_guest_sessions_platform_created (migration 0118) instead of the whole-table read it
+      // used to need - available rather than guaranteed, since the planner still prefers a
+      // sequential scan while the table is small enough for that to be cheaper, and keeps the index
+      // only while created_at below the inactivity threshold stays selective.
       "LEFT JOIN LATERAL (",
       // occurred_at is the skew-corrected client clock and can sit up to 30 days before the server
       // ever saw the batch, so it alone would let a guest look older than it is. ingested_at is the
@@ -701,10 +701,8 @@ export async function reapInactiveWebGuests(
       // Everything earlier pages deleted is already permanent, so a scan that throws must not carry
       // those counts out with it: the run stops here and still reports what it deleted, skipped and
       // failed, with finished left false so WebGuestReaperSaturatedAlarm sees the candidates left
-      // behind. The invocation still has to fail - WebGuestReaperLambdaErrorAlarm is the stated
-      // reason the (platform, created_at) index is safe to defer, and an unindexed scan outgrowing
-      // the reporting role's 30s statement_timeout has to surface as an errored invocation - so the
-      // entrypoint throws on scanFailed after emitting the completion record.
+      // behind. The invocation still has to fail, so the entrypoint throws on scanFailed after
+      // emitting the completion record.
       recordScanFailure(result.pagesScanned, observationScope, error);
       return { ...result, scanFailed: true };
     }

--- a/db/migrations/0118_guest_sessions_platform_created_at_index.sql
+++ b/db/migrations/0118_guest_sessions_platform_created_at_index.sql
@@ -1,0 +1,41 @@
+-- Migration status: Current / additive.
+-- Introduces: idx_guest_sessions_platform_created, the index the web guest reaper's driving
+--   aggregate reads. That aggregate selects auth.guest_sessions by platform = 'web' and created_at
+--   below the inactivity threshold, and 0031 left the table with only (user_id, created_at DESC)
+--   and the active-token hash index, so every daily run read the whole table. The reaper scans as
+--   reporting_readonly, whose 30s statement_timeout (migration 0044) is the only bound on that
+--   scan, and 57014 is not in the reaper's transient set: an unindexed scan that outgrows the
+--   timeout does not degrade, it fails the job on that day and on every day after it.
+-- Schemas touched/read explicitly: auth.
+
+-- Full rather than partial on platform = 'web', even though only web guests are ever reaped. Not
+-- because of the reaper query's other reading of platform: that one, IS DISTINCT FROM 'web' in the
+-- NOT EXISTS subquery, is correlated on user_id and is served by idx_guest_sessions_user_created
+-- (0031) whichever shape this index takes, so a web-only partial index would cost it nothing. What
+-- decides it is that the partial index has nothing to offer in exchange: its only advantage is
+-- size, and on a table this small that buys nothing, while the full index covers every value of
+-- platform - ios, android and the NULL pre-1.7.0 mobile clients still write - for anything that
+-- later selects on the column without already being keyed by user_id.
+--
+-- A third key column was considered and rejected. (platform, created_at, user_id) would carry
+-- user_id too, so the driving aggregate could satisfy its GROUP BY from the index alone and run
+-- index-only, instead of fetching user_id from the heap for every matched row. That is a constant
+-- factor on a job that runs once a day; what this migration exists to remove is the full table
+-- scan, and two columns remove it, while a wider key is paid on every write to the table. The
+-- trade is worth reopening only if the reaper's scan ever comes close to its timeout on the range
+-- scan itself.
+--
+-- Plain CREATE INDEX rather than CREATE INDEX CONCURRENTLY, which is not an option here:
+-- apps/backend/src/database/migrationRunner.ts runs each migration file inside its own
+-- BEGIN/COMMIT so a file that fails rolls back whole, and CONCURRENTLY cannot run in a transaction.
+-- The build therefore holds a SHARE lock that blocks every write to auth.guest_sessions until it
+-- finishes, and that is more paths than guest session creation: sessions are also updated and
+-- deleted from several places in guestAuth, and rows go away indirectly whenever an
+-- org.user_settings row is deleted, through the ON DELETE CASCADE 0031 put on user_id. Those paths
+-- are deliberately not listed here. The list is not what makes the block acceptable, and a list is
+-- the part of this comment that would rot as writers are added. What makes it acceptable is how
+-- long the lock is held: the table holds a negligible number of rows at this product stage, so the
+-- build is over in milliseconds and any blocked writer waits only that long. Reusing this
+-- reasoning on a bigger table means re-checking the row count, not assembling the writer list.
+CREATE INDEX IF NOT EXISTS idx_guest_sessions_platform_created
+  ON auth.guest_sessions (platform, created_at);

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0117_guest_session_creation_idempotency.sql",
+    "0118_guest_sessions_platform_created_at_index.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0117_guest_session_creation_idempotency.sql"
+    && resource.Properties?.RequiredMigration === "0118_guest_sessions_platform_created_at_index.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -585,14 +585,15 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
   }), alertTopic);
 
   // The reaper permanently deletes org.user_settings and org.workspaces rows once a day, so a run
-  // that throws every night has to reach the alert topic rather than only Sentry. This alarm is
-  // also what makes the deferred auth.guest_sessions (platform, created_at) index safe to defer: if
-  // the unindexed candidate scan ever grows past the reporting role's 30s statement_timeout, the
-  // query errors, the entrypoint rethrows, and the reaper stops deleting anything until the index
-  // lands. That is an errored invocation, which is exactly what this alarm sees, and it is why the
-  // error alarm must stay in place while the index is deferred. The staleness alarm below cannot
-  // stand in for it: Lambda counts an errored invocation in Invocations like any other, so the run
-  // count stays at one per day and a job that fails every night never looks stale.
+  // that throws every night has to reach the alert topic rather than only Sentry. A candidate scan
+  // that errors, on the reporting role's 30s statement_timeout or on anything else, ends that run
+  // where it stopped and does the same every night for as long as the cause persists, and the
+  // entrypoint rethrows so it surfaces here as an errored invocation. WebGuestReaperSaturatedAlarm
+  // below fires on such a run too, because it completes with finished: false, but it describes
+  // guests being minted faster than the schedule reaps them, which a failed scan is not; this alarm
+  // is the one that names it. The staleness alarm below cannot stand in for it either: Lambda
+  // counts an errored invocation in Invocations like any other, so the run count stays at one per
+  // day and a job that fails every night never looks stale.
   notifyAlertTopic(new cloudwatch.Alarm(scope, "WebGuestReaperLambdaErrorAlarm", {
     metric: props.webGuestReaperFn.metricErrors({
       period: cdk.Duration.minutes(15),
@@ -628,9 +629,8 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
   // batchSize or maxPages only helps a run that still stops on its page limit; once a real backlog
   // exists the run is deadline-bound instead, because 500 x 5 per-guest transactions of about six
   // round trips each do not fit the reaper Lambda's five-minute timeout, and raising either knob
-  // then changes nothing. The other two levers are that Lambda's timeout and memorySize in
-  // lib/scheduled-jobs/web-guest-reaper.ts, and the deferred auth.guest_sessions
-  // (platform, created_at) index.
+  // then changes nothing. The remaining levers are that Lambda's timeout and memorySize in
+  // lib/scheduled-jobs/web-guest-reaper.ts.
   const webGuestReaperSaturationMetricFilter = new logs.MetricFilter(
     scope,
     "WebGuestReaperSaturationMetricFilter",

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -98,7 +98,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
   for (const { relativePath, requiredMigration } of [
     {
       relativePath: "../../.github/workflows/aws-web-release.yml",
-      requiredMigration: "0117_guest_session_creation_idempotency.sql",
+      requiredMigration: "0118_guest_sessions_platform_created_at_index.sql",
     },
     {
       relativePath: "../../scripts/deploy/bootstrap.sh",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -208,7 +208,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0117_guest_session_creation_idempotency.sql",
+    "--require-migration 0118_guest_sessions_platform_created_at_index.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -238,7 +238,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0117_guest_session_creation_idempotency\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0118_guest_sessions_platform_created_at_index\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -360,7 +360,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0117_guest_session_creation_idempotency.sql",
+      "0118_guest_sessions_platform_created_at_index.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,


### PR DESCRIPTION
The web-guest reaper's candidate scan aggregates `auth.guest_sessions` by user under `platform = 'web' AND created_at < threshold`. The table carried `(user_id, created_at DESC)` and an active-token hash index, neither of which serves that. Every nightly run therefore read the whole table, bounded only by the reporting role's 30s `statement_timeout`.

That is a one-way failure. `57014` is not in the reaper's transient set and is not retried, so the first run that outgrows the timeout fails — and so does every run after it, forever. `WebGuestReaperLambdaErrorAlarm` was the stated and only reason deferring this index was safe.

**Two columns, not three.** `(platform, created_at, user_id)` would let the aggregate run index-only and skip a heap fetch per matched row, but that is a constant factor on a once-a-day job, paid on every write; what this migration removes is the full table scan, and two columns remove it. The migration records that trade and the condition for reopening it, because a migration cannot be amended later.

**Not partial on `web`.** The same query reads the column as `platform IS DISTINCT FROM 'web'` in its `NOT EXISTS`, which matches the `ios`, `android` and `NULL` rows a web-only index would omit. That subquery is correlated on `user_id` and served by the `0031` index either way, so the real reason to keep the index full is that narrowing it buys nothing on a table this size.

**Locking.** `CREATE INDEX CONCURRENTLY` is unavailable: both executors wrap each migration file in a single transaction. The plain build takes a lock that blocks writes to the table. That is acceptable because the table is effectively empty — established read-only, 3 `POST /guest-auth/*` requests across the entire access-log history — so the build is over in milliseconds. The migration says that the duration is the leg the conclusion rests on, and warns that reusing the reasoning on a larger table means re-checking the duration.

Comments in four files described the index as deferred and named the alarm that made its absence safe. They now describe what is true, including which signals actually see a failed scan and which of them can name it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)