### PR TITLE
Let agents run Gradle and the iOS simulator when it helps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ When proposing a test plan, treat "real testing" as one of these two options onl
 
 For iOS local testing details, see [docs/ios-local-setup.md](docs/ios-local-setup.md).
 For Android local testing details, see [docs/android-ci-cd.md](docs/android-ci-cd.md).
-Running `./gradlew` is resource-heavy in this repository. Do not run `./gradlew` locally unless the user explicitly allows that Gradle run for the current task. This applies even when a Gradle run seems necessary to validate a change: ask the user for permission first when validation genuinely requires it, wait for approval, and otherwise report that the Gradle check was not run. When allowed, choose the narrowest Gradle task that validates the change, and avoid broad Gradle runs without a clear reason.
-Running iOS simulator-backed tests or local smoke flows is resource-heavy in this repository. Do not run iOS simulator `xcodebuild test`, XCUITest, screenshot-generation, or local smoke flows unless the user explicitly allows that simulator-backed run for the current task. When allowed, choose the narrowest iOS simulator run that validates the change, and avoid broad iOS test runs without a clear reason.
+Running `./gradlew` is resource-heavy in this repository, so do not run it reflexively after every edit. When a Gradle run genuinely helps validate a change, run it: choose the narrowest Gradle task that validates the change, and avoid broad Gradle runs without a clear reason.
+Running iOS simulator-backed tests or local smoke flows is resource-heavy in this repository, so do not run `xcodebuild test`, XCUITest, screenshot-generation, or local smoke flows reflexively after every edit. When a simulator-backed run genuinely helps validate a change, run it: choose the narrowest iOS simulator run that validates the change, and avoid broad iOS test runs without a clear reason.
 For the optional private analytical DB access path, granted reporting permissions, and operator setup flow, see [docs/analytics-db-access.md](docs/analytics-db-access.md).
 
 ## Release Gates and Monitoring

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -73,23 +73,23 @@ Only test the app against the final supported iOS target.
 - Do not try to cover the iOS app exhaustively with tests
 - Do not add isolated unit tests by default
 - Prefer native integration, parity, or UI tests when they validate a real module boundary or user flow
-- Do not run iOS simulator-backed tests, UI tests, screenshot-generation, or local smoke flows unless the user explicitly allows that simulator-backed run for the current task
+- Do not run iOS simulator-backed tests, UI tests, screenshot-generation, or local smoke flows reflexively after every edit; run them when they genuinely help validate a change
 - Do not spend time validating older iOS versions
 - Do not add compatibility code for older iOS versions unless explicitly requested
-- If an iOS simulator-backed run is explicitly allowed, use one locally available iPhone simulator runtime only
+- Use one locally available iPhone simulator runtime only
 - Prefer an already booted local iPhone simulator on the final supported runtime
 - Prefer background CLI runs with `simctl` and `xcodebuild` instead of opening heavy Xcode UI flows
 - Do not open a visible Simulator window for test runs unless the user explicitly asks for a visible simulator at that time
 - Prefer `xcodebuild ... test` so each run validates the current sources and build settings on the selected simulator
 - Pass `-derivedDataPath "tmp/ios-derived-data"` for local CLI builds and tests so repeated runs reuse repo-local build artifacts instead of creating new global DerivedData directories
 - If a test fails, inspect the generated `.xcresult` bundle and read the relevant screenshots, attachments, and logs before changing code
-- If no suitable local runtime is already installed, stop and ask the user how to proceed instead of downloading extra simulator runtimes
+- If no suitable local runtime is already installed, tell the user before downloading an extra simulator runtime
 
 The most trusted iOS checks are the simulator-backed native smoke flows because they exercise the real app closest to production behavior.
 
 ## Local Test Workflow
 
-When the user has explicitly allowed a local iOS simulator-backed test run for the current task, prefer this sequence:
+For a local iOS simulator-backed test run, prefer this sequence:
 
 1. Reuse an already booted iPhone simulator when available.
 2. Wait for that simulator with `xcrun simctl bootstatus <device-uuid> -b`.

--- a/apps/ios/docs/marketing-screenshots.md
+++ b/apps/ios/docs/marketing-screenshots.md
@@ -11,7 +11,7 @@ The generator is a small manual pipeline built from:
 - deterministic localized fixture data used by both the UI tests and app-side UI-test seeding
 
 It writes into the directories used for committed App Store marketing PNG assets and derived marketing compositions, but it is not part of CI or release-gate validation.
-Because this generator drives local iOS simulator-backed XCUITest flows, do not run screenshot-generation scripts unless the user explicitly allows that simulator-backed run for the current task.
+Because this generator drives local iOS simulator-backed XCUITest flows, it is slow, so run the screenshot-generation scripts only when screenshots are actually being regenerated.
 The generator configuration now targets five-shot outputs. Existing repository media can still contain the previous four-shot assets until the screenshot flows and derived-material builder are run and the generated PNGs are reviewed.
 
 ## What is included

--- a/docs/ios-local-setup.md
+++ b/docs/ios-local-setup.md
@@ -171,18 +171,17 @@ distribution.
 ## Local Testing Rules
 
 The iOS Xcode project is file-synchronized, so new Swift files can be added without manual `project.pbxproj` edits.
-Running iOS simulator-backed tests and local smoke flows is resource-heavy in this repository.
-Do not run iOS simulator `xcodebuild test`, XCUITest, screenshot-generation, or local smoke flows unless the user explicitly allows that simulator-backed run for the current task.
-When allowed, choose the narrowest iOS simulator run that validates the change, and avoid broad iOS test runs without a clear reason.
+Running iOS simulator-backed tests and local smoke flows is resource-heavy in this repository, so do not run `xcodebuild test`, XCUITest, screenshot-generation, or local smoke flows reflexively after every edit.
+When a simulator-backed run genuinely helps validate a change, run it: choose the narrowest iOS simulator run that validates the change, and avoid broad iOS test runs without a clear reason.
 iOS full test runs can take a bit more than 2 minutes locally, and that is normal.
-If an iOS simulator-backed run is explicitly allowed, run it only on one specific iPhone simulator runtime that is already downloaded locally.
+Run on one specific iPhone simulator runtime that is already downloaded locally.
 Prefer an already booted local iPhone simulator on the final supported iOS runtime. Reuse that exact device instead of booting a different one when possible.
 Prefer the background CLI flow over opening heavy Xcode UI: `xcrun simctl bootstatus`, then `xcodebuild test`.
 Do not open a visible iOS Simulator window for test runs unless the user explicitly asks for a visible simulator at that time.
 Pass `-derivedDataPath "tmp/ios-derived-data"` for local CLI builds and tests so repeated runs reuse repo-local build artifacts instead of creating new global DerivedData directories.
 If an iOS test fails, inspect the generated `.xcresult` bundle and read the relevant screenshots, attachments, and logs before changing code.
 If a suitable simulator is already warmed, keep using it and avoid rebuilding unnecessarily.
-If no suitable local iPhone simulator runtime is already available, do not trigger extra runtime downloads or installations. Stop and ask the user how to proceed.
+If no suitable local iPhone simulator runtime is already available, downloading one is slow and large, so tell the user before starting that download.
 For iOS, `My Mac` can be used only for iOS compile smoke-checks such as `build` or `build-for-testing`, not as a reliable destination for app-hosted unit tests.
 Preferred local CLI examples:
 


### PR DESCRIPTION
The local-run rules in this repo had hardened into permission gates: `./gradlew` and every iOS simulator-backed run were forbidden until the user explicitly allowed that exact run for that exact task. The intent was only to keep expensive runs off every code edit, not to block validation, so the wording now says that directly.

## Changed

- `AGENTS.md` — Gradle and iOS simulator paragraphs: "do not run reflexively after every edit" + "when a run genuinely helps validate a change, run it", keeping the narrowest-run guidance
- `docs/ios-local-setup.md` — same softening in Local Testing Rules; a missing simulator runtime is now a heads-up before downloading rather than a stop-and-ask
- `apps/ios/README.md` — testing bullets, runtime-selection bullet, and the Local Test Workflow heading no longer hinge on explicit permission
- `apps/ios/docs/marketing-screenshots.md` — screenshot generation is scoped by "only when screenshots are actually being regenerated" instead of a permission gate

## Left alone

- Xcode Cloud / `Android Release` / `MCP Registry Publish` trigger rules
- Local AWS deploys and deployment-artifact builds
- Visible simulator/emulator windows, sequential Android tests, one-clean-emulator rules
- Testing Philosophy rules about *writing* unit tests

Documentation only; no code paths touched.