### PR TITLE
Revise the analytics catalog around facts instead of interpretations

### DIFF
--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsEvent.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsEvent.kt
@@ -1,18 +1,24 @@
 package com.flashcardsopensourceapp.core.observability.analytics
 
 /**
- * Hand-written mirror of the frozen backend product-analytics catalog.
+ * Hand-written mirror of the backend product-analytics catalog.
  *
  * The server keeps a closed allowlist of event names, property names and property values, so this
  * file is deliberately type-strict: there is no `track(name, properties)` anywhere. Every event is
  * its own data class whose constructor arguments are exactly the properties the server declares,
- * which means an event that cannot satisfy the contract does not compile.
+ * which means an event missing a property or inventing one does not compile.
+ *
+ * That strictness covers event names and properties, and no longer covers every enum value here:
+ * `AnalyticsSurface` still declares `ONBOARDING`, which the catalog dropped, so an event carrying
+ * it as its `screen` compiles and is rejected `invalid_event`. No call site uses that value, and
+ * until the enum drops it a value in this file is not on its own proof that the server accepts it.
  *
  * `guest_upgrade_completed` and `catalog_deck_installed` are server-derived. A client batch that
  * contains either is rejected, so they are absent here on purpose.
  *
- * `onboarding_step_completed`, `review_session_started` and `review_session_ended` are still
- * declared by the server but retired, so no client sends them.
+ * `onboarding_step_completed`, `review_session_started` and `review_session_ended` were removed
+ * from the catalog outright, so the server no longer declares them and rejects them as unknown
+ * event names.
  */
 
 /** Named because the delivery path has to recognise a batch that carries nothing else. */

--- a/apps/backend/src/catalog/distribution/install/index.ts
+++ b/apps/backend/src/catalog/distribution/install/index.ts
@@ -411,7 +411,9 @@ export async function installCatalogPackageVersion(
   }
 
   // Emitted after the transaction committed, so the analytics row only ever reports an install the
-  // workspace actually kept.
+  // workspace actually kept. The install is observed as it happens, so the two timestamps are one
+  // moment and there is no skew to keep recoverable.
+  const observedAt = new Date();
   await emitServerDerivedProductAnalyticsEvent({
     // The install is idempotent, so a client retry replays the stored result and reaches this
     // emission again. The install id is the same across those retries, so the derived id makes the
@@ -421,7 +423,8 @@ export async function installCatalogPackageVersion(
       [normalizedWorkspaceId, result.summary.installId],
     ),
     eventName: "catalog_deck_installed",
-    occurredAt: new Date(),
+    occurredAt: observedAt,
+    serverReceivedAt: observedAt,
     userId,
     // The identity the install acted as, which for a guest install is the guest user id that the
     // guest upgrade later links to the account. Together with guestSessionId this is what keeps a
@@ -429,10 +432,14 @@ export async function installCatalogPackageVersion(
     subjectUserId: actor.subjectUserId,
     guestSessionId: actor.guestSessionId,
     workspaceId: normalizedWorkspaceId,
+    // The install names no server-stored replica or guest session row here, and the request headers
+    // that do name a platform are a client claim this row must not repeat.
+    platform: null,
     properties: {
       package_slug: packageSlug.packageSlug,
       card_count: result.summary.cardCount,
     },
+    details: null,
   });
   return result;
 }

--- a/apps/backend/src/chat/runs/analytics.ts
+++ b/apps/backend/src/chat/runs/analytics.ts
@@ -21,14 +21,22 @@ export async function recordAiMessageSentAnalytics(
   runId: string,
   actor: ChatRunActor,
 ): Promise<void> {
+  // The turn is observed as it happens, so the two timestamps are one moment and there is no skew
+  // to keep recoverable.
+  const observedAt = new Date();
   await emitServerDerivedProductAnalyticsEvent({
     eventId: deriveServerDerivedProductAnalyticsEventId("ai_message_sent", [workspaceId, runId]),
     eventName: "ai_message_sent",
-    occurredAt: new Date(),
+    occurredAt: observedAt,
+    serverReceivedAt: observedAt,
     userId,
     subjectUserId: actor.subjectUserId,
     guestSessionId: actor.guestSessionId,
     workspaceId,
+    // The run carries no server-stored platform for the actor, and the request headers that do name
+    // one are a client claim this row must not repeat.
+    platform: null,
     properties: {},
+    details: null,
   });
 }

--- a/apps/backend/src/guestAuth/index.ts
+++ b/apps/backend/src/guestAuth/index.ts
@@ -126,20 +126,29 @@ async function recordGuestUpgradeCompletedAnalytics(
     });
   }
 
+  // The upgrade is observed as it happens, so the two timestamps are one moment and there is no
+  // skew to keep recoverable.
+  const observedAt = new Date();
   await emitServerDerivedProductAnalyticsEvent({
     eventId: deriveServerDerivedProductAnalyticsEventId(
       "guest_upgrade_completed",
       [completion.guestSessionId],
     ),
     eventName: "guest_upgrade_completed",
-    occurredAt: new Date(),
+    occurredAt: observedAt,
+    serverReceivedAt: observedAt,
     userId: completion.targetUserId,
     // The guest identity the client's earlier events already carried, so the row names both sides of
     // the upgrade on its own.
     subjectUserId: completion.guestUserId,
     guestSessionId: completion.guestSessionId,
     workspaceId: completion.targetWorkspaceId,
+    // auth.guest_sessions.platform would supply this from a server-stored source, but this path
+    // does not read the session row and reporting the platform of upgrades is not what this change
+    // is for; a producer that starts reading it may fill this in.
+    platform: null,
     properties: {},
+    details: null,
   });
 }
 

--- a/apps/backend/src/productAnalytics/catalog.ts
+++ b/apps/backend/src/productAnalytics/catalog.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 
-// Frozen v1 product analytics contract. Every client mirrors this file by hand and the server
+// The product analytics contract. Every client mirrors this file by hand and the server
 // rejects anything that is not declared here, which is what keeps event_properties free of
 // personal data and therefore safe to keep after an account is anonymized. A string property must
 // declare a bounded format and not merely a length cap: a length-capped free-text property would be
 // a client-controlled channel into a column that is retained indefinitely and that account
 // anonymization deliberately keeps intact.
+//
+// schema_version stamps the catalog generation a stored row was accepted under, and it stayed 1
+// across the revision that retired the session and onboarding events and added the fact-shaped
+// ones. 0119 deleted every row written under the previous generation, so no stored row belongs to
+// it: bumping would have created a generation with no rows and no meaning. The bump is reserved for
+// the first revision after which rows survive on both sides of it.
 export const productAnalyticsSchemaVersion = 1;
 
 // event_id is the primary key of an append-only table, so time-ordered ids are the only thing that
@@ -37,16 +43,64 @@ export const productAnalyticsExperimentTokenPattern = /^[a-z0-9](?:[a-z0-9_-]{0,
 
 // Platform-independent surfaces so funnels compare across clients. Each client maps its own
 // native screens onto these and never sends a native screen name.
+//
+// The list names screens, never funnel steps, and it is the union of the screens the web, iOS and
+// Android apps actually have. One granularity rule keeps it a surface enum rather than a route
+// table: a screen earns a value when it is a destination of its own, meaning a tab, a public route,
+// a prompt a person has to answer, an abandonable step of a flow, or one of the content objects the
+// enum already names, while the app preference and account leaves that all three clients nest under
+// their settings screen collapse into `settings`. A client whose screen has no value here sends no
+// `screen` at all rather than the nearest wrong one.
+//
+// `screen` carries two readings, deliberately. On `screen_viewed` and on every other event it is
+// where the person is now. On `signin_failed` alone it is the entry point: the surface that owned
+// the sign-in control the person tapped, never `signin` itself. That set is open, because any
+// surface can grow such a control — `settings`, `progress`, `review` and `ai` carry one today — and
+// a sign-in the client cannot attribute to a surface reports no `screen` at all, so filtering the
+// event to a fixed list of surfaces silently drops entry points. Adding `signin` for the sign-in
+// screen itself does not change that, but a funnel that mixes the two readings will misread
+// `signin_failed`.
 export const productAnalyticsSurfaces = [
   "review",
   "catalog",
   "deck_detail",
-  "onboarding",
   "card_editor",
   "cards",
   "progress",
   "settings",
   "ai",
+  // Workspace content management. These sit under the settings screen on all three clients only as
+  // a routing accident: they act on the person's own decks, cards and tags, which is the same
+  // object family `cards`, `card_editor` and `deck_detail` already name.
+  "decks",
+  "deck_editor",
+  "tags",
+  // Authentication. `signin` is the sign-in screen itself whatever the client splits it into: the
+  // email step, the code step and the workspace choice are one screen here.
+  // `credential_recovery` is the gate that replaces the whole app root on iOS and Android when
+  // stored credentials can no longer be used, and is the one sign-in entry point that until now
+  // could only be reported as no screen at all.
+  "signin",
+  "credential_recovery",
+  // Our own in-app prompts, each a screen a person has to answer before anything else continues.
+  // `prompt_answered.prompt` repeats these two values verbatim, so an answer joins to its surface by
+  // equality; the two spellings have to stay identical for that join to keep working.
+  "notifications_pre_prompt",
+  "signin_after_review_prompt",
+  // The catalog import flow, whose steps are internal component state rather than routes, so the
+  // surface is the only place the step can be recorded. `catalog_import_signin` is the gate a
+  // signed-out person lands on when they open an import link; `catalog` stays the surface of the
+  // route's own loading, not-found and error states.
+  "catalog_import_signin",
+  "catalog_import_workspace",
+  "catalog_import_confirm",
+  "catalog_import_done",
+  // The two sides of a friend invitation: the screen that creates and shares one, and the landing
+  // page the invited person opens.
+  "friend_invite",
+  "friend_invite_accept",
+  // The public page that hands out the app's other platform links.
+  "share",
 ] as const;
 
 export const productAnalyticsNetworkStates = [
@@ -56,15 +110,59 @@ export const productAnalyticsNetworkStates = [
   "unknown",
 ] as const;
 
+// The clients an event can come from. `agent` is the terminal / AI-agent API and MCP client that
+// AGENTS.md lists as a supported client alongside the three apps and that had no value here at all,
+// so every event it produced was platform-less. The name is the one the repository already uses for
+// that client, in the `agent_connection` sync actor kind, in apps/backend/src/agent/, on the
+// /settings/agent-connections screen and on the GET /v1/agent discovery route, rather than a fourth
+// spelling invented for analytics. No stored platform column holds it — sync.workspace_replicas,
+// sync.installations and auth.guest_sessions each constrain platform to a set without it — so only
+// the actor kind identifies this client. This list is the stored-value domain and not the set a
+// client may claim; see productAnalyticsClientReportablePlatforms below.
+// ServerDerivedProductAnalyticsEvent carries the rules and the hazards a server-derived producer
+// works through before reporting any value at all.
 export const productAnalyticsPlatforms = [
   "ios",
   "android",
   "web",
+  "agent",
 ] as const;
 
 export type ProductAnalyticsSurface = (typeof productAnalyticsSurfaces)[number];
 export type ProductAnalyticsNetworkState = (typeof productAnalyticsNetworkStates)[number];
 export type ProductAnalyticsPlatform = (typeof productAnalyticsPlatforms)[number];
+
+// Which of the stored platform values a client request may claim for itself. The two sets are
+// deliberately different, and the difference is load-bearing rather than tidiness: the ingestion
+// route is public and human-authenticated, so a hand-posted or mis-headered batch reaches it, and
+// analytics.product_events is append-only, so a client-origin row that claimed a platform it is not
+// could never be repaired and would poison every `WHERE platform = ...` read of it afterwards.
+//
+// `agent` is the value that must stay unreachable from a request header. The agent client cannot
+// legitimately produce a client-origin row at all: its transport is api_key, which
+// isProductAnalyticsTransportAccepted refuses outright, so every client-origin row carrying
+// platform 'agent' is necessarily a false claim.
+//
+// The table is exhaustive over the stored domain rather than a second literal list, so a platform
+// added above does not compile until this question is answered for it, and no future platform can
+// become client-claimable by omission.
+const productAnalyticsClientReportablePlatformFlags = {
+  ios: true,
+  android: true,
+  web: true,
+  agent: false,
+} as const satisfies Readonly<Record<ProductAnalyticsPlatform, boolean>>;
+
+export type ProductAnalyticsClientReportablePlatform = {
+  [Platform in ProductAnalyticsPlatform]:
+    (typeof productAnalyticsClientReportablePlatformFlags)[Platform] extends true ? Platform : never;
+}[ProductAnalyticsPlatform];
+
+export const productAnalyticsClientReportablePlatforms: ReadonlyArray<ProductAnalyticsClientReportablePlatform> =
+  productAnalyticsPlatforms.filter(
+    (platform): platform is ProductAnalyticsClientReportablePlatform =>
+      productAnalyticsClientReportablePlatformFlags[platform],
+  );
 
 export type ProductAnalyticsPropertyValue = string | number;
 export type ProductAnalyticsEventProperties = Readonly<Record<string, ProductAnalyticsPropertyValue>>;
@@ -78,22 +176,39 @@ type ProductAnalyticsPropertySpec =
   // client that writes -1 or 1.5 cannot be repaired afterwards; the contract admits neither.
   | Readonly<{ kind: "nonNegativeInteger" }>;
 
-type ProductAnalyticsEventSpec = Readonly<{
-  // Emitted by the backend from its own observation. Client ingest rejects these outright, so a
-  // client can never forge an outcome the server never saw, and the server-side emission path is
-  // the only producer of the row.
-  serverOnly: boolean;
-  // A required surface, carried by the event's own screen field rather than duplicated into properties.
-  requiresScreen: boolean;
+type ProductAnalyticsEventSpecProperties = Readonly<{
   properties: Readonly<Record<string, ProductAnalyticsPropertySpec>>;
 }>;
+
+// serverOnly and requiresScreen are mutually exclusive, and the union below is what makes the
+// combination unwritable rather than merely wrong. The backend has no surface of its own to report,
+// so createServerDerivedProductAnalyticsRow stores screen NULL for every server-derived row; a
+// server-only entry that also required a surface would fail the writer's catalog assertion, and
+// emitServerDerivedProductAnalyticsEvent turns that throw into a Sentry warning, so every row of
+// that event would be dropped with nothing visible at ingest. A compile error on the catalog entry
+// is the only form of that failure a person can act on.
+type ProductAnalyticsEventSpec = ProductAnalyticsEventSpecProperties &
+  (
+    // Emitted by the backend from its own observation. Client ingest rejects these outright, so a
+    // client can never forge an outcome the server never saw, and the server-side emission path is
+    // the only producer of the row.
+    | Readonly<{ serverOnly: true; requiresScreen: false }>
+    // requiresScreen is a required surface, carried by the event's own screen field rather than
+    // duplicated into properties.
+    | Readonly<{ serverOnly: false; requiresScreen: boolean }>
+  );
 
 export const productAnalyticsEventCatalog = {
   app_opened: {
     serverOnly: false,
     requiresScreen: false,
     properties: {
-      launch_type: { kind: "enum", values: ["cold", "warm"] },
+      // `unknown` is not a client value: a live client always knows whether it cold- or
+      // warm-started. It exists because a day reconstructed from stored activity long after the
+      // fact cannot know which it was, and inventing either would be a lie. The property stays
+      // required so "we do not know" is a stored fact rather than an absent key that a reader
+      // cannot tell apart from a client that failed to send one.
+      launch_type: { kind: "enum", values: ["cold", "warm", "unknown"] },
     },
   },
   screen_viewed: {
@@ -101,15 +216,30 @@ export const productAnalyticsEventCatalog = {
     requiresScreen: true,
     properties: {},
   },
-  onboarding_step_completed: {
+  // Our own in-app prompts, which are ours to decide when to show. The OS-level result of the
+  // permission dialog a person may then be handed is a separate event, because a person can accept
+  // this prompt and still deny the system one. `prompt` is spelled exactly as the prompt's own
+  // surface above, so the answer joins to the surface without a mapping.
+  prompt_answered: {
     serverOnly: false,
     requiresScreen: false,
     properties: {
-      step: {
-        kind: "enum",
-        values: ["language", "goal", "notifications", "first_deck", "first_review", "signin"],
-      },
-      outcome: { kind: "enum", values: ["completed", "skipped"] },
+      prompt: { kind: "enum", values: ["signin_after_review_prompt", "notifications_pre_prompt"] },
+      outcome: { kind: "enum", values: ["accepted", "dismissed", "snoozed"] },
+    },
+  },
+  // The OS-level permission dialog, whose outcome the app only observes. The surface is carried by
+  // the event's own screen and never duplicated into a property: there is exactly one place a
+  // surface belongs on an event. It carries the ordinary reading above and not the entry-point one
+  // `signin_failed` has: an OS dialog can be answered after the app was backgrounded and resumed
+  // somewhere else, so the screen is where the person is when the answer is reported and reading it
+  // as the surface that asked for the permission would be wrong.
+  permission_prompt_answered: {
+    serverOnly: false,
+    requiresScreen: false,
+    properties: {
+      permission: { kind: "enum", values: ["notifications", "photo_library", "camera", "microphone"] },
+      outcome: { kind: "enum", values: ["granted", "denied", "dismissed"] },
     },
   },
   signin_failed: {
@@ -127,20 +257,23 @@ export const productAnalyticsEventCatalog = {
     requiresScreen: false,
     properties: {},
   },
-  review_session_started: {
+  // The card flip. It never reaches the backend on its own, so only a client can report it, and it
+  // is the denominator `review_answered` is read against: the gap between the two is the person who
+  // looked at the answer and walked away.
+  review_card_revealed: {
     serverOnly: false,
-    requiresScreen: false,
-    properties: {
-      deck_scope: { kind: "enum", values: ["all", "deck", "filter"] },
-    },
+    requiresScreen: true,
+    properties: {},
   },
-  review_session_ended: {
-    serverOnly: false,
+  // One graded answer, derived from the content.review_events row the answer stored rather than
+  // reported by the client, so a review answered offline is counted once it syncs and is never
+  // counted twice. The rating names the four buttons; the stored column holds them as 0..3 and the
+  // producer maps them here, because a stored integer is unreadable in a query five months later.
+  review_answered: {
+    serverOnly: true,
     requiresScreen: false,
     properties: {
-      end_reason: { kind: "enum", values: ["completed", "abandoned", "interrupted"] },
-      answered_count: { kind: "nonNegativeInteger" },
-      duration_ms: { kind: "nonNegativeInteger" },
+      rating: { kind: "enum", values: ["again", "hard", "good", "easy"] },
     },
   },
   review_answer_failed: {
@@ -159,6 +292,45 @@ export const productAnalyticsEventCatalog = {
         values: ["cards", "deck_detail", "review", "ai", "quick_action"],
       },
     },
+  },
+  // The content facts, each derived from the row the write actually left behind rather than from
+  // the client that intended it. An offline-first client queues a write and syncs it later, so the
+  // server is the only place that knows a card or a deck really exists; `card_create_started` above
+  // stays a client event precisely because it reports the intent, which is the other half of the
+  // pair. Carrying no properties is deliberate: the row is the fact, and anything describing what
+  // was written would be content a person typed.
+  card_created: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
+  },
+  card_updated: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
+  },
+  deck_created: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
+  },
+  deck_updated: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
+  },
+  friend_invitation_created: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
+  },
+  // One event per directed friendship row, so an accepted invitation produces two: the inviter and
+  // the accepter each gained a friend, and each sees that when looking only at their own events.
+  // Emitting one event for the pair would leave one of the two people with no record of it.
+  friendship_created: {
+    serverOnly: true,
+    requiresScreen: false,
+    properties: {},
   },
   ai_message_sent: {
     serverOnly: true,
@@ -228,7 +400,7 @@ function createPropertySchema(spec: ProductAnalyticsPropertySpec) {
 }
 
 function createPropertiesParser(
-  spec: ProductAnalyticsEventSpec,
+  spec: ProductAnalyticsEventSpecProperties,
 ): (value: unknown) => ProductAnalyticsEventProperties | null {
   const shape: Record<string, ReturnType<typeof createPropertySchema>> = {};
   for (const [propertyName, propertySpec] of Object.entries(spec.properties)) {

--- a/apps/backend/src/productAnalytics/serverEvents.ts
+++ b/apps/backend/src/productAnalytics/serverEvents.ts
@@ -8,24 +8,78 @@ import {
   productAnalyticsSchemaVersion,
   type ProductAnalyticsEventName,
   type ProductAnalyticsEventProperties,
+  type ProductAnalyticsPlatform,
 } from "./catalog";
-import type { ProductAnalyticsEventRow } from "./types";
+import type { ProductAnalyticsEventDetails, ProductAnalyticsEventRow } from "./types";
 import { insertProductAnalyticsEvents, insertProductAnalyticsIdentityLink } from "./writer";
 
 // A server-derived emission carries only what the backend observed itself. There is no field for
-// client context here on purpose: the row below leaves every client-owned column NULL, and
-// product_events_client_columns_shape rejects the row if it ever stops doing so.
+// client context here on purpose: the row below leaves client_occurred_at, client_sent_at,
+// session_id and anonymous_id NULL, and product_events_client_columns_shape rejects the row if it
+// ever stops doing so.
+//
+// platform is the one field that describes a client, and it is not a hole in that rule. What the
+// rule forbids is a platform a client request body claimed: a client able to name its own platform
+// on a server-derived row could attribute the backend's own observation to any platform it liked,
+// and the table is append-only, so that could never be repaired. A producer therefore reads it only
+// from data the server itself stored.
+//
+// The field is optional, and null is always a correct answer. A producer that cannot justify a
+// value passes null, and there is no safe default it may reach for instead. Both outcomes have a
+// cost and they are not symmetric: null leaves the row out of "daily active users by platform",
+// while a guess files it under a platform it never had, permanently, on an append-only table. Each
+// producer therefore justifies its own derivation at its own call site, against the rows it
+// actually reads, and this comment is a list of hazards rather than a mapping to copy.
+//
+// The hard requirement, and the reason this comment exists at all: a producer must never read
+// sync.workspace_replicas.platform without reading actor_kind on the same row. The column is
+// constrained to ios, android, web and system, and more than one actor kind stores a value in it
+// that does not describe a client device at all, so the column on its own cannot tell a device
+// apart from a backend actor. Known hazards, as examples and not as the answer for every actor
+// kind:
+//   - agent_connection stores 'web' (apps/backend/src/agent/syncIdentity.ts) even though the client
+//     is the machine API and not a browser, so the column names the wrong client outright.
+//   - ai_chat stores whatever the chat tool layer passed, and both production call sites in
+//     apps/backend/src/chat/openai/tools/tools.ts hardcode "web". The value describes nothing about
+//     the device the person was on: ai_chat is not a platform source, and a producer passes null
+//     unless it can justify a value from something other than this column.
+//   - workspace_seed and workspace_reset store 'system', which is no client at all.
+// A producer that cannot name the one replica row behind the fact has an additional problem before
+// any of this: a lookup by workspace alone can return an unrelated replica, so it passes null
+// rather than choosing among the workspace's replicas.
+//
+// auth.guest_sessions.platform is the one column that is safe to read directly:
+// guest_sessions_platform_check admits ios, android and web and nothing else, so it never holds a
+// non-client value. It is nullable for pre-1.7.0 mobile clients, and that null passes through
+// unchanged.
+//
+// No stored platform column anywhere holds `agent` — not sync.workspace_replicas.platform, not
+// sync.installations.platform, not auth.guest_sessions.platform. A producer that wants to report
+// the machine API client must therefore derive it from the actor kind and can never read it out of
+// a column.
 export type ServerDerivedProductAnalyticsEvent = Readonly<{
   // Chosen by the producer so an operation that can be replayed can derive a stable id and be
   // counted once, because the writer deduplicates on event_id.
   eventId: string;
   eventName: ProductAnalyticsEventName;
+  // When the fact happened, and when the backend learned of it. A producer that observes both,
+  // such as a backfill or anything reading a row a client synced later, passes both, so the skew
+  // between them stays recoverable as their difference. A producer that observes the fact as it
+  // happens passes the same value twice, which is what every producer did before these were two
+  // separate fields.
   occurredAt: Date;
+  serverReceivedAt: Date;
   userId: string | null;
   subjectUserId: string | null;
   guestSessionId: string | null;
   workspaceId: string | null;
+  platform: ProductAnalyticsPlatform | null;
   properties: ProductAnalyticsEventProperties;
+  // Free-form provenance about how this row was produced, such as the production table a
+  // reconstructed fact was read from. Nothing that identifies a person may go here: the column
+  // survives account anonymization untouched, so anything person-linked would outlive the deletion
+  // meant to remove it.
+  details: ProductAnalyticsEventDetails | null;
 }>;
 
 // Folded into every derived id, and part of no request or response. Without it an id is a pure
@@ -86,7 +140,10 @@ function createServerDerivedProductAnalyticsRow(
     clientSentAt: null,
     sessionId: null,
     anonymousId: null,
-    platform: null,
+    // The exception, and only because the producer read it from a source the server stored itself.
+    // See the invariant on ServerDerivedProductAnalyticsEvent: a platform a client request body
+    // claimed must never reach this column on a server-derived row.
+    platform: event.platform,
     appVersion: null,
     osVersion: null,
     deviceModel: null,
@@ -95,8 +152,9 @@ function createServerDerivedProductAnalyticsRow(
     country: null,
     networkState: null,
     // server_received_at anchors the skew correction of a client batch. A server-derived row has no
-    // client clock to correct, so it repeats the time the backend observed the event.
-    serverReceivedAt: event.occurredAt,
+    // client clock to correct, so here it records when the backend learned of the fact instead, and
+    // the two are equal for every producer that learns of it as it happens.
+    serverReceivedAt: event.serverReceivedAt,
     occurredAt: event.occurredAt,
     userId: event.userId,
     subjectUserId: event.subjectUserId,
@@ -104,14 +162,17 @@ function createServerDerivedProductAnalyticsRow(
     trustLevel: "server_derived",
     guestSessionId: event.guestSessionId,
     workspaceId: event.workspaceId,
-    // No catalog event the backend emits itself is defined around a surface, and the backend has no
-    // surface of its own to report.
+    // The backend has no surface of its own to report, so every server-derived row leaves this
+    // NULL. That is not a property of today's catalog: ProductAnalyticsEventSpec makes serverOnly
+    // together with requiresScreen unwritable, so no catalog entry the backend emits itself can
+    // ever be defined around a surface.
     screen: null,
     eventProperties: event.properties,
     // Experiment assignments are client state that was active at event time. The backend does not
     // observe them, and guessing them would misattribute the outcome to a variant.
     experimentAssignments: {},
     requestId: null,
+    details: event.details,
   };
 }
 

--- a/apps/backend/src/productAnalytics/types.ts
+++ b/apps/backend/src/productAnalytics/types.ts
@@ -9,6 +9,23 @@ import type {
 
 export type ProductAnalyticsOrigin = "client" | "server" | "backfill";
 
+// The details column is schema-less by design, so this is a JSON object type rather than a declared
+// shape. It is spelled out instead of using unknown to keep out the values JSON.stringify silently
+// drops — undefined, functions, symbols. It is a type and not a runtime guarantee about every value
+// it admits: NaN and the infinities are `number` and serialize as null, and a value that references
+// itself still throws inside the writer's transaction. Unlike event_properties, this column is never
+// mirrored by a client and never written by one: 0119 documents it as derivation provenance and
+// product_events_details_client_shape keeps it NULL on every client-origin row.
+export type ProductAnalyticsDetailValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ReadonlyArray<ProductAnalyticsDetailValue>
+  | Readonly<{ [key: string]: ProductAnalyticsDetailValue }>;
+
+export type ProductAnalyticsEventDetails = Readonly<Record<string, ProductAnalyticsDetailValue>>;
+
 export type ProductAnalyticsTrustLevel =
   | "server_derived"
   | "authenticated_client"
@@ -89,6 +106,12 @@ export type ProductAnalyticsEventRow = Readonly<{
   eventProperties: ProductAnalyticsEventProperties;
   experimentAssignments: ProductAnalyticsExperimentAssignments;
   requestId: string | null;
+  // How the row itself was produced, not what was observed. Server-derived producers and backfills
+  // may write it; a client-origin row always leaves it NULL, which
+  // product_events_details_client_shape enforces and which the ingest path has no field to break.
+  // Its size is bounded by product_events_details_shape, on the jsonb rendering rather than on this
+  // value, so the bound stays where the rendering it measures lives.
+  details: ProductAnalyticsEventDetails | null;
 }>;
 
 // server_derived comes from the two places the backend observes the pair itself: the guest upgrade,

--- a/apps/backend/src/productAnalytics/validation.ts
+++ b/apps/backend/src/productAnalytics/validation.ts
@@ -70,6 +70,7 @@ const serverOwnedEventFields: ReadonlySet<string> = new Set([
   "country",
   "requestId",
   "request_id",
+  "details",
 ]);
 
 // Postgres compares uuid values case-insensitively and returns them canonically lowercased, so every

--- a/apps/backend/src/productAnalytics/writer.postgres.integration.ts
+++ b/apps/backend/src/productAnalytics/writer.postgres.integration.ts
@@ -46,6 +46,7 @@ type StoredEventRow = Readonly<{
   event_properties: Readonly<Record<string, unknown>>;
   experiment_assignments: Readonly<Record<string, unknown>>;
   request_id: string | null;
+  details: Readonly<Record<string, unknown>> | null;
 }>;
 
 type StoredIdentityLinkRow = Readonly<{
@@ -83,7 +84,8 @@ const storedEventColumns = `
   screen,
   event_properties,
   experiment_assignments,
-  request_id
+  request_id,
+  details
 `;
 
 function requireOwnerDatabaseUrl(): string {
@@ -114,11 +116,15 @@ const slugPropertyEventId = createEventId();
 const redeliveredBatchEventId = createEventId();
 
 // Every optional column carries a value, so the uuid, text, smallint, timestamptz and jsonb casts are
-// all exercised with a real value at least once.
+// all exercised with a real value at least once. details is the one exception it cannot make: every
+// row in this batch is client-origin, and product_events_details_client_shape requires that column
+// to be NULL on exactly those rows.
 const fullyPopulatedRow: ProductAnalyticsEventRow = {
   eventId: fullyPopulatedEventId,
   schemaVersion: productAnalyticsSchemaVersion,
-  eventName: "review_session_ended",
+  // Carries both an enum and a counter property, so the jsonb cast is exercised with a mixed
+  // payload rather than with strings alone.
+  eventName: "analytics_events_dropped",
   origin: "client",
   backfillId: null,
   clientOccurredAt: new Date("2026-08-27T10:14:00.000Z"),
@@ -142,13 +148,17 @@ const fullyPopulatedRow: ProductAnalyticsEventRow = {
   country: null,
   networkState: "wifi",
   screen: "review",
-  eventProperties: { end_reason: "completed", answered_count: 12, duration_ms: 41_250 },
+  eventProperties: { reason: "queue_overflow", count: 12 },
   experimentAssignments: { onboarding_v2: "variant_b", review_order: "interleaved" },
   requestId,
+  // details is the one nullable jsonb column, and a client-origin row is exactly the case
+  // product_events_details_client_shape requires it to be NULL for.
+  details: null,
 };
 
-// The mirror image: every optional uuid and text column is NULL and both jsonb columns are empty
-// objects, which is the row shape a guest client with no workspace and no device context produces.
+// The mirror image: every optional uuid and text column is NULL and the two non-nullable jsonb
+// columns are empty objects, which is the row shape a guest client with no workspace and no device
+// context produces.
 const minimalRow: ProductAnalyticsEventRow = {
   eventId: minimalEventId,
   schemaVersion: productAnalyticsSchemaVersion,
@@ -180,6 +190,7 @@ const minimalRow: ProductAnalyticsEventRow = {
   eventProperties: {},
   experimentAssignments: {},
   requestId: null,
+  details: null,
 };
 
 const slugPropertyRow: ProductAnalyticsEventRow = {
@@ -212,6 +223,7 @@ const slugPropertyRow: ProductAnalyticsEventRow = {
   eventProperties: { package_slug: "spanish-basics" },
   experimentAssignments: {},
   requestId,
+  details: null,
 };
 
 const redeliveredBatchRow: ProductAnalyticsEventRow = {
@@ -262,7 +274,7 @@ test("the product analytics writer stores a batch, dedupes a redelivery, and lin
     const [storedFullyPopulated, storedMinimal, storedSlugProperty] = stored.rows;
     assert.equal(storedFullyPopulated?.event_id, fullyPopulatedEventId);
     assert.equal(storedFullyPopulated?.schema_version, productAnalyticsSchemaVersion);
-    assert.equal(storedFullyPopulated?.event_name, "review_session_ended");
+    assert.equal(storedFullyPopulated?.event_name, "analytics_events_dropped");
     assert.equal(storedFullyPopulated?.origin, "client");
     assert.equal(storedFullyPopulated?.trust_level, "authenticated_client");
     // identity_state and ingested_at are owned by the database and are never sent by the writer.
@@ -284,17 +296,18 @@ test("the product analytics writer stores a batch, dedupes a redelivery, and lin
       fullyPopulatedRow.clientOccurredAt?.getTime(),
     );
     assert.equal(storedFullyPopulated?.client_sent_at?.getTime(), clientSentAt.getTime());
-    // The two jsonb casts are the parameter paths most likely to surprise, so both columns are read
-    // back as objects rather than as text.
+    // The three jsonb casts are the parameter paths most likely to surprise, so all three columns
+    // are read back as values rather than as text. details is the one that carries a NULL element
+    // in its jsonb[] parameter, which is the shape every row written today has.
     assert.deepEqual(storedFullyPopulated?.event_properties, {
-      end_reason: "completed",
-      answered_count: 12,
-      duration_ms: 41_250,
+      reason: "queue_overflow",
+      count: 12,
     });
     assert.deepEqual(storedFullyPopulated?.experiment_assignments, {
       onboarding_v2: "variant_b",
       review_order: "interleaved",
     });
+    assert.equal(storedFullyPopulated?.details, null);
 
     assert.equal(storedSlugProperty?.event_id, slugPropertyEventId);
     assert.deepEqual(storedSlugProperty?.event_properties, { package_slug: "spanish-basics" });

--- a/apps/backend/src/productAnalytics/writer.ts
+++ b/apps/backend/src/productAnalytics/writer.ts
@@ -71,6 +71,14 @@ const productAnalyticsInsertColumns: ReadonlyArray<ProductAnalyticsInsertColumn>
     readValue: (row) => JSON.stringify(row.experimentAssignments),
   },
   { columnName: "request_id", columnType: "text", readValue: (row) => row.requestId },
+  // The only nullable jsonb column: event_properties and experiment_assignments are always objects,
+  // while details is absent on every client-origin row and on every server-derived row whose
+  // producer has no provenance to record, so this parameter carries NULL elements in its jsonb[].
+  {
+    columnName: "details",
+    columnType: "jsonb",
+    readValue: (row) => (row.details === null ? null : JSON.stringify(row.details)),
+  },
 ];
 
 // unnest keeps the parameter count and the query plan stable no matter how many events a batch

--- a/apps/backend/src/routes/productAnalytics.ts
+++ b/apps/backend/src/routes/productAnalytics.ts
@@ -4,9 +4,9 @@ import {
   findProductAnalyticsEventDefinition,
   isPlainObject,
   isProductAnalyticsEventIdVersionValid,
-  productAnalyticsPlatforms,
+  productAnalyticsClientReportablePlatforms,
   productAnalyticsSchemaVersion,
-  type ProductAnalyticsPlatform,
+  type ProductAnalyticsClientReportablePlatform,
 } from "../productAnalytics/catalog";
 import {
   validateProductAnalyticsBatch,
@@ -171,7 +171,7 @@ type ContractViolationCapture = Readonly<{
 }> & ProductAnalyticsPropertyDescription;
 
 type ProductAnalyticsRequestFacts = Readonly<{
-  platform: ProductAnalyticsPlatform | null;
+  platform: ProductAnalyticsClientReportablePlatform | null;
   appVersion: string | null;
 }>;
 
@@ -238,13 +238,22 @@ function toFailureTrustLevel(requestContext: RequestContext | null): string {
   return toTrustLevel(requestContext);
 }
 
-function readClientPlatform(clientPlatform: string | null): ProductAnalyticsPlatform | null {
+// x-client-platform is a claim the request makes about itself, so it is matched against the
+// client-reportable list rather than the stored platform domain. Matching it against the domain
+// would let any request claim `agent`, which no client-origin row can honestly carry, on a route
+// that is public and human-authenticated and writes to an append-only table. A header outside the
+// list is recorded as absent, exactly as an unparseable app version is.
+function readClientPlatform(
+  clientPlatform: string | null,
+): ProductAnalyticsClientReportablePlatform | null {
   if (clientPlatform === null) {
     return null;
   }
 
   const platform = clientPlatform.trim().toLowerCase();
-  return productAnalyticsPlatforms.find((knownPlatform) => knownPlatform === platform) ?? null;
+  return productAnalyticsClientReportablePlatforms.find(
+    (knownPlatform) => knownPlatform === platform,
+  ) ?? null;
 }
 
 // app_version is retained for the lifetime of the row, so it is bound to a version shape instead of
@@ -646,6 +655,12 @@ function toProductAnalyticsEventRow(
     eventProperties: event.properties,
     experimentAssignments: event.experimentAssignments,
     requestId,
+    // details records how a row was derived, and a client-origin row was not derived from anything.
+    // The ingest path has no field that could set it and must never gain one:
+    // product_events_details_client_shape refuses a client row that carries it, and the column
+    // survives account anonymization untouched, which is exactly what a client-writable free-form
+    // column must never do.
+    details: null,
   };
 }
 

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
@@ -1,17 +1,23 @@
 import Foundation
 
 /**
- * Hand-written mirror of the frozen backend product analytics catalog in
+ * Hand-written mirror of the backend product analytics catalog in
  * `apps/backend/src/productAnalytics/catalog.ts`. The server rejects anything it does not declare,
  * so the client API is type-strict per event: every case carries exactly the properties the catalog
  * declares and there is deliberately no `track(name:properties:)` anywhere. A typo or an undeclared
  * property does not compile instead of becoming a silent server-side rejection.
  *
+ * That strictness covers event names and properties, and no longer covers every enum value here:
+ * `AnalyticsSurface` still declares `onboarding`, which the catalog dropped, so an event carrying
+ * it as its `screen` compiles and is rejected `invalid_event`. No call site uses that value, and
+ * until the enum drops it a value in this file is not on its own proof that the server accepts it.
+ *
  * `guest_upgrade_completed` and `catalog_deck_installed` are server-derived and are absent here on
  * purpose: a client batch that carries one is rejected `server_only_event`.
  *
- * `onboarding_step_completed`, `review_session_started` and `review_session_ended` are still
- * declared by the server but retired, so no client sends them.
+ * `onboarding_step_completed`, `review_session_started` and `review_session_ended` were removed
+ * from the catalog outright, so the server no longer declares them and rejects them as unknown
+ * event names.
  */
 enum AnalyticsEvent: Sendable, Equatable {
     case appOpened(launchType: AnalyticsLaunchType)

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -1,10 +1,16 @@
 /**
  * Hand-written mirror of the backend product analytics catalog
- * (`apps/backend/src/productAnalytics/catalog.ts`). The union is closed on `name`, so an event the
- * server would reject cannot be constructed. `guest_upgrade_completed` and `catalog_deck_installed`
- * are server-derived and deliberately absent. `onboarding_step_completed`,
- * `review_session_started` and `review_session_ended` are still declared by the server but retired,
- * so no client sends them.
+ * (`apps/backend/src/productAnalytics/catalog.ts`). The union is closed on `name`, so an event
+ * whose name the server does not declare cannot be constructed. That closure is about names alone
+ * and no longer covers the whole contract: `AnalyticsSurface` below still declares `onboarding`,
+ * which the catalog dropped, so a well-typed event carrying it as its `screen` is rejected
+ * `invalid_event`. No call site constructs that value, and until the enum drops it a value in this
+ * file is not on its own proof that the server accepts it.
+ *
+ * `guest_upgrade_completed` and `catalog_deck_installed` are server-derived and deliberately
+ * absent. `onboarding_step_completed`, `review_session_started` and `review_session_ended` were
+ * removed from the catalog outright, so the server no longer declares them and rejects them as
+ * unknown event names.
  *
  * `signin_failed` is declared but never tracked from here. The web sign-in surface is the auth
  * service's own login page on a different origin, reached by a full page navigation, so this app


### PR DESCRIPTION
**Three events leave.** `onboarding_step_completed` named a flow this product does not have. `review_session_started` / `review_session_ended` named a session, which is something a query decides rather than something that happens. No client has emitted any of them since the previous release.

**Eight arrive**, and each is a thing that occurred: a card answered, revealed, created, updated; a deck created or updated; an invitation created; a friendship created, once per side so each person's own history shows it. Sessions, funnels and cohorts become arithmetic over these — the same funnel is legitimately counted three ways, and an event that picks one forecloses the other two forever.

**The surface enum grows from 9 to 22** so `screen_viewed` can name a screen a person is actually on, including the three steps of the catalog install flow that were previously indistinguishable. `onboarding` leaves with the event that was its only user. `screen` keeps its two readings on purpose — on `signin_failed` it is where the person came from, everywhere else where they are — now written down rather than implied.

**A server-derived row can carry a platform, its own arrival time and a free-form `details` object.** The platform *derivation* is deliberately not specified here: `sync.workspace_replicas.platform` means different things for different actor kinds — an agent connection stores `web`, an `ai_chat` replica stores a hardcoded `web` that describes no device at all — so this file carries a warning with no safe default, and each producer justifies its own value against the rows it actually reads. `agent` is a valid stored platform but unreachable from any request header, since the transport that would claim it is refused at ingest and the table is append-only.

**Two shapes are now impossible to express rather than merely discouraged:** a server-only event that requires a screen, which would have thrown inside a swallowed emission and dropped every row of that event silently; and a platform added to the enum without deciding whether a client may report it.

No new event has a producer yet — those are the next three items. Ingest accepts a superset of what clients send, and rejects three names nothing sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)