### PR TITLE
Stop reporting sign-in cancellations nobody made

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/CloudCredentialRecoveryGateView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/CloudCredentialRecoveryGateView.swift
@@ -92,10 +92,10 @@ struct CloudCredentialRecoveryGateView: View {
             .navigationTitle(self.presentation.title)
             .navigationBarTitleDisplayMode(.inline)
         }
-        .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .credentialRecoveryGate)
-                .environment(self.store)
-        }
+        .cloudSignInSheet(
+            isPresented: self.$isCloudSignInPresented,
+            presentationContext: .credentialRecoveryGate
+        )
         .alert(
             aiSettingsLocalized(
                 "settings.sync.recoveryGate.eraseAlert.title",

--- a/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
@@ -452,16 +452,16 @@ struct RootTabView: View {
 
     private var tabRootSheets: some View {
         self.tabRootChangeHandlers
-        .sheet(isPresented: self.$isGuestSignInCloudSignInPresented) {
-            // The origin is the surface that owns the control the person tapped, not the tab the
-            // alert happens to float over. This prompt belongs to the review flow, so it stays
-            // Review: it is a distinct entry point with its own conversion, and following the
-            // visible tab would scatter its failures across the other tabs' own sign-in buttons and
-            // make all of them unreadable. The prompt's accept and snooze buttons already report
-            // `onboarding_step_completed(step: .signin)` on Review for the very same tap.
-            CloudSignInSheet(presentationContext: .standard(originSurface: .review))
-                .environment(store)
-        }
+        // The origin is the surface that owns the control the person tapped, not the tab the alert
+        // happens to float over. This prompt belongs to the review flow, so it stays Review: it is a
+        // distinct entry point with its own conversion, and following the visible tab would scatter
+        // its failures across the other tabs' own sign-in buttons and make all of them unreadable.
+        // The prompt's accept and snooze buttons already report
+        // `onboarding_step_completed(step: .signin)` on Review for the very same tap.
+        .cloudSignInSheet(
+            isPresented: self.$isGuestSignInCloudSignInPresented,
+            presentationContext: .standard(originSurface: .review)
+        )
         .sheet(item: self.feedbackPresentation) { presentation in
             FeedbackSheet(presentation: presentation)
                 .environment(store)

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -87,10 +87,10 @@ struct ProgressScreen: View {
                 await self.handleProgressPresentationRequest(proxy: proxy)
             }
         }
-        .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard(originSurface: .progress))
-                .environment(self.store)
-        }
+        .cloudSignInSheet(
+            isPresented: self.$isCloudSignInPresented,
+            presentationContext: .standard(originSurface: .progress)
+        )
         .sheet(isPresented: self.$isFriendInvitePresented) {
             ProgressFriendInviteSheet()
                 .environment(self.store)

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
@@ -134,10 +134,10 @@ struct AccountStatusView: View {
         .listStyle(.insetGrouped)
         .accessibilityIdentifier(UITestIdentifier.accountStatusScreen)
         .navigationTitle(aiSettingsLocalized("settings.account.status.title", "Account Status"))
-        .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard(originSurface: .settings))
-                .environment(store)
-        }
+        .cloudSignInSheet(
+            isPresented: self.$isCloudSignInPresented,
+            presentationContext: .standard(originSurface: .settings)
+        )
         .alert(aiSettingsLocalized("settings.account.status.logoutAlertTitle", "Log out and clear this device?"), isPresented: self.$isLogoutConfirmationPresented) {
             Button(aiSettingsLocalized("common.cancel", "Cancel"), role: .cancel) {}
             Button(aiSettingsLocalized("settings.account.status.logOut", "Log out"), role: .destructive) {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -24,8 +24,7 @@ struct CloudSignInSheet: View {
     @State private var technicalErrorPresentation: TechnicalErrorPresentation?
     @State private var isSendingCode: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
-    @State private var hasRecordedActivePresentation: Bool = false
-    @State private var wasCredentialRecoveryGateActiveAtPresentation: Bool = false
+    @State private var hasRecordedSurfacePresence: Bool = false
     @State private var postAuthLoadingTask: CloudSignInPostAuthTaskHandle?
     @State private var postAuthGuestLocalRecoveryPreparationTask: CloudSignInPostAuthTaskHandle?
     @State private var postAuthSyncTask: CloudSignInPostAuthTaskHandle?
@@ -191,12 +190,12 @@ struct CloudSignInSheet: View {
                 )
             }
             .onAppear {
-                self.recordActivePresentationIfNeeded()
+                self.recordSurfacePresenceIfNeeded()
                 self.scheduleEmailFieldFocus()
             }
             .onDisappear {
                 self.cancelPostAuthTasksAndClearInFlightState()
-                self.clearActivePresentationIfNeeded()
+                self.clearSurfacePresenceIfNeeded()
             }
         }
         .accessibilityIdentifier(UITestIdentifier.cloudSignInScreen)
@@ -284,10 +283,6 @@ struct CloudSignInSheet: View {
         }
     }
 
-    private var isCredentialRecoveryGateActive: Bool {
-        self.store.cloudCredentialRecoveryState != nil
-    }
-
     private var isStandardPresentation: Bool {
         switch self.presentationContext {
         case .standard:
@@ -297,42 +292,22 @@ struct CloudSignInSheet: View {
         }
     }
 
-    private func recordActivePresentationIfNeeded() {
-        guard self.hasRecordedActivePresentation == false else {
+    private func recordSurfacePresenceIfNeeded() {
+        guard self.hasRecordedSurfacePresence == false else {
             return
         }
 
-        self.hasRecordedActivePresentation = true
-        self.wasCredentialRecoveryGateActiveAtPresentation = self.isCredentialRecoveryGateActive
-        self.store.beginCloudSignInSheetPresentation(
-            originSurface: self.presentationContext.originSurface
-        )
+        self.hasRecordedSurfacePresence = true
+        self.store.beginCloudSignInSurfacePresence()
     }
 
-    /**
-     * The sheet is gone. This is the one place that sees every way it can go: the Close button, the
-     * interactive swipe, and the programmatic dismissals that follow success, logout or a post-auth
-     * failure. Backgrounding the app does not reach it, so an attempt still open here was abandoned
-     * by the person — with one exception.
-     *
-     * The exception is the credential-recovery gate. `RootTabView.body` swaps its whole tab root for
-     * `CloudCredentialRecoveryGateView` the moment `cloudCredentialRecoveryState` becomes non-nil,
-     * and swaps it back when the state clears; either swap tears down whichever sheet the other
-     * branch was presenting, and a background poll can flip that state while the person is typing.
-     * That is the system taking the surface away, not a person closing it, so the gate's activation
-     * is latched at presentation time and a mismatch here reports nothing. Android's gate sits above
-     * its navigation host and reports nothing for the same swap, so the two clients agree.
-     */
-    private func clearActivePresentationIfNeeded() {
-        guard self.hasRecordedActivePresentation else {
+    private func clearSurfacePresenceIfNeeded() {
+        guard self.hasRecordedSurfacePresence else {
             return
         }
 
-        self.hasRecordedActivePresentation = false
-        if self.isCredentialRecoveryGateActive == self.wasCredentialRecoveryGateActiveAtPresentation {
-            self.store.reportCloudSignInAbandonment()
-        }
-        self.store.endCloudSignInSheetPresentation()
+        self.hasRecordedSurfacePresence = false
+        self.store.endCloudSignInSurfacePresence()
     }
 
     private func sendCode() {
@@ -690,6 +665,93 @@ struct CloudSignInSheet: View {
         self.postAuthRecoveryNeededState = nil
         self.otpSheetState = nil
         self.dismiss()
+    }
+}
+
+/**
+ * The one place that decides a person closed the sign-in sheet.
+ *
+ * `onDismiss` fires when the presentation itself goes away. The sheet's own `onAppear`/`onDisappear`
+ * do not mean that: SwiftUI rebuilds the sheet's content while the sheet stays on screen — switching
+ * tabs under the Settings presenter is enough — and reading a dismissal from that reports an
+ * abandoned sign-in for a sheet the person is still typing in.
+ *
+ * Every presentation this modifier makes opens exactly one attempt, and it opens it before the sheet
+ * can be closed. That needs both halves of `onChange(initial:)`, because a presentation does not
+ * always start from a false→true edge this modifier can see. `RootTabView` keeps
+ * `isGuestSignInCloudSignInPresented` in `@State` on itself while the `.cloudSignInSheet` that reads
+ * it lives in the `else` branch of its body, so a credential-recovery gate that opens and closes
+ * under a presented sheet destroys this modifier with the binding still `true` and installs a fresh
+ * one that presents immediately. `initial: true` arms that presentation; without it the sheet is on
+ * screen owing an event nobody opened, and the person's Close reports the previous presenter's
+ * `screen` or nothing at all.
+ *
+ * `hasOpenedAttemptForCurrentPresentation` is what keeps that safe. `beginCloudSignInAttempt` starts
+ * a *new* attempt — it re-reads the credential-recovery gate into the latch that decides whether a
+ * later dismissal is the person or the system — so running it twice inside one presentation would
+ * re-latch the gate mid-attempt and turn a system-caused teardown back into a reported cancellation.
+ * The flag makes "one begin per presentation" a property of this modifier rather than of SwiftUI's
+ * delivery order: it is `@State`, so a modifier that is destroyed and reinstalled starts clear and
+ * arms its new presentation, while one that merely re-evaluates does not re-arm the presentation it
+ * already owns.
+ */
+struct CloudSignInSheetModifier: ViewModifier {
+    @Environment(FlashcardsStore.self) private var store: FlashcardsStore
+
+    @Binding private var isPresented: Bool
+    @State private var hasOpenedAttemptForCurrentPresentation: Bool = false
+    private let presentationContext: CloudSignInPresentationContext
+
+    init(isPresented: Binding<Bool>, presentationContext: CloudSignInPresentationContext) {
+        self._isPresented = isPresented
+        self.presentationContext = presentationContext
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: self.isPresented, initial: true) { _, isNowPresented in
+                self.openAttemptForPresentationIfNeeded(isNowPresented: isNowPresented)
+            }
+            .sheet(
+                isPresented: self.$isPresented,
+                onDismiss: {
+                    self.hasOpenedAttemptForCurrentPresentation = false
+                    self.store.endCloudSignInAttempt()
+                },
+                content: {
+                    CloudSignInSheet(presentationContext: self.presentationContext)
+                        .environment(self.store)
+                }
+            )
+    }
+
+    private func openAttemptForPresentationIfNeeded(isNowPresented: Bool) {
+        guard isNowPresented else {
+            self.hasOpenedAttemptForCurrentPresentation = false
+            return
+        }
+        guard self.hasOpenedAttemptForCurrentPresentation == false else {
+            return
+        }
+
+        self.hasOpenedAttemptForCurrentPresentation = true
+        self.store.beginCloudSignInAttempt(
+            originSurface: self.presentationContext.originSurface
+        )
+    }
+}
+
+extension View {
+    func cloudSignInSheet(
+        isPresented: Binding<Bool>,
+        presentationContext: CloudSignInPresentationContext
+    ) -> some View {
+        self.modifier(
+            CloudSignInSheetModifier(
+                isPresented: isPresented,
+                presentationContext: presentationContext
+            )
+        )
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
@@ -22,24 +22,70 @@ struct CloudOtpSheetState: Identifiable, Hashable {
 
 @MainActor
 extension FlashcardsStore {
-    func beginCloudSignInSheetPresentation(originSurface: AnalyticsSurface?) {
+    /**
+     * A sign-in attempt begins when a presenter asks for the sheet, not when the sheet's content
+     * appears. SwiftUI tears that content down and rebuilds it while the presentation stays on
+     * screen — a tab switch under the Settings presenter is enough — so an attempt anchored to the
+     * content would re-open on every rebuild and owe a `signin_failed` for each one.
+     *
+     * This starts an attempt from scratch: it writes all three fields the attempt is made of, so a
+     * presentation that ended without a dismissal — the credential-recovery gate swapping the tab
+     * root out from under a presented sheet is the one way that happens — cannot leave an origin
+     * surface or a gate latch behind for the next presentation to be judged on. Because it re-reads
+     * the gate into the latch, the caller owes exactly one call per presentation:
+     * `CloudSignInSheetModifier` is the only caller and holds that guarantee.
+     */
+    func beginCloudSignInAttempt(originSurface: AnalyticsSurface?) {
+        self.isCloudSignInAttemptOpen = true
+        self.cloudSignInOriginSurface = originSurface
+        self.wasCredentialRecoveryGateActiveAtSignInStart = self.isCloudCredentialRecoveryGateActive
+    }
+
+    /**
+     * The sheet was dismissed. This is the one place that sees every way it can go: the Close
+     * button, the interactive swipe, and the programmatic dismissals that follow success, logout or
+     * a post-auth failure. Backgrounding the app does not reach it, so an attempt still open here
+     * was abandoned by the person — with one exception. A dismissal that follows success or a
+     * reported failure finds the attempt settled and reports nothing.
+     *
+     * The exception is the credential-recovery gate. `RootTabView.body` swaps its whole tab root for
+     * `CloudCredentialRecoveryGateView` the moment `cloudCredentialRecoveryState` becomes non-nil,
+     * and swaps it back when the state clears; either swap takes away whichever sheet the other
+     * branch was presenting, and a background poll can flip that state while the person is typing.
+     * That is the system taking the surface away, not a person closing it, so the gate's activation
+     * is latched when the attempt begins and a mismatch here reports nothing. Android's gate sits
+     * above its navigation host and reports nothing for the same swap, so the two clients agree.
+     */
+    func endCloudSignInAttempt() {
+        if self.isCloudSignInAttemptOpen,
+           self.isCloudCredentialRecoveryGateActive == self.wasCredentialRecoveryGateActiveAtSignInStart {
+            self.trackCloudSignInFailed(reason: .cancelled)
+        }
+
+        self.isCloudSignInAttemptOpen = false
+        self.cloudSignInOriginSurface = nil
+        self.wasCredentialRecoveryGateActiveAtSignInStart = false
+    }
+
+    /**
+     * The sheet's content is on screen. SwiftUI can take that content away and bring it back within
+     * one presentation, so this tracks the surface and says nothing about the attempt.
+     */
+    func beginCloudSignInSurfacePresence() {
         assert(
             self.activeCloudSignInSheetCount == 0,
             "A second cloud sign-in sheet was presented while one was already on screen."
         )
         self.activeCloudSignInSheetCount += 1
-        self.isCloudSignInAttemptOpen = true
-        self.cloudSignInOriginSurface = originSurface
     }
 
-    func endCloudSignInSheetPresentation() {
+    func endCloudSignInSurfacePresence() {
         guard self.activeCloudSignInSheetCount > 0 else {
-            assertionFailure("Cloud sign-in sheet presentation ended without a matching begin.")
+            assertionFailure("Cloud sign-in surface presence ended without a matching begin.")
             return
         }
 
         self.activeCloudSignInSheetCount -= 1
-        self.cloudSignInOriginSurface = nil
     }
 
     /**
@@ -49,7 +95,7 @@ extension FlashcardsStore {
      * otherwise a counter: the credential-recovery gate and the tab root are the two mutually
      * exclusive branches of `RootTabView.body`, the guest-sign-in prompt is blocked outright while
      * this count is non-zero, and a presented sheet covers the tab bar, so no second presenter can
-     * be reached. `beginCloudSignInSheetPresentation` asserts on the overlap rather than leaving
+     * be reached. `beginCloudSignInSurfacePresence` asserts on the overlap rather than leaving
      * that as an assumption.
      */
     var isCloudSignInSurfacePresented: Bool {
@@ -79,17 +125,8 @@ extension FlashcardsStore {
         self.isCloudSignInAttemptOpen = false
     }
 
-    /**
-     * The person closed the sign-in sheet on an attempt that had neither failed nor been verified.
-     * A programmatic dismissal after success or after a reported failure finds the attempt settled
-     * and reports nothing.
-     */
-    func reportCloudSignInAbandonment() {
-        guard self.isCloudSignInAttemptOpen else {
-            return
-        }
-
-        self.trackCloudSignInFailed(reason: .cancelled)
+    private var isCloudCredentialRecoveryGateActive: Bool {
+        self.cloudCredentialRecoveryState != nil
     }
 
     private func trackCloudSignInFailed(reason: AnalyticsSignInFailureReason) {

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -344,10 +344,10 @@ struct SettingsView: View {
         .onAppear {
             store.triggerCloudAccountContextRefreshIfActive(surfacesGlobalErrorMessage: false)
         }
-        .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard(originSurface: .settings))
-                .environment(self.store)
-        }
+        .cloudSignInSheet(
+            isPresented: self.$isCloudSignInPresented,
+            presentationContext: .standard(originSurface: .settings)
+        )
         .sheet(isPresented: self.$isFriendInvitePresented) {
             ProgressFriendInviteSheet()
                 .environment(self.store)

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -131,9 +131,13 @@ final class FlashcardsStore {
     /// Whether the presented sign-in sheet still owes one `signin_failed`.
     @ObservationIgnored var isCloudSignInAttemptOpen: Bool
     /// The surface the presented sign-in sheet was opened from, and the `screen` its `signin_failed`
-    /// carries. Latched at presentation because the OTP step and the abandonment report both emit
-    /// from places that no longer know the presenter.
+    /// carries. Latched when the attempt begins because the OTP step and the abandonment report both
+    /// emit from places that no longer know the presenter.
     @ObservationIgnored var cloudSignInOriginSurface: AnalyticsSurface?
+    /// Whether the credential-recovery gate was already up when the sign-in attempt began. A gate
+    /// that flips while the sheet is on screen takes the surface away instead of the person closing
+    /// it, and the abandonment report is suppressed on that mismatch.
+    @ObservationIgnored var wasCredentialRecoveryGateActiveAtSignInStart: Bool
     /// Whether a background analytics guest identity claim is already in flight. Sign-in and startup
     /// both start one, and two claims racing would send the same guest token twice.
     @ObservationIgnored var isAnalyticsGuestIdentityLinkResumeRunning: Bool
@@ -483,6 +487,7 @@ final class FlashcardsStore {
         self.isGuestUpgradeLocalOutboxMutationBlocked = false
         self.isCloudSignInAttemptOpen = false
         self.cloudSignInOriginSurface = nil
+        self.wasCredentialRecoveryGateActiveAtSignInStart = false
         self.isAnalyticsGuestIdentityLinkResumeRunning = false
         self.reportedAnalyticsGuestCredentialFailureStages = []
         self.currentVisibleTab = .review


### PR DESCRIPTION
Tapping a review reminder while signing in from Settings emitted **two** `signin_failed(cancelled)` events. The sheet stayed visually on screen the whole time and the person kept typing in it.

Reproduced twice, deterministically, on a simulator against `main`, and corroborated by the app's own durable analytics queue — two rows at the Settings switch, none at the two presenters that turned out to be unaffected. Manual Close always produced exactly one event, so the absence elsewhere was real rather than broken instrumentation.

**Cause.** SwiftUI tore down and rebuilt the sheet's *content* twice without dismissing the *presentation*. Everything deciding "the person closed this" hung off the content's `onAppear`/`onDisappear`: the attempt flag, the origin surface, and the credential-recovery latch meant to suppress exactly this class of teardown. The latch could not help — the same rebuild reset it. Because `begin` re-armed the attempt, the rebuild produced two events rather than one.

**Fix.** The attempt now follows the presentation: armed when the binding becomes true, settled in `onDismiss`, with the gate latch on the store where a rebuild cannot reach it. Arming is guaranteed once per presentation by the modifier itself rather than by SwiftUI's delivery semantics, so a presentation that begins already-presented is still armed and cannot inherit the previous one's surface or latch.

**The counter deliberately stays on the content lifecycle.** `onDismiss` is not reliably delivered when the *presenter* is torn down — a real case here, since the credential-recovery gate swaps the tab root. A counter stranded at one would block the guest and feedback prompts forever and trip the assertion on the next presentation. The guaranteed-balanced signal keeps the counter; the semantically correct signal keeps the attempt.

The five presenters now share one `cloudSignInSheet` modifier, so a sixth gets the contract by construction.

A person-initiated close still emits exactly one `signin_failed(cancelled)`, carrying its origin surface. Compiled locally before merge (`xcodebuild build`, exit 0), since PR checks do not build Swift.

Known and left for a simulator: whether the gate-mismatch suppression is now dead in practice, and the `onDismiss` delivery-ordering case — a guard there was considered and rejected, because it depends on an unverified ordering and getting it backwards would suppress every real close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)