### PR TITLE
Name the sign-in path prefix for what it is

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/prompts/guestreview/GuestSignInAfterReviewPromptDialogTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/prompts/guestreview/GuestSignInAfterReviewPromptDialogTest.kt
@@ -9,12 +9,15 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
+import com.flashcardsopensourceapp.core.observability.analytics.AnalyticsSurface
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInEmailRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInUiState
@@ -83,12 +86,25 @@ class GuestSignInAfterReviewPromptDialogTest : FirebaseAppInstrumentationTimeout
                         GuestSignInAfterReviewPromptDialog(
                             onSignIn = {
                                 signInCalls += 1
-                                navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                                navController.navigate(
+                                    route = SettingsAccountSignInEmailDestination.createRoute(
+                                        origin = AnalyticsSurface.REVIEW
+                                    )
+                                )
                             },
                             onLater = {}
                         )
                     }
-                    composable(route = SettingsAccountSignInEmailDestination.route) {
+                    composable(
+                        route = SettingsAccountSignInEmailDestination.routePattern,
+                        arguments = listOf(
+                            navArgument(name = SettingsAccountSignInEmailDestination.routeArgument) {
+                                type = NavType.StringType
+                                nullable = true
+                                defaultValue = null
+                            }
+                        )
+                    ) {
                         CloudSignInEmailRoute(
                             uiState = CloudSignInUiState(
                                 email = "",

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -772,7 +772,7 @@ private fun isProgressContextRefreshBroadcastAction(action: String?): Boolean {
 }
 
 private fun isGuestSignInAfterReviewPromptAuthRoute(route: String?): Boolean {
-    return route?.startsWith(prefix = SettingsAccountSignInEmailDestination.route) == true
+    return route?.startsWith(prefix = SettingsAccountSignInEmailDestination.routePrefix) == true
 }
 
 private fun isGuestSignInAfterReviewPromptModalActive(
@@ -786,7 +786,7 @@ private fun isGuestSignInAfterReviewPromptModalActive(
 }
 
 private fun isFeedbackPromptAuthRoute(route: String?): Boolean {
-    return route?.startsWith(prefix = SettingsAccountSignInEmailDestination.route) == true
+    return route?.startsWith(prefix = SettingsAccountSignInEmailDestination.routePrefix) == true
 }
 
 private fun isFeedbackPromptModalActive(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -41,7 +41,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
     ) {
         composable(
             route = SettingsAccountSignInEmailDestination.routePattern,
-            arguments = listOf(navArgument(name = SettingsAccountSignInEmailDestination.originArgument) {
+            arguments = listOf(navArgument(name = SettingsAccountSignInEmailDestination.routeArgument) {
                 type = NavType.StringType
                 nullable = true
                 defaultValue = null
@@ -241,7 +241,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
  */
 private fun signInOriginSurface(authGraphBackStackEntry: NavBackStackEntry): AnalyticsSurface? {
     val originWireValue: String? = authGraphBackStackEntry.arguments
-        ?.getString(SettingsAccountSignInEmailDestination.originArgument)
+        ?.getString(SettingsAccountSignInEmailDestination.routeArgument)
     return AnalyticsSurface.entries.firstOrNull { surface -> surface.wireValue == originWireValue }
 }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
@@ -108,15 +108,19 @@ data object SettingsAccountStatusDestination {
  * surface that owns the tapped control rides along as an optional query argument and ends up on the
  * graph's back stack entry, which is where `signin_failed` reads it from.
  *
- * [route] stays the bare path: it is what the route-prefix checks in `FlashcardsApp` match on.
+ * [routePrefix] is not navigable on its own: navigating it still matches this destination, but the
+ * origin stays unset and `signin_failed` then reports no surface. Navigate with [createRoute]; the
+ * bare prefix is only for the route `startsWith` checks in `FlashcardsApp`, which are meant to
+ * cover the code and post-auth steps nested under this path too, so the after-review and feedback
+ * prompts stay held back for the whole sign-in flow rather than only its first screen.
  */
 data object SettingsAccountSignInEmailDestination {
-    const val route: String = "settings/account/sign-in"
-    const val originArgument: String = "origin"
-    const val routePattern: String = "$route?$originArgument={$originArgument}"
+    const val routePrefix: String = "settings/account/sign-in"
+    const val routeArgument: String = "origin"
+    const val routePattern: String = "$routePrefix?$routeArgument={$routeArgument}"
 
     fun createRoute(origin: AnalyticsSurface): String {
-        return "$route?$originArgument=${origin.wireValue}"
+        return "$routePrefix?$routeArgument=${origin.wireValue}"
     }
 }
 


### PR DESCRIPTION
`SettingsAccountSignInEmailDestination.route` stopped being navigable when the origin surface became a navigation argument — the graph registers `routePattern`, and every production caller goes through `createRoute`. It was still called `route`.

That is a silent trap. Navigating with the bare constant still resolves, because the `origin` argument is nullable with a default and the deep-link path regex terminates before the query string. Nothing crashes and nothing is logged; the only symptom is a `null` in the `screen` column of `signin_failed` — the exact failure the argument was introduced to fix.

- `route` → `routePrefix`, and `originArgument` → `routeArgument`. Not invented: that is what this file already calls these members on its other parameterized destinations, and `routePrefix` is literally what the two `startsWith` checks want.
- Every route string the object produces is byte-identical. Only the identifiers inside the templates changed.
- The KDoc now records **why** the prefix is a prefix: it deliberately spans the code and post-auth steps as well, which is what holds the guest and feedback prompts back across the whole sign-in flow instead of only its first screen. Without that written down, the rename made it easier to "tighten" those checks to an equality and narrow the suppression by accident.
- The androidTest now registers the pattern and navigates through `createRoute`, so the tree no longer contains the one grep-able example of the call this rename exists to make unwriteable.

No behaviour change.

Known and queued, not done here: the sibling `/code` and `/post-auth` destinations hard-code their paths as independent literals rather than deriving from `routePrefix`, so editing the prefix alone would still silently narrow both gates. That is a change to other destination objects and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)