### PR TITLE
Run analytics-writing integration tests on a schema that has details

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -74,7 +74,9 @@ export const boundaryDefinitions = Object.freeze([
     migrationFileName: "0119_product_analytics_contract_revision.sql",
     expectedMigrationCount: 121,
     testFiles: Object.freeze([
+      "src/catalog/distribution/install/install.postgres.integration.ts",
       "src/productAnalytics/serverEvents.postgres.integration.ts",
+      "src/productAnalytics/writer.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
@@ -82,10 +84,8 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 118,
     testFiles: Object.freeze([
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
-      "src/catalog/distribution/install/install.postgres.integration.ts",
       "src/catalog/distribution/public/public.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/cleanup/sharedProvenance.postgres.integration.ts",
-      "src/productAnalytics/writer.postgres.integration.ts",
     ]),
   }),
   Object.freeze({


### PR DESCRIPTION
`Pre-deploy checks` is failing for every commit on `main`, so nothing can deploy. The analytics writer's INSERT names the `details` column that `0119` adds, but two integration tests were still pinned to the `0116` boundary, whose schema predates it.

Only one of the two looks like an analytics test. `install.postgres.integration.ts` contains no analytics code at all — it calls `installCatalogPackageVersion`, which emits `catalog_deck_installed` four calls deeper, and the emission wrapper swallows a failed write into a warning rather than raising it. So the missing column surfaced there as an event count of `"0"` where the test expected `"1"`, with nothing naming the real cause.

That indirection is the general hazard, so the fix was derived from the write entry points rather than from the two observed failures: every test registered below `0119` was checked for a path reaching `insertProductAnalyticsEvents` through any code it exercises. Twenty-six files — two reach the writer only through a barrel re-export or a type-only import and never call it, and two genuinely emit. Those two moved.

`insertProductAnalyticsIdentityLink` is deliberately not part of this: it writes `analytics.identity_links`, which `0119` does not touch, so reaching it alone does not require the newer schema.

No `expectedMigrationCount`, test contents, writer or catalog changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)