### PR TITLE
Keep a sign-in alive when its sheet is rebuilt

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudCredentialRecovery.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudCredentialRecovery.swift
@@ -39,11 +39,33 @@ extension FlashcardsStore {
         Flashcards.clearCloudCredentialRecoveryState(userDefaults: self.userDefaults)
     }
 
+    /**
+     * The recovery gate's "erase local data and start fresh".
+     *
+     * A sign-in attempt can still be running here. The gate replaces the tab root rather than
+     * dismissing whatever sheet the other branch was presenting, so no `onDismiss` reaches
+     * `endCloudSignInAttempt` and the attempt's post-auth work keeps going with no surface. Ending
+     * the attempt first is what stops it going further: every post-auth step compares its own state
+     * `id` against the attempt after its awaited work, and a fresh `CloudSignInAttemptState` fails
+     * all of them, so no result of a step in flight reaches the attempt and no further post-auth
+     * step is started from one. The person asked to start fresh, and the attempt they lost the
+     * surface of does not get to drive the sign-in on behind that.
+     *
+     * That is narrower than "nothing writes across the reset", and the difference matters if you are
+     * working here. Those comparisons gate the write-back only; they sit after the awaited work and
+     * do not gate its identity side effects. `FlashcardsStore.completeCloudLink` runs its body
+     * through `CloudSessionRuntime.runWorkspaceCompletion`, which awaits an unstructured `Task`, so
+     * cancelling `postAuthSyncTask` cancels the wait and not that task: a `completeCloudLink`
+     * already in flight when this runs still finishes its credential and workspace writes, and this
+     * call does not stop it. That overlap is a known gap left open on purpose — closing it is a
+     * larger change than this one.
+     */
     func eraseLocalDataForCredentialRecovery() throws {
         guard self.cloudCredentialRecoveryState != nil else {
             throw LocalStoreError.validation("Cloud credential recovery is not active.")
         }
 
+        self.endCloudSignInAttempt()
         try self.resetLocalStateForCloudIdentityChange()
     }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
@@ -3,6 +3,10 @@ import SwiftUI
 struct CloudOtpVerificationSheet: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
 
+    /// The attempt this code step belongs to. `otpSheetState` is a binding into the store, so a
+    /// request that outlives this sheet would otherwise write the previous attempt's email and
+    /// challenge into whichever attempt replaced it.
+    let attemptId: String
     @Binding var otpSheetState: CloudOtpSheetState?
     let onVerified: (CloudVerifiedAuthContext) -> Void
     let onReturnToEmail: () -> Void
@@ -23,10 +27,12 @@ struct CloudOtpVerificationSheet: View {
     }
 
     init(
+        attemptId: String,
         otpSheetState: Binding<CloudOtpSheetState?>,
         onVerified: @escaping (CloudVerifiedAuthContext) -> Void,
         onReturnToEmail: @escaping () -> Void
     ) {
+        self.attemptId = attemptId
         self._otpSheetState = otpSheetState
         self.onVerified = onVerified
         self.onReturnToEmail = onReturnToEmail
@@ -201,6 +207,12 @@ struct CloudOtpVerificationSheet: View {
                 self.authErrorPresentation = nil
                 self.onVerified(verifiedContext)
             } catch {
+                // The verify request outlives this sheet, so its failure belongs to the attempt it
+                // was started for and is neither reported nor settled against whichever attempt
+                // replaced that one — the same shape as `resendCode`'s catch.
+                guard self.store.cloudSignInAttempt.id == self.attemptId else {
+                    return
+                }
                 if isRequestCancellationError(error: error) {
                     return
                 }
@@ -234,6 +246,10 @@ struct CloudOtpVerificationSheet: View {
 
                 switch sendCodeResult {
                 case .otpChallenge(let nextChallenge):
+                    guard self.store.cloudSignInAttempt.id == self.attemptId else {
+                        return
+                    }
+
                     self.otpSheetState = self.otpSheetState?.withChallenge(nextChallenge)
                     self.code = ""
                     self.authErrorPresentation = nil
@@ -242,6 +258,12 @@ struct CloudOtpVerificationSheet: View {
                     throw LocalStoreError.validation("Demo review sign-in cannot resend an OTP challenge")
                 }
             } catch {
+                // Nothing below this guard writes into the attempt today, but the request outlives
+                // the sheet, so the guard keeps an abandoned attempt's failure out of whichever
+                // attempt replaced it — the same shape as `CloudSignInSheet.sendCode`'s catch.
+                guard self.store.cloudSignInAttempt.id == self.attemptId else {
+                    return
+                }
                 if isRequestCancellationError(error: error) {
                     return
                 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
-private struct CloudSignInPostAuthTaskHandle {
-    let stateId: String
-    let task: Task<Void, Never>
-}
-
+/**
+ * The sign-in sheet's content, which SwiftUI may destroy and rebuild while the sheet stays on
+ * screen. Everything that describes the attempt lives in `store.cloudSignInAttempt` so that rebuild
+ * is invisible to the person; only what describes this view instance is `@State` here.
+ */
 struct CloudSignInSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
@@ -12,35 +12,24 @@ struct CloudSignInSheet: View {
 
     let presentationContext: CloudSignInPresentationContext
 
-    @State private var email: String = ""
-    @State private var otpSheetState: CloudOtpSheetState?
-    @State private var postAuthLoadingState: CloudPostAuthLoadingState?
-    @State private var postAuthGuestLocalRecoveryPreparationState: CloudPostAuthGuestLocalRecoveryPreparationState?
-    @State private var postAuthSyncState: CloudPostAuthSyncState?
-    @State private var workspaceLinkContext: CloudWorkspaceLinkContext?
-    @State private var postAuthRecoveryNeededState: CloudPostAuthRecoveryNeededState?
-    @State private var postAuthFailureState: CloudPostAuthFailureState?
-    @State private var authErrorPresentation: CloudAuthInlineErrorPresentation?
     @State private var technicalErrorPresentation: TechnicalErrorPresentation?
-    @State private var isSendingCode: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
     @State private var hasRecordedSurfacePresence: Bool = false
-    @State private var postAuthLoadingTask: CloudSignInPostAuthTaskHandle?
-    @State private var postAuthGuestLocalRecoveryPreparationTask: CloudSignInPostAuthTaskHandle?
-    @State private var postAuthSyncTask: CloudSignInPostAuthTaskHandle?
 
     init(presentationContext: CloudSignInPresentationContext) {
         self.presentationContext = presentationContext
     }
 
     var body: some View {
+        @Bindable var store = self.store
+
         NavigationStack {
             ReadableContentLayout(
                 maxWidth: flashcardsReadableFormMaxWidth,
                 horizontalPadding: 0
             ) {
                 Form {
-                    if let authErrorPresentation = self.authErrorPresentation {
+                    if let authErrorPresentation = self.store.cloudSignInAttempt.authErrorPresentation {
                         Section {
                             CloudAuthInlineErrorView(
                                 presentation: authErrorPresentation,
@@ -62,7 +51,7 @@ struct CloudSignInSheet: View {
                     }
 
                     Section(aiSettingsLocalized("common.email", "Email")) {
-                        TextField(aiSettingsLocalized("settings.account.cloudSignIn.emailPlaceholder", "Your email"), text: self.$email)
+                        TextField(aiSettingsLocalized("settings.account.cloudSignIn.emailPlaceholder", "Your email"), text: $store.cloudSignInAttempt.email)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
                             .keyboardType(.emailAddress)
@@ -79,7 +68,10 @@ struct CloudSignInSheet: View {
                         Button(aiSettingsLocalized("settings.account.cloudSignIn.sendOneTimeCode", "Send one-time code")) {
                             self.sendCode()
                         }
-                        .disabled(self.isSendingCode || isValidCloudEmail(self.email) == false)
+                        .disabled(
+                            self.store.cloudSignInAttempt.isSendingCode
+                                || isValidCloudEmail(self.store.cloudSignInAttempt.email) == false
+                        )
                         .accessibilityIdentifier(UITestIdentifier.cloudSignInSendCodeButton)
                     }
                 }
@@ -87,63 +79,73 @@ struct CloudSignInSheet: View {
             .navigationTitle(aiSettingsLocalized("settings.account.cloudSignIn.title", "Sign in"))
             .navigationBarTitleDisplayMode(.inline)
             .accessibilityIdentifier(UITestIdentifier.cloudSignInScreen)
-            .interactiveDismissDisabled(self.isPostAuthActionInFlight)
+            .interactiveDismissDisabled(self.store.cloudSignInAttempt.isPostAuthActionInFlight)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(aiSettingsLocalized("common.close", "Close")) {
                         self.dismiss()
                     }
-                    .disabled(self.isSendingCode || self.isPostAuthActionInFlight)
+                    .disabled(
+                        self.store.cloudSignInAttempt.isSendingCode
+                            || self.store.cloudSignInAttempt.isPostAuthActionInFlight
+                    )
                 }
             }
-            .sheet(item: self.$otpSheetState) { otpState in
+            .sheet(item: $store.cloudSignInAttempt.otpSheetState) { otpState in
+                // The code step's requests outlive it exactly as `sendCode`'s do — the OTP sheet has
+                // no `interactiveDismissDisabled`, so a slow verify can still be in flight when the
+                // person swipes it and the sign-in sheet away. Its write-backs carry the attempt they
+                // belong to for the same reason `sendCode` does.
+                let attemptId = self.store.cloudSignInAttempt.id
+
                 CloudOtpVerificationSheet(
-                    otpSheetState: self.$otpSheetState,
+                    attemptId: attemptId,
+                    otpSheetState: $store.cloudSignInAttempt.otpSheetState,
                     onVerified: { verifiedContext in
-                        self.handleVerifiedAuthContext(verifiedContext)
+                        self.handleVerifiedAuthContext(verifiedContext, attemptId: attemptId)
                     },
                     onReturnToEmail: {
                         self.cancelPostAuthTasksAndClearInFlightState()
-                        self.otpSheetState = nil
-                        self.workspaceLinkContext = nil
-                        self.postAuthRecoveryNeededState = nil
-                        self.postAuthFailureState = nil
+                        self.store.cloudSignInAttempt.otpSheetState = nil
+                        self.store.cloudSignInAttempt.workspaceLinkContext = nil
+                        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
+                        self.store.cloudSignInAttempt.postAuthFailureState = nil
                         self.scheduleEmailFieldFocus()
                     }
                 )
                 .environment(self.store)
             }
-            .sheet(item: self.$postAuthLoadingState) { loadingState in
+            .sheet(item: $store.cloudSignInAttempt.postAuthLoadingState) { loadingState in
                 CloudPostAuthLoadingSheet()
                     .interactiveDismissDisabled(true)
             }
-            .sheet(item: self.$postAuthGuestLocalRecoveryPreparationState) { recoveryState in
+            .sheet(item: $store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState) { recoveryState in
                 CloudPostAuthGuestLocalRecoveryPreparationSheet()
                     .interactiveDismissDisabled(true)
             }
-            .sheet(item: self.$postAuthSyncState) { syncState in
+            .sheet(item: $store.cloudSignInAttempt.postAuthSyncState) { syncState in
                 CloudPostAuthSyncSheet(operation: syncState.operation)
                     .interactiveDismissDisabled(true)
             }
-            .sheet(item: self.$workspaceLinkContext) { linkContext in
+            .sheet(item: $store.cloudSignInAttempt.workspaceLinkContext) { linkContext in
                 CloudWorkspaceSelectionSheet(
                     linkContext: linkContext,
-                    isSelectionDisabled: self.isPostAuthActionInFlight,
+                    isSelectionDisabled: self.store.cloudSignInAttempt.isPostAuthActionInFlight,
                     onSelection: { selection in
                         self.completeLink(linkContext: linkContext, selection: selection)
                     },
                     onCancelled: {
-                        self.workspaceLinkContext = nil
+                        self.store.cloudSignInAttempt.workspaceLinkContext = nil
                     }
                 )
                 .environment(self.store)
             }
-            .sheet(item: self.$postAuthRecoveryNeededState) { recoveryState in
+            .sheet(item: $store.cloudSignInAttempt.postAuthRecoveryNeededState) { recoveryState in
                 CloudPostAuthRecoveryNeededSheet(
                     state: recoveryState,
                     allowsLogoutAction: self.isStandardPresentation,
                     onClose: {
-                        self.postAuthRecoveryNeededState = nil
+                        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
                         self.dismiss()
                     },
                     onLogout: {
@@ -151,10 +153,10 @@ struct CloudSignInSheet: View {
                     }
                 )
             }
-            .sheet(item: self.$postAuthFailureState) { failureState in
+            .sheet(item: $store.cloudSignInAttempt.postAuthFailureState) { failureState in
                 CloudPostAuthFailureSheet(
                     state: failureState,
-                    isRetryDisabled: self.isPostAuthActionInFlight,
+                    isRetryDisabled: self.store.cloudSignInAttempt.isPostAuthActionInFlight,
                     allowsCloseAction: failureState.allowsAccountExitActions
                         || self.presentationContext == .credentialRecoveryGate,
                     allowsLogoutAction: failureState.allowsAccountExitActions
@@ -163,7 +165,7 @@ struct CloudSignInSheet: View {
                         self.retryPostAuthFailure(failureState)
                     },
                     onClose: {
-                        self.postAuthFailureState = nil
+                        self.store.cloudSignInAttempt.postAuthFailureState = nil
                         self.dismiss()
                     },
                     onLogout: {
@@ -189,98 +191,105 @@ struct CloudSignInSheet: View {
                     }
                 )
             }
+            // The attempt decides when the presentation closes, because the work that finishes it
+            // may well have been started by a view instance that no longer exists.
+            .onChange(of: self.store.cloudSignInAttempt.isCompleted, initial: true) { _, isCompleted in
+                guard isCompleted else {
+                    return
+                }
+
+                self.dismiss()
+            }
             .onAppear {
                 self.recordSurfacePresenceIfNeeded()
-                self.scheduleEmailFieldFocus()
+                self.scheduleEmailFieldFocusIfShowingEmailForm()
             }
             .onDisappear {
-                self.cancelPostAuthTasksAndClearInFlightState()
                 self.clearSurfacePresenceIfNeeded()
             }
         }
         .accessibilityIdentifier(UITestIdentifier.cloudSignInScreen)
     }
 
-    private var isPostAuthActionInFlight: Bool {
-        self.postAuthLoadingState != nil
-            || self.postAuthGuestLocalRecoveryPreparationState != nil
-            || self.postAuthSyncState != nil
-    }
-
-    private func cancelPostAuthTasks() {
-        self.postAuthLoadingTask?.task.cancel()
-        self.postAuthLoadingTask = nil
-        self.postAuthGuestLocalRecoveryPreparationTask?.task.cancel()
-        self.postAuthGuestLocalRecoveryPreparationTask = nil
-        self.postAuthSyncTask?.task.cancel()
-        self.postAuthSyncTask = nil
-    }
-
     private func cancelPostAuthTasksAndClearInFlightState() {
-        self.cancelPostAuthTasks()
-        self.postAuthLoadingState = nil
-        self.postAuthGuestLocalRecoveryPreparationState = nil
-        self.postAuthSyncState = nil
+        self.store.cancelCloudSignInPostAuthTasks()
+        self.store.cloudSignInAttempt.postAuthLoadingState = nil
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
+        self.store.cloudSignInAttempt.postAuthSyncState = nil
     }
 
     private func clearPostAuthLoadingTaskIfCurrent(stateId: String) {
-        guard self.postAuthLoadingTask?.stateId == stateId else {
+        guard self.store.cloudSignInAttempt.postAuthLoadingTask?.stateId == stateId else {
             return
         }
-        self.postAuthLoadingTask = nil
+        self.store.cloudSignInAttempt.postAuthLoadingTask = nil
     }
 
     private func clearPostAuthGuestLocalRecoveryPreparationTaskIfCurrent(stateId: String) {
-        guard self.postAuthGuestLocalRecoveryPreparationTask?.stateId == stateId else {
+        guard self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationTask?.stateId == stateId else {
             return
         }
-        self.postAuthGuestLocalRecoveryPreparationTask = nil
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationTask = nil
     }
 
     private func clearPostAuthSyncTaskIfCurrent(stateId: String) {
-        guard self.postAuthSyncTask?.stateId == stateId else {
+        guard self.store.cloudSignInAttempt.postAuthSyncTask?.stateId == stateId else {
             return
         }
-        self.postAuthSyncTask = nil
+        self.store.cloudSignInAttempt.postAuthSyncTask = nil
     }
 
     private func startPostAuthLoadingTask(_ loadingState: CloudPostAuthLoadingState) {
-        self.postAuthLoadingTask?.task.cancel()
+        self.store.cloudSignInAttempt.postAuthLoadingTask?.task.cancel()
         let task = Task { @MainActor in
             await self.prepareCloudLink(loadingState)
             self.clearPostAuthLoadingTaskIfCurrent(stateId: loadingState.id)
         }
-        self.postAuthLoadingTask = CloudSignInPostAuthTaskHandle(stateId: loadingState.id, task: task)
+        self.store.cloudSignInAttempt.postAuthLoadingTask = CloudSignInPostAuthTaskHandle(
+            stateId: loadingState.id,
+            task: task
+        )
     }
 
     private func startPostAuthGuestLocalRecoveryPreparationTask(
         _ recoveryState: CloudPostAuthGuestLocalRecoveryPreparationState
     ) {
-        self.postAuthGuestLocalRecoveryPreparationTask?.task.cancel()
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationTask?.task.cancel()
         let task = Task { @MainActor in
             await Task.yield()
             await self.runGuestLocalRecoveryPreparation(recoveryState)
             self.clearPostAuthGuestLocalRecoveryPreparationTaskIfCurrent(stateId: recoveryState.id)
         }
-        self.postAuthGuestLocalRecoveryPreparationTask = CloudSignInPostAuthTaskHandle(
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationTask = CloudSignInPostAuthTaskHandle(
             stateId: recoveryState.id,
             task: task
         )
     }
 
     private func startPostAuthSyncTask(_ syncState: CloudPostAuthSyncState) {
-        self.postAuthSyncTask?.task.cancel()
+        self.store.cloudSignInAttempt.postAuthSyncTask?.task.cancel()
         let task = Task { @MainActor in
             await self.runPostAuthSync(syncState)
             self.clearPostAuthSyncTaskIfCurrent(stateId: syncState.id)
         }
-        self.postAuthSyncTask = CloudSignInPostAuthTaskHandle(stateId: syncState.id, task: task)
+        self.store.cloudSignInAttempt.postAuthSyncTask = CloudSignInPostAuthTaskHandle(
+            stateId: syncState.id,
+            task: task
+        )
     }
 
     private func scheduleEmailFieldFocus() {
         DispatchQueue.main.async {
             self.isEmailFieldFocused = true
         }
+    }
+
+    private func scheduleEmailFieldFocusIfShowingEmailForm() {
+        guard self.store.cloudSignInAttempt.isStepAboveEmailFormPresented == false else {
+            return
+        }
+
+        self.scheduleEmailFieldFocus()
     }
 
     private var isStandardPresentation: Bool {
@@ -313,25 +322,33 @@ struct CloudSignInSheet: View {
     private func sendCode() {
         self.isEmailFieldFocused = false
 
-        guard isValidCloudEmail(self.email) else {
-            self.authErrorPresentation = CloudAuthInlineErrorPresentation(
+        guard isValidCloudEmail(self.store.cloudSignInAttempt.email) else {
+            self.store.cloudSignInAttempt.authErrorPresentation = CloudAuthInlineErrorPresentation(
                 message: aiSettingsLocalized("settings.account.cloudSignIn.enterValidEmail", "Enter a valid email address"),
                 technicalError: nil
             )
             return
         }
 
-        let nextEmail = normalizedCloudEmail(self.email)
+        let attemptId = self.store.cloudSignInAttempt.id
+        let nextEmail = normalizedCloudEmail(self.store.cloudSignInAttempt.email)
         let nextOtpSheetState = CloudOtpSheetState(email: nextEmail, challenge: nil)
-        self.email = nextEmail
-        self.authErrorPresentation = nil
-        self.otpSheetState = nextOtpSheetState
+        self.store.cloudSignInAttempt.email = nextEmail
+        self.store.cloudSignInAttempt.authErrorPresentation = nil
+        self.store.cloudSignInAttempt.otpSheetState = nextOtpSheetState
+        // Raised here rather than inside the task, so it is always the attempt that owns the request
+        // that carries the flag. `finishSendingCode` lowers it only for that same attempt, and a
+        // raise deferred to the task's first hop could land on an attempt that replaced this one and
+        // leave it with both "Send one-time code" and Close disabled for good.
+        self.store.cloudSignInAttempt.isSendingCode = true
 
+        // This request is deliberately not tied to the sheet's lifetime: it outlives a rebuilt view
+        // instance, and its result now reaches the attempt that started it instead of a view nobody
+        // can see. The `attemptId` guards keep it out of whichever attempt replaced that one.
         Task { @MainActor in
-            self.isSendingCode = true
             let captureContext = self.store.beginTechnicalErrorCaptureContext()
             defer {
-                self.isSendingCode = false
+                self.finishSendingCode(attemptId: attemptId)
             }
 
             do {
@@ -340,34 +357,39 @@ struct CloudSignInSheet: View {
                     captureContext: captureContext
                 )
 
+                guard self.store.cloudSignInAttempt.id == attemptId else {
+                    return
+                }
+
                 switch sendCodeResult {
                 case .otpChallenge(let nextChallenge):
-                    guard self.otpSheetState?.id == nextOtpSheetState.id else {
+                    guard self.store.cloudSignInAttempt.otpSheetState?.id == nextOtpSheetState.id else {
                         return
                     }
 
-                    self.email = nextChallenge.email
-                    self.otpSheetState = nextOtpSheetState.withChallenge(nextChallenge)
+                    self.store.cloudSignInAttempt.email = nextChallenge.email
+                    self.store.cloudSignInAttempt.otpSheetState = nextOtpSheetState.withChallenge(nextChallenge)
                 case .verifiedCredentials(let credentials):
                     // This intentionally insecure path exists only for
                     // configured review account emails on the auth service.
-                    self.otpSheetState = nil
+                    self.store.cloudSignInAttempt.otpSheetState = nil
                     self.handleVerifiedAuthContext(
                         CloudVerifiedAuthContext(
                             apiBaseUrl: try self.store.currentCloudServiceConfiguration().apiBaseUrl,
                             credentials: credentials
-                        )
+                        ),
+                        attemptId: attemptId
                     )
                 }
             } catch {
-                if isRequestCancellationError(error: error) {
-                    if self.otpSheetState?.id == nextOtpSheetState.id {
-                        self.otpSheetState = nil
-                    }
+                guard self.store.cloudSignInAttempt.id == attemptId else {
                     return
                 }
-                if self.otpSheetState?.id == nextOtpSheetState.id {
-                    self.otpSheetState = nil
+                if self.store.cloudSignInAttempt.otpSheetState?.id == nextOtpSheetState.id {
+                    self.store.cloudSignInAttempt.otpSheetState = nil
+                }
+                if isRequestCancellationError(error: error) {
+                    return
                 }
                 self.store.reportCloudSignInFailure(reason: analyticsSignInFailureReason(error: error))
                 self.presentAuthErrorPresentation(
@@ -381,12 +403,20 @@ struct CloudSignInSheet: View {
         }
     }
 
+    private func finishSendingCode(attemptId: String) {
+        guard self.store.cloudSignInAttempt.id == attemptId else {
+            return
+        }
+
+        self.store.cloudSignInAttempt.isSendingCode = false
+    }
+
     private func handlePreparedLinkContext(_ linkContext: CloudWorkspaceLinkContext) {
-        self.authErrorPresentation = nil
-        self.postAuthLoadingState = nil
-        self.postAuthGuestLocalRecoveryPreparationState = nil
-        self.postAuthRecoveryNeededState = nil
-        self.postAuthFailureState = nil
+        self.store.cloudSignInAttempt.authErrorPresentation = nil
+        self.store.cloudSignInAttempt.postAuthLoadingState = nil
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
+        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
+        self.store.cloudSignInAttempt.postAuthFailureState = nil
 
         switch makeCloudWorkspacePostAuthRoute(linkContext: linkContext) {
         case .autoLink(let selection):
@@ -395,33 +425,51 @@ struct CloudSignInSheet: View {
                     linkContext: linkContext,
                     selection: selection
                 )
-                self.postAuthGuestLocalRecoveryPreparationState = nextState
+                self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nextState
                 self.startPostAuthGuestLocalRecoveryPreparationTask(nextState)
             } else {
                 self.completeLink(linkContext: linkContext, selection: selection)
             }
         case .chooseWorkspace:
-            self.workspaceLinkContext = linkContext
+            self.store.cloudSignInAttempt.workspaceLinkContext = linkContext
         case .guestLocalRecoveryNeeded:
-            self.postAuthRecoveryNeededState = CloudPostAuthRecoveryNeededState(
+            self.store.cloudSignInAttempt.postAuthRecoveryNeededState = CloudPostAuthRecoveryNeededState(
                 title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
                 message: localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
             )
-            self.workspaceLinkContext = nil
+            self.store.cloudSignInAttempt.workspaceLinkContext = nil
         }
     }
 
-    private func handleVerifiedAuthContext(_ verifiedContext: CloudVerifiedAuthContext) {
+    /**
+     * Credentials came back verified. Both callers reach here from a request that outlives the view
+     * that started it, so the attempt this verification belongs to is checked before anything is
+     * written: a verification that lands after its attempt was cancelled must not settle the attempt
+     * that replaced it, and must not start post-auth work — linking a workspace and uploading local
+     * data — behind a presentation nobody is showing.
+     *
+     * The per-state `id` guards further down cannot stand in for this one. They compare against state
+     * this call would have just written, so they all pass; this is the entry point where the attempt
+     * is still the only thing that can be compared.
+     */
+    private func handleVerifiedAuthContext(
+        _ verifiedContext: CloudVerifiedAuthContext,
+        attemptId: String
+    ) {
+        guard self.store.cloudSignInAttempt.id == attemptId else {
+            return
+        }
+
         self.store.recordCloudSignInVerified()
 
         let loadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
-        self.otpSheetState = nil
-        self.postAuthLoadingState = loadingState
-        self.postAuthGuestLocalRecoveryPreparationState = nil
-        self.postAuthSyncState = nil
-        self.workspaceLinkContext = nil
-        self.postAuthRecoveryNeededState = nil
-        self.authErrorPresentation = nil
+        self.store.cloudSignInAttempt.otpSheetState = nil
+        self.store.cloudSignInAttempt.postAuthLoadingState = loadingState
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
+        self.store.cloudSignInAttempt.postAuthSyncState = nil
+        self.store.cloudSignInAttempt.workspaceLinkContext = nil
+        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
+        self.store.cloudSignInAttempt.authErrorPresentation = nil
 
         self.startPostAuthLoadingTask(loadingState)
     }
@@ -429,18 +477,18 @@ struct CloudSignInSheet: View {
     private func prepareCloudLink(_ loadingState: CloudPostAuthLoadingState) async {
         do {
             let linkContext = try await self.store.prepareCloudLink(verifiedContext: loadingState.verifiedContext)
-            guard self.postAuthLoadingState?.id == loadingState.id else {
+            guard self.store.cloudSignInAttempt.postAuthLoadingState?.id == loadingState.id else {
                 return
             }
-            self.postAuthFailureState = nil
+            self.store.cloudSignInAttempt.postAuthFailureState = nil
             self.handlePreparedLinkContext(linkContext)
         } catch {
-            guard self.postAuthLoadingState?.id == loadingState.id else {
+            guard self.store.cloudSignInAttempt.postAuthLoadingState?.id == loadingState.id else {
                 return
             }
-            self.postAuthLoadingState = nil
-            self.postAuthGuestLocalRecoveryPreparationState = nil
-            self.postAuthSyncState = nil
+            self.store.cloudSignInAttempt.postAuthLoadingState = nil
+            self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
+            self.store.cloudSignInAttempt.postAuthSyncState = nil
             if isRequestCancellationError(error: error) {
                 return
             }
@@ -472,7 +520,7 @@ struct CloudSignInSheet: View {
     }
 
     private func completeLink(linkContext: CloudWorkspaceLinkContext, selection: CloudWorkspaceLinkSelection) {
-        guard self.isPostAuthActionInFlight == false else {
+        guard self.store.cloudSignInAttempt.isPostAuthActionInFlight == false else {
             return
         }
 
@@ -484,11 +532,11 @@ struct CloudSignInSheet: View {
     }
 
     private func runGuestLocalRecoveryPreparation(_ recoveryState: CloudPostAuthGuestLocalRecoveryPreparationState) async {
-        guard self.postAuthGuestLocalRecoveryPreparationState?.id == recoveryState.id else {
+        guard self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState?.id == recoveryState.id else {
             return
         }
 
-        self.postAuthGuestLocalRecoveryPreparationState = nil
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
         self.presentPostAuthSync(
             operation: .completeLink(
                 linkContext: recoveryState.linkContext,
@@ -498,12 +546,12 @@ struct CloudSignInSheet: View {
     }
 
     private func retryPostAuthFailure(_ failureState: CloudPostAuthFailureState) {
-        self.postAuthFailureState = nil
+        self.store.cloudSignInAttempt.postAuthFailureState = nil
 
         switch failureState.retryAction {
         case .prepareLink(let verifiedContext):
             let loadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
-            self.postAuthLoadingState = loadingState
+            self.store.cloudSignInAttempt.postAuthLoadingState = loadingState
             self.startPostAuthLoadingTask(loadingState)
         case .completeLink(let linkContext, let selection):
             self.completeLink(linkContext: linkContext, selection: selection)
@@ -517,14 +565,14 @@ struct CloudSignInSheet: View {
     private func presentPostAuthSync(operation: CloudPostAuthSyncOperation) {
         let nextState = CloudPostAuthSyncState(operation: operation)
 
-        self.authErrorPresentation = nil
-        self.postAuthLoadingState = nil
-        self.postAuthGuestLocalRecoveryPreparationState = nil
-        self.postAuthSyncState = nil
-        self.workspaceLinkContext = nil
-        self.postAuthRecoveryNeededState = nil
-        self.postAuthFailureState = nil
-        self.postAuthSyncState = nextState
+        self.store.cloudSignInAttempt.authErrorPresentation = nil
+        self.store.cloudSignInAttempt.postAuthLoadingState = nil
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
+        self.store.cloudSignInAttempt.postAuthSyncState = nil
+        self.store.cloudSignInAttempt.workspaceLinkContext = nil
+        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
+        self.store.cloudSignInAttempt.postAuthFailureState = nil
+        self.store.cloudSignInAttempt.postAuthSyncState = nextState
 
         self.startPostAuthSyncTask(nextState)
     }
@@ -554,19 +602,19 @@ struct CloudSignInSheet: View {
                 )
             }
 
-            guard self.postAuthSyncState?.id == syncState.id else {
+            guard self.store.cloudSignInAttempt.postAuthSyncState?.id == syncState.id else {
                 return
             }
 
-            self.postAuthFailureState = nil
-            self.postAuthSyncState = nil
-            self.dismiss()
+            self.store.cloudSignInAttempt.postAuthFailureState = nil
+            self.store.cloudSignInAttempt.postAuthSyncState = nil
+            self.store.cloudSignInAttempt.isCompleted = true
         } catch {
-            guard self.postAuthSyncState?.id == syncState.id else {
+            guard self.store.cloudSignInAttempt.postAuthSyncState?.id == syncState.id else {
                 return
             }
             if isRequestCancellationError(error: error) {
-                self.postAuthSyncState = nil
+                self.store.cloudSignInAttempt.postAuthSyncState = nil
                 return
             }
 
@@ -575,7 +623,7 @@ struct CloudSignInSheet: View {
                 cloudState: self.store.cloudSettings?.cloudState
             )
 
-            self.postAuthSyncState = nil
+            self.store.cloudSignInAttempt.postAuthSyncState = nil
             self.presentPostAuthFailure(
                 title: failurePresentation.title,
                 message: failurePresentation.message ?? makeCloudPostAuthVisibleFailureMessage(error: error),
@@ -598,13 +646,13 @@ struct CloudSignInSheet: View {
         retryAction: CloudPostAuthRetryAction,
         kind: CloudPostAuthFailureKind
     ) {
-        self.cancelPostAuthTasks()
-        self.authErrorPresentation = nil
-        self.postAuthLoadingState = nil
-        self.postAuthGuestLocalRecoveryPreparationState = nil
-        self.postAuthSyncState = nil
-        self.postAuthRecoveryNeededState = nil
-        self.postAuthFailureState = CloudPostAuthFailureState(
+        self.store.cancelCloudSignInPostAuthTasks()
+        self.store.cloudSignInAttempt.authErrorPresentation = nil
+        self.store.cloudSignInAttempt.postAuthLoadingState = nil
+        self.store.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationState = nil
+        self.store.cloudSignInAttempt.postAuthSyncState = nil
+        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
+        self.store.cloudSignInAttempt.postAuthFailureState = CloudPostAuthFailureState(
             title: title,
             message: message,
             technicalError: technicalError.map { action in
@@ -632,7 +680,7 @@ struct CloudSignInSheet: View {
         _ presentation: CloudAuthInlineErrorPresentation,
         captureContext: TechnicalErrorCaptureContext
     ) {
-        self.authErrorPresentation = CloudAuthInlineErrorPresentation(
+        self.store.cloudSignInAttempt.authErrorPresentation = CloudAuthInlineErrorPresentation(
             message: presentation.message,
             technicalError: presentation.technicalError.map { action in
                 self.store.captureTechnicalErrorActionIfNeeded(
@@ -654,16 +702,16 @@ struct CloudSignInSheet: View {
         do {
             try self.store.logoutCloudAccount()
         } catch {
-            self.authErrorPresentation = CloudAuthInlineErrorPresentation(
+            self.store.cloudSignInAttempt.authErrorPresentation = CloudAuthInlineErrorPresentation(
                 message: Flashcards.errorMessage(error: error),
                 technicalError: nil
             )
         }
 
-        self.postAuthFailureState = nil
-        self.workspaceLinkContext = nil
-        self.postAuthRecoveryNeededState = nil
-        self.otpSheetState = nil
+        self.store.cloudSignInAttempt.postAuthFailureState = nil
+        self.store.cloudSignInAttempt.workspaceLinkContext = nil
+        self.store.cloudSignInAttempt.postAuthRecoveryNeededState = nil
+        self.store.cloudSignInAttempt.otpSheetState = nil
         self.dismiss()
     }
 }
@@ -674,7 +722,8 @@ struct CloudSignInSheet: View {
  * `onDismiss` fires when the presentation itself goes away. The sheet's own `onAppear`/`onDisappear`
  * do not mean that: SwiftUI rebuilds the sheet's content while the sheet stays on screen — switching
  * tabs under the Settings presenter is enough — and reading a dismissal from that reports an
- * abandoned sign-in for a sheet the person is still typing in.
+ * abandoned sign-in for a sheet the person is still typing in. `CloudSignInSheet` keeps nothing of
+ * the attempt for the same reason, so ending the attempt here is what tears its work down.
  *
  * Every presentation this modifier makes opens exactly one attempt, and it opens it before the sheet
  * can be closed. That needs both halves of `onChange(initial:)`, because a presentation does not
@@ -688,8 +737,9 @@ struct CloudSignInSheet: View {
  *
  * `hasOpenedAttemptForCurrentPresentation` is what keeps that safe. `beginCloudSignInAttempt` starts
  * a *new* attempt — it re-reads the credential-recovery gate into the latch that decides whether a
- * later dismissal is the person or the system — so running it twice inside one presentation would
- * re-latch the gate mid-attempt and turn a system-caused teardown back into a reported cancellation.
+ * later dismissal is the person or the system, and it clears the attempt's screen state and work —
+ * so running it twice inside one presentation would re-latch the gate mid-attempt, turn a
+ * system-caused teardown back into a reported cancellation, and throw away what the person typed.
  * The flag makes "one begin per presentation" a property of this modifier rather than of SwiftUI's
  * delivery order: it is `@State`, so a modifier that is destroyed and reinstalled starts clear and
  * arms its new presentation, while one that merely re-evaluates does not re-arm the presentation it

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
@@ -20,6 +20,84 @@ struct CloudOtpSheetState: Identifiable, Hashable {
     }
 }
 
+struct CloudSignInPostAuthTaskHandle {
+    let stateId: String
+    let task: Task<Void, Never>
+}
+
+/**
+ * Everything one sign-in attempt is made of: the step the person is on, what they typed into it,
+ * and the post-auth work the attempt started.
+ *
+ * This lives on the store rather than in `CloudSignInSheet` because SwiftUI destroys and rebuilds
+ * that content while the presentation stays on screen — switching tabs under the Settings presenter
+ * is enough. State the view owns does not survive that, so an attempt anchored to the view loses
+ * the typed email, the open code step, and the in-flight work of a sign-in that already succeeded,
+ * without the person ever closing anything. Only state that genuinely describes one view instance —
+ * keyboard focus, an open technical-error inspector, a confirmation alert — stays in the view.
+ *
+ * `id` identifies the attempt, and every write-back from work that can outlive it compares that `id`
+ * first: neither `sendCode` nor the code step's verify and resend calls are cancelled by a presenter
+ * teardown, so each of them carries the attempt it was started for and drops its result when that
+ * attempt is gone. Once post-auth work is under way the per-state `id` guards take over, but only
+ * downstream of `handleVerifiedAuthContext`, which is where the post-auth states are created: a
+ * write-back that creates the state it then compares against would find its own guard passing, so
+ * the attempt `id` is the only thing an entry point can check.
+ */
+struct CloudSignInAttemptState {
+    let id: String
+    var email: String
+    var otpSheetState: CloudOtpSheetState?
+    var postAuthLoadingState: CloudPostAuthLoadingState?
+    var postAuthGuestLocalRecoveryPreparationState: CloudPostAuthGuestLocalRecoveryPreparationState?
+    var postAuthSyncState: CloudPostAuthSyncState?
+    var workspaceLinkContext: CloudWorkspaceLinkContext?
+    var postAuthRecoveryNeededState: CloudPostAuthRecoveryNeededState?
+    var postAuthFailureState: CloudPostAuthFailureState?
+    var authErrorPresentation: CloudAuthInlineErrorPresentation?
+    var isSendingCode: Bool
+    /// The attempt finished its work and the presentation should close. The dismissal itself belongs
+    /// to whichever view instance is on screen, which is not always the one that started the work.
+    var isCompleted: Bool
+    var postAuthLoadingTask: CloudSignInPostAuthTaskHandle?
+    var postAuthGuestLocalRecoveryPreparationTask: CloudSignInPostAuthTaskHandle?
+    var postAuthSyncTask: CloudSignInPostAuthTaskHandle?
+
+    init() {
+        self.id = UUID().uuidString
+        self.email = ""
+        self.otpSheetState = nil
+        self.postAuthLoadingState = nil
+        self.postAuthGuestLocalRecoveryPreparationState = nil
+        self.postAuthSyncState = nil
+        self.workspaceLinkContext = nil
+        self.postAuthRecoveryNeededState = nil
+        self.postAuthFailureState = nil
+        self.authErrorPresentation = nil
+        self.isSendingCode = false
+        self.isCompleted = false
+        self.postAuthLoadingTask = nil
+        self.postAuthGuestLocalRecoveryPreparationTask = nil
+        self.postAuthSyncTask = nil
+    }
+
+    var isPostAuthActionInFlight: Bool {
+        self.postAuthLoadingState != nil
+            || self.postAuthGuestLocalRecoveryPreparationState != nil
+            || self.postAuthSyncState != nil
+    }
+
+    /// Whether a step above the email form is on screen. A rebuilt view instance must not pull focus
+    /// back to the email field underneath one.
+    var isStepAboveEmailFormPresented: Bool {
+        self.otpSheetState != nil
+            || self.workspaceLinkContext != nil
+            || self.postAuthRecoveryNeededState != nil
+            || self.postAuthFailureState != nil
+            || self.isPostAuthActionInFlight
+    }
+}
+
 @MainActor
 extension FlashcardsStore {
     /**
@@ -28,33 +106,41 @@ extension FlashcardsStore {
      * screen — a tab switch under the Settings presenter is enough — so an attempt anchored to the
      * content would re-open on every rebuild and owe a `signin_failed` for each one.
      *
-     * This starts an attempt from scratch: it writes all three fields the attempt is made of, so a
-     * presentation that ended without a dismissal — the credential-recovery gate swapping the tab
-     * root out from under a presented sheet is the one way that happens — cannot leave an origin
-     * surface or a gate latch behind for the next presentation to be judged on. Because it re-reads
-     * the gate into the latch, the caller owes exactly one call per presentation:
-     * `CloudSignInSheetModifier` is the only caller and holds that guarantee.
+     * This starts an attempt from scratch: it clears the previous attempt's screen state and work
+     * and writes every field the attempt is made of, so a presentation that ended without a
+     * dismissal — the credential-recovery gate swapping the tab root out from under a presented
+     * sheet is the one way that happens — cannot leave an origin surface, a gate latch, a typed
+     * email or a running post-auth task behind for the next presentation. Because it re-reads the
+     * gate into the latch and resets the sheet's state, the caller owes exactly one call per
+     * presentation: `CloudSignInSheetModifier` is the only caller and holds that guarantee.
      */
     func beginCloudSignInAttempt(originSurface: AnalyticsSurface?) {
+        self.cancelCloudSignInPostAuthTasks()
+        self.cloudSignInAttempt = CloudSignInAttemptState()
         self.isCloudSignInAttemptOpen = true
         self.cloudSignInOriginSurface = originSurface
         self.wasCredentialRecoveryGateActiveAtSignInStart = self.isCloudCredentialRecoveryGateActive
     }
 
     /**
-     * The sheet was dismissed. This is the one place that sees every way it can go: the Close
-     * button, the interactive swipe, and the programmatic dismissals that follow success, logout or
-     * a post-auth failure. Backgrounding the app does not reach it, so an attempt still open here
-     * was abandoned by the person — with one exception. A dismissal that follows success or a
-     * reported failure finds the attempt settled and reports nothing.
+     * The attempt is over. `CloudSignInSheetModifier`'s `onDismiss` is the usual way in and sees
+     * every way the sheet can go: the Close button, the interactive swipe, and the programmatic
+     * dismissals that follow success, logout or a post-auth failure. Backgrounding the app does not
+     * reach it, so an attempt still open here was abandoned by the person; a dismissal that follows
+     * success or a reported failure finds the attempt settled and reports nothing. Ending the
+     * attempt also ends its work, which is why the attempt's screen state and post-auth tasks are
+     * torn down here. The sheet's content going away is never a reason to do that.
      *
-     * The exception is the credential-recovery gate. `RootTabView.body` swaps its whole tab root for
-     * `CloudCredentialRecoveryGateView` the moment `cloudCredentialRecoveryState` becomes non-nil,
-     * and swaps it back when the state clears; either swap takes away whichever sheet the other
-     * branch was presenting, and a background poll can flip that state while the person is typing.
-     * That is the system taking the surface away, not a person closing it, so the gate's activation
-     * is latched when the attempt begins and a mismatch here reports nothing. Android's gate sits
-     * above its navigation host and reports nothing for the same swap, so the two clients agree.
+     * `eraseLocalDataForCredentialRecovery` is the other way in, and the only one that is not a
+     * dismissal: the recovery gate takes the surface away without dismissing anything, so an attempt
+     * can still be running when the person erases local data, and it has to be ended before that
+     * reset rather than left to write across it.
+     *
+     * The credential-recovery-gate comparison below is defence-in-depth on every path in, and is
+     * meant to stay that way. It draws one distinction and claims nothing beyond it: an attempt the
+     * person walked away from is theirs to abandon and is worth a `signin_failed(cancelled)`, while
+     * an attempt whose surface the recovery gate took away is not. That is why the gate's activation
+     * is latched when the attempt begins and a mismatch here reports nothing.
      */
     func endCloudSignInAttempt() {
         if self.isCloudSignInAttemptOpen,
@@ -62,9 +148,22 @@ extension FlashcardsStore {
             self.trackCloudSignInFailed(reason: .cancelled)
         }
 
+        self.cancelCloudSignInPostAuthTasks()
+        self.cloudSignInAttempt = CloudSignInAttemptState()
         self.isCloudSignInAttemptOpen = false
         self.cloudSignInOriginSurface = nil
         self.wasCredentialRecoveryGateActiveAtSignInStart = false
+    }
+
+    /// Stops the post-auth work the current attempt started. A rebuilt sheet is not a reason to call
+    /// this: the work belongs to the attempt, not to the view instance that happened to start it.
+    func cancelCloudSignInPostAuthTasks() {
+        self.cloudSignInAttempt.postAuthLoadingTask?.task.cancel()
+        self.cloudSignInAttempt.postAuthLoadingTask = nil
+        self.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationTask?.task.cancel()
+        self.cloudSignInAttempt.postAuthGuestLocalRecoveryPreparationTask = nil
+        self.cloudSignInAttempt.postAuthSyncTask?.task.cancel()
+        self.cloudSignInAttempt.postAuthSyncTask = nil
     }
 
     /**

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -107,6 +107,9 @@ final class FlashcardsStore {
     private(set) var presentedTechnicalError: TechnicalErrorPresentation?
     var feedbackPromptState: PersistedFeedbackPromptState
     var activeCloudSignInSheetCount: Int
+    /// What the presented sign-in sheet is showing and the work it started. Owned here because
+    /// SwiftUI rebuilds that sheet's content within one presentation.
+    var cloudSignInAttempt: CloudSignInAttemptState
     var accountDeletionState: AccountDeletionState
     var accountDeletionSuccessMessage: String?
     var pendingStoreReviewRequestAttempt: StoreReviewRequestAttempt?
@@ -458,6 +461,7 @@ final class FlashcardsStore {
             decoder: decoder
         )
         self.activeCloudSignInSheetCount = 0
+        self.cloudSignInAttempt = CloudSignInAttemptState()
         self.accountDeletionState = .hidden
         self.accountDeletionSuccessMessage = nil
         self.pendingStoreReviewRequestAttempt = nil


### PR DESCRIPTION
Tapping a review reminder while signing in switches tabs, and SwiftUI rebuilds the sign-in sheet's content **without dismissing it** — twice per tap. The sheet stays visually on screen. Everything the sheet owned was destroyed with it.

Measured on a simulator against `main`, by calling the real `handleAppNotificationTap(.openStrictReminder)`:

- the typed email came back empty and an open "Verify code" sheet was gone, with no error and no explanation;
- **a sign-in that had already succeeded lost its post-auth work.** `onDisappear` cancelled it, both live requests were observed being torn down, and the person was returned to an empty "Sign in" form. No spinner, no error, no account, `cloudState` still disconnected ten seconds later — and no analytics either, because the attempt was settled by the verification, so nothing reported a failure. A completed authentication produced nothing at all;
- an in-flight `sendCode` survived the rebuild and its failure still reached the store, writing `signin_failed{reason: offline, screen: settings}` while the person looked at a pristine empty form.

**The fix.** State that describes the *attempt* now lives on the store and survives a rebuild; only state that describes a *view instance* stays in the view. Cancelling post-auth work moved off `onDisappear`, which means the content went away — not that the person left. Same principle as the previous change, which moved the attempt itself onto the presentation.

**The hazard that created, and how it is closed.** Writes from work that outlives its attempt used to land on a dead view's state and stop there. Hoisting the state meant they would land on the attempt that *replaced* it — so a person could cancel, get their `signin_failed(cancelled)`, and still have a cloud workspace created and their local data uploaded in the background, with no UI and no way to stop it. Review caught it. Every write-back from work that can outlive its attempt now carries the attempt it started for and drops its result when that attempt is gone, and erasing local data from the recovery gate ends the attempt first.

Four review rounds; the last confirmed by independent count that all three failure-report sites are covered. Compiled locally before merge (`xcodebuild build`, exit 0, zero errors), since PR checks do not build Swift.

**Known and left open**, deliberately: `CloudSessionRuntime.runWorkspaceCompletion` awaits an unstructured `Task`, which propagates no cancellation, so a workspace link already inside it survives an erase. Pre-existing, not caused here, needs a decision larger than this change — and the erase docstring now names it instead of implying it is handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)