### PR TITLE
Prepare analytics storage for the revised event contract

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -388,7 +388,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0118_guest_sessions_platform_created_at_index.sql
+            --require-migration 0119_product_analytics_contract_revision.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,6 +71,13 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0119_product_analytics_contract_revision.sql",
+    expectedMigrationCount: 121,
+    testFiles: Object.freeze([
+      "src/productAnalytics/serverEvents.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0116_guest_session_web_platform.sql",
     expectedMigrationCount: 118,
     testFiles: Object.freeze([

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0118_guest_sessions_platform_created_at_index.sql",
+      RequiredMigration: "0119_product_analytics_contract_revision.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0118_guest_sessions_platform_created_at_index.sql",
+    requiredMigration: "0119_product_analytics_contract_revision.sql",
   });
 });
 

--- a/apps/backend/src/productAnalytics/serverEvents.postgres.integration.ts
+++ b/apps/backend/src/productAnalytics/serverEvents.postgres.integration.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import type { ProductAnalyticsEventName } from "./catalog";
+import { deriveServerDerivedProductAnalyticsEventId } from "./serverEvents";
+
+// analytics.derive_server_event_id (migration 0119) is a hand-written twin of
+// deriveServerDerivedProductAnalyticsEventId, and the backfills that call it depend on the two
+// agreeing exactly: a backfilled row and the live emission of the same fact are counted once only
+// because they collide on event_id, which is the primary key of an append-only table. If the two
+// derivations ever disagree, nothing fails - both rows are simply stored, and every reconstructed
+// fact is silently counted twice, forever, with no way to tell the pair apart afterwards. That is
+// why this equality is pinned by a test even though this repository does not add unit tests by
+// default: it is the only thing standing between a divergence and permanently doubled metrics.
+
+type ServerEventIdDerivationVector = Readonly<{
+  eventName: ProductAnalyticsEventName;
+  keyParts: ReadonlyArray<string>;
+}>;
+
+// The first three are the shapes the live producers actually derive today, so the vectors that
+// matter most for the backfill are covered exactly as they occur. The rest pin the cases where the
+// two implementations could plausibly drift apart: no key parts at all, an empty-string part, a part
+// containing the ':' separator itself, non-ASCII text, which only agrees while both sides hash the
+// same UTF-8 bytes, and a NULL part, which the two sides render alike only because 0119 passes
+// array_to_string its three-argument null_string form.
+const serverEventIdDerivationVectors: ReadonlyArray<ServerEventIdDerivationVector> = [
+  {
+    eventName: "guest_upgrade_completed",
+    keyParts: ["3f1d5b0e-8a2c-4d61-9f77-2b8c4a1e6d05"],
+  },
+  {
+    eventName: "ai_message_sent",
+    keyParts: ["b7c0a1d2-3e4f-4a5b-8c6d-7e8f9a0b1c2d", "0c9b8a76-5d4e-4f3a-9b2c-1d0e9f8a7b6c"],
+  },
+  {
+    eventName: "catalog_deck_installed",
+    keyParts: ["6a5b4c3d-2e1f-4a09-8b7c-6d5e4f3a2b1c", "install-2026-08-28-0001"],
+  },
+  {
+    eventName: "guest_upgrade_completed",
+    keyParts: [],
+  },
+  {
+    eventName: "ai_message_sent",
+    keyParts: ["", "part-after-an-empty-part"],
+  },
+  {
+    eventName: "catalog_deck_installed",
+    keyParts: ["a:b:c", "café-Ω-über", "trailing-colon:"],
+  },
+  {
+    // Deliberately ill-typed. keyParts is ReadonlyArray<string> because no TypeScript producer can
+    // reach a NULL part, but the SQL backfill this function exists for builds key_parts out of
+    // production columns that are nullable at the schema level, so it can - and this is the one
+    // case the two implementations do not agree on by default: Array.prototype.join renders a null
+    // element as an empty string, while a two-argument pg_catalog.array_to_string would drop it and
+    // derive an id no live emission could ever collide with. The vector therefore has to carry a
+    // real null into both sides, which means casting past the signature on the TypeScript one.
+    eventName: "guest_upgrade_completed",
+    keyParts: [
+      "d4c3b2a1-0f9e-4d8c-9b6a-5f4e3d2c1b0a",
+      null as unknown as string,
+      "part-after-a-null-part",
+    ],
+  },
+];
+
+function requireOwnerDatabaseUrl(): string {
+  const databaseUrl = process.env.TEST_DATABASE_ADMIN_URL?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error(
+      "TEST_DATABASE_ADMIN_URL is required for the server-derived event id derivation integration test.",
+    );
+  }
+
+  return databaseUrl;
+}
+
+test("the SQL and TypeScript server-derived event id derivations agree", async () => {
+  const ownerPool = new pg.Pool({
+    connectionString: requireOwnerDatabaseUrl(),
+    application_name: "product-analytics-server-event-id-integration-owner",
+  });
+
+  try {
+    for (const vector of serverEventIdDerivationVectors) {
+      const derivedInDatabase = await ownerPool.query<Readonly<{ event_id: string }>>(
+        "SELECT analytics.derive_server_event_id($1::text, $2::text[])::text AS event_id",
+        [vector.eventName, [...vector.keyParts]],
+      );
+      const derivedInTypeScript = deriveServerDerivedProductAnalyticsEventId(
+        vector.eventName,
+        vector.keyParts,
+      );
+
+      assert.equal(
+        derivedInDatabase.rows[0]?.event_id,
+        derivedInTypeScript,
+        `SQL and TypeScript derivations disagree. eventName=${vector.eventName} keyParts=${JSON.stringify(vector.keyParts)}`,
+      );
+    }
+
+    // The derivation has to separate the vectors as well as reproduce them: two implementations that
+    // both collapsed every input onto one id would satisfy the equality above and make the backfill
+    // suppress every row after the first. Checking distinctness on the TypeScript side is enough,
+    // because each SQL id was just asserted equal to its TypeScript counterpart.
+    const derivedIds = new Set(
+      serverEventIdDerivationVectors.map(
+        (vector) => deriveServerDerivedProductAnalyticsEventId(vector.eventName, vector.keyParts),
+      ),
+    );
+    assert.equal(derivedIds.size, serverEventIdDerivationVectors.length);
+  } finally {
+    await ownerPool.end();
+  }
+});

--- a/db/migrations/0119_product_analytics_contract_revision.sql
+++ b/db/migrations/0119_product_analytics_contract_revision.sql
@@ -1,0 +1,159 @@
+-- Migration status: Current / additive plus a one-time data reset.
+-- Introduces: analytics.product_events.details, the (event_name, occurred_at) index the rewritten
+--   admin dashboard reads, analytics.derive_server_event_id as the in-database twin of the backend's
+--   server-derived event id derivation, and the deletion of every event row written under the
+--   pre-revision catalog.
+-- Schemas touched/read explicitly: analytics, pg_catalog.
+
+ALTER TABLE analytics.product_events
+  ADD COLUMN IF NOT EXISTS details JSONB;
+
+-- The column is schema-less by design, so a key allowlist or a per-value rule would be a contract
+-- this migration cannot state. What is bounded instead is the only thing that stays meaningful
+-- without one: the object shape, so a reader can always address it by key, and the serialized size
+-- of a single row's payload, so no producer can turn an indefinitely retained table into a log sink.
+-- The cap is measured on the jsonb text rendering rather than on the stored representation, because
+-- that rendering is what every reader sees and what a producer can reason about before writing.
+ALTER TABLE analytics.product_events
+  ADD CONSTRAINT product_events_details_shape CHECK (
+    details IS NULL
+    OR (
+      pg_catalog.jsonb_typeof(details) = 'object'
+      AND pg_catalog.octet_length(details::text) <= 2000
+    )
+  );
+
+COMMENT ON COLUMN analytics.product_events.details IS
+  'Free-form, deliberately schema-less detail about how the row itself was produced, such as which '
+  'production table a backfilled fact was reconstructed from. It is written only by server-derived '
+  'producers and by backfills. The client ingest path has no field for it and must never gain one: '
+  'a client-writable free-form column is exactly the channel event_properties was bound to fixed '
+  'formats to avoid. Like event_properties and experiment_assignments, this column survives account '
+  'anonymization untouched, so nothing that identifies a person may ever be written here - not a '
+  'name, an email, a device identifier, free text a person typed, or anything joinable back to '
+  'them. It is derivation provenance, not observation payload.';
+
+-- The rule the comment above states is enforced rather than left advisory. 0114 bound the
+-- client-owned columns to origin 'client' with product_events_client_columns_shape; this is the
+-- mirror of that constraint, for the one column the client must never write. It is worth a
+-- constraint rather than a convention because details survives account anonymization untouched, so
+-- anything a client managed to write here would outlive the account deletion meant to remove it.
+ALTER TABLE analytics.product_events
+  ADD CONSTRAINT product_events_details_client_shape CHECK (
+    origin <> 'client'
+    OR details IS NULL
+  );
+
+-- 0114 revoked the analytics schema's default table privileges for reporting_readonly and granted
+-- that role one explicit column list per table instead, so a column added later stays invisible to
+-- reporting until it is named in a grant of its own. This is that grant. Column grants are
+-- additive, so it extends the 0114 list rather than replacing it.
+GRANT SELECT (details) ON TABLE analytics.product_events TO reporting_readonly;
+
+-- No privilege is granted to backend_app for this column, and none is needed: server-derived
+-- producers write it through the INSERT 0114 already granted. The UPDATE 0114 granted on this table
+-- exists solely for the account-deletion anonymization path, which clears the person-linked columns
+-- in place; that grant is table-wide and therefore already reaches this column, so nothing here can
+-- narrow it further. What keeps details out of that path is the rule stated on the column above:
+-- nothing person-linked is ever stored in it, so anonymization has nothing to clear here and must
+-- not add it to its SET list.
+
+-- 0114 states that every additional index is write amplification on an insert-only table, and that a
+-- composite index such as this one is added only when a concrete query needs it. This is that query:
+-- the rewritten admin dashboard reads a single event_name over a date range and groups it by day and
+-- by actor. idx_product_events_occurred_at (0114) leads on occurred_at alone, so that panel scans
+-- every event name in the range and discards all but one; leading on event_name reduces the scan to
+-- the rows the panel actually reports, and keeping occurred_at as the second key column holds the
+-- date range inside the same index scan.
+CREATE INDEX IF NOT EXISTS idx_product_events_event_name_occurred_at
+  ON analytics.product_events (event_name, occurred_at);
+
+-- The in-database twin of deriveServerDerivedProductAnalyticsEventId in
+-- apps/backend/src/productAnalytics/serverEvents.ts. It exists so a backfill written in SQL derives
+-- exactly the id the live emitter derives for the same operation: backfilled and live rows then
+-- collide on the primary key of an append-only table and are counted once, instead of both being
+-- stored and double-counting every reconstructed fact.
+--
+-- The two implementations must never diverge. Neither may be changed without the other, and the
+-- equality is proved for fixed vectors by
+-- apps/backend/src/productAnalytics/serverEvents.postgres.integration.ts, which runs both sides
+-- against each other. The salt below is a plain constant in that same public source file, so
+-- restating it here publishes nothing that was not already published; like there, it must never
+-- change, because every id ever stored was derived from it.
+--
+-- PostgreSQL 18 has sha256(bytea) built in, so no extension is involved. The digest is laid out as a
+-- UUID only because event_id is a uuid column: its version and variant nibbles carry no meaning,
+-- exactly as 0115's corrected comment on event_id says.
+--
+-- STRICT so a NULL argument yields NULL and fails loudly against the NOT NULL primary key, rather
+-- than silently hashing a shorter string. A NULL *element* inside key_parts needs no such guard,
+-- because array_to_string is given its three-argument form: the '' null_string renders a NULL
+-- element as the empty string, which is exactly what Array.prototype.join does on the TypeScript
+-- side. The two-argument form would drop the element instead and derive an id that no live emission
+-- could ever collide with, so the third argument is what makes this twin exact for key_parts built
+-- out of columns that are nullable at the schema level, and not only for NULL-free ones. It is
+-- byte-identical to the two-argument form for every input that has no NULL element.
+CREATE FUNCTION analytics.derive_server_event_id(
+  event_name TEXT,
+  key_parts TEXT[]
+)
+RETURNS UUID
+LANGUAGE SQL
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog
+AS $$
+  SELECT (
+    pg_catalog.substr(derived.digest, 1, 8)
+    || '-' || pg_catalog.substr(derived.digest, 9, 4)
+    || '-' || pg_catalog.substr(derived.digest, 13, 4)
+    || '-' || pg_catalog.substr(derived.digest, 17, 4)
+    || '-' || pg_catalog.substr(derived.digest, 21, 12)
+  )::uuid
+  FROM (
+    SELECT pg_catalog.encode(
+      pg_catalog.sha256(
+        pg_catalog.convert_to(
+          pg_catalog.array_to_string(
+            ARRAY[
+              'flashcards-open-source-app:product-analytics:server-derived-event-id:v1',
+              event_name
+            ] || key_parts,
+            ':',
+            ''
+          ),
+          'UTF8'
+        )
+      ),
+      'hex'
+    ) AS digest
+  ) AS derived;
+$$;
+
+COMMENT ON FUNCTION analytics.derive_server_event_id(TEXT, TEXT[]) IS
+  'In-database twin of deriveServerDerivedProductAnalyticsEventId in '
+  'apps/backend/src/productAnalytics/serverEvents.ts, so a SQL backfill derives exactly the event_id '
+  'the live emitter derives for the same operation and the two rows collide on the primary key '
+  'instead of double-counting the fact. The two implementations must never diverge; '
+  'apps/backend/src/productAnalytics/serverEvents.postgres.integration.ts proves they agree on fixed '
+  'vectors. A NULL element inside key_parts renders as the empty string, exactly as '
+  'Array.prototype.join does on the TypeScript side, so key_parts built out of nullable columns '
+  'needs no coalescing or filtering by the caller.';
+
+-- Every row stored so far is deleted, unconditionally, because every one of them was written under
+-- the pre-revision event catalog. What is stored is one day of low-volume, web-only rows. Everything
+-- server-derived in it is re-derived from the production tables by the later backfill, and the
+-- derivation above is what makes those reconstructed rows land on the same ids, so the only thing
+-- actually lost is the client events of that single day. Keeping them instead would mean carrying
+-- rows from a retired contract indefinitely, plus a permanent note on every query and every reader
+-- explaining which day to exclude and why, which is a worse cost than losing one day of early
+-- traffic.
+--
+-- Migrations run as the database owner (infra/aws/lib/migration-runner.ts passes
+-- DB_OWNER_SECRET_ARN), so this statement needs no grant and backend_app still has no DELETE on the
+-- table: the application role stays unable to remove an event row.
+--
+-- analytics.identity_links is deliberately not touched. A link is a fact about which anonymous
+-- identity became which account, it is still true after this revision, and the backfill depends on
+-- those links to resolve the actors of the rows it reconstructs.
+DELETE FROM analytics.product_events;

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0118_guest_sessions_platform_created_at_index.sql",
+    "0119_product_analytics_contract_revision.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0118_guest_sessions_platform_created_at_index.sql"
+    && resource.Properties?.RequiredMigration === "0119_product_analytics_contract_revision.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -98,7 +98,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
   for (const { relativePath, requiredMigration } of [
     {
       relativePath: "../../.github/workflows/aws-web-release.yml",
-      requiredMigration: "0118_guest_sessions_platform_created_at_index.sql",
+      requiredMigration: "0119_product_analytics_contract_revision.sql",
     },
     {
       relativePath: "../../scripts/deploy/bootstrap.sh",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -208,7 +208,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0118_guest_sessions_platform_created_at_index.sql",
+    "--require-migration 0119_product_analytics_contract_revision.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -238,7 +238,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0118_guest_sessions_platform_created_at_index\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0119_product_analytics_contract_revision\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -360,7 +360,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0118_guest_sessions_platform_created_at_index.sql",
+      "0119_product_analytics_contract_revision.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,


### PR DESCRIPTION
Four changes to `analytics.product_events`, each one something a later item needs in place before it can be written safely.

**`details`** is a free-form JSONB column with no schema of its own. Every other column on this table is bound to an allowlist precisely because the client fills it; this one is filled only by server-derived producers and backfills, and the ingest path has no field for it. A CHECK now enforces that instead of a comment asking for it, matching what `0114` already does for the client-owned columns on this same table. The column survives account anonymization, which is why a client-written value would outlive the deletion meant to remove it.

**`analytics.derive_server_event_id`** mirrors `deriveServerDerivedProductAnalyticsEventId` so a SQL backfill derives the same id the live emitter would. That equality is the whole no-double-counting property: the backfill and the running system collide on the primary key instead of storing the same fact twice. It is exact including for a NULL key part, because `array_to_string` is given its three-argument form and renders NULL as the empty string exactly as `Array.prototype.join` does — the case a backfill over nullable production columns would otherwise hit silently. A contract test pins both implementations to the same vectors so they cannot drift apart.

**The composite index** on `(event_name, occurred_at)` is the one the rewritten dashboard needs; `0114` defers such indexes until a concrete query asks for one, and this is that query.

**Every existing row is deleted.** It is one day of low-volume web-only events written under a catalog that no longer applies; everything server-derived in it is re-derived later from the production tables that still hold the facts, and keeping it would mean carrying a dead schema and a note explaining it forever. `analytics.identity_links` is untouched — those rows are identity facts that are still true.

After this PR the column is unused, the index inert and the function uncalled. The catalog revision that gives them work is the next item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)