### PR TITLE
Point at where the analytics ingest contract lives

### DIFF
--- a/docs/auth-service.md
+++ b/docs/auth-service.md
@@ -7,6 +7,13 @@ Email + OTP authentication via AWS Cognito (passwordless).
   guest session is an analytics credential only: the browser requests one lazily on a signed-out
   visitor's first real interaction and sends it as `Authorization: Guest <token>` to
   `POST /v1/analytics/events` alone.
+  - The route's own ingest contract lives in the source:
+    `apps/backend/src/routes/productAnalytics.ts` owns its HTTP surface, accepted transports,
+    and the `accepted`/`rejected` envelope; `apps/backend/src/productAnalytics/validation.ts`
+    owns batch and per-event validation and the rejection reasons;
+    `apps/backend/src/productAnalytics/catalog.ts` owns the frozen event catalog and property
+    specs every client mirrors; `apps/backend/src/productAnalytics/writer.ts` owns the
+    analytics connection pool and its `429 ANALYTICS_WRITER_BUSY`.
   - `apps/backend/src/guestAuth/webPlatform.ts` is the single gate. Every authenticated route builds
     its context through `loadRequestContextFromRequest`, which refuses a `web` guest platform with
     `403 GUEST_WEB_PLATFORM_UNSUPPORTED` unless the route opts in; analytics ingest is the only


### PR DESCRIPTION
`POST /v1/analytics/events` was named exactly once in all of `docs/` — as the address a `web` guest token is sent to, and nothing else. There was no pointer anywhere to where its behaviour is actually defined.

One bullet, four files, a clause each:

- the route file, for the HTTP surface, the accepted transports, and the `accepted`/`rejected` envelope;
- validation, for batch and per-event rules and the rejection reasons;
- the catalog, for the frozen event list and property specs every client mirrors by hand;
- the writer, for the analytics pool and the `429` it raises.

Deliberately **not** added: an error-code table, a request/response example, the batch and size limits, the event-id requirement, or the clock-skew anchor. Each is commented where it is defined; a second copy here would be a second source of truth that quietly drifts. The point of the bullet is to say where to read, not to re-narrate.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)