### PR TITLE
Record friend invitations and friendships as analytics facts

### DIFF
--- a/apps/backend/src/community/analytics.ts
+++ b/apps/backend/src/community/analytics.ts
@@ -1,0 +1,115 @@
+import {
+  deriveServerDerivedProductAnalyticsEventId,
+  emitServerDerivedProductAnalyticsEvent,
+} from "../productAnalytics/serverEvents";
+
+export type FriendInvitationCreatedFact = Readonly<{
+  friendInvitationId: string;
+  inviterUserId: string;
+  // community.friend_invitations.created_at.
+  createdAt: Date;
+}>;
+
+export type FriendshipCreatedFact = Readonly<{
+  friendInvitationId: string;
+  inviterUserId: string;
+  accepterUserId: string;
+  // community.friendships.created_at. One statement inserts both directed rows, so this single
+  // reading dates both of the events below.
+  createdAt: Date;
+}>;
+
+/**
+ * Reports one friend invite link the inviter created.
+ *
+ * Every create stores a new invitation row with a fresh id, so a client that repeats the POST really
+ * did create a second link and is counted twice. Deriving the id from that row is what keeps this
+ * producer replay-safe instead: one invitation row can only ever produce one event id, and the
+ * writer's ON CONFLICT (event_id) DO NOTHING turns any second attempt at the same row into nothing.
+ */
+export async function recordFriendInvitationCreatedAnalytics(
+  invitation: FriendInvitationCreatedFact,
+): Promise<void> {
+  await emitServerDerivedProductAnalyticsEvent({
+    eventId: deriveServerDerivedProductAnalyticsEventId(
+      "friend_invitation_created",
+      [invitation.friendInvitationId],
+    ),
+    eventName: "friend_invitation_created",
+    // The row's own created_at is the moment the backend created it, so the two timestamps are one
+    // moment and there is no skew to keep recoverable. Reading the Node clock for the second one
+    // would file the difference between two machines' clocks as if it were skew.
+    occurredAt: invitation.createdAt,
+    serverReceivedAt: invitation.createdAt,
+    userId: invitation.inviterUserId,
+    // The routes take only signed-in human transport, so there is no guest identity behind this
+    // fact that user_id does not already name.
+    subjectUserId: null,
+    guestSessionId: null,
+    // community.friend_invitations is account-scoped and names no workspace.
+    workspaceId: null,
+    // No column the server stored names a device here. An invitation belongs to an account and not
+    // to a workspace, so there is no sync.workspace_replicas row to read even carefully, and the
+    // route rejects guest transport, so auth.guest_sessions — the one platform column that is safe
+    // to read directly — has no row for this request either. The request headers do name a platform
+    // and are a client claim this row must not repeat.
+    platform: null,
+    properties: {},
+    details: null,
+  });
+}
+
+/**
+ * Reports one accepted invitation as the two directed community.friendships rows it inserted.
+ *
+ * Both people gained a friend and each of them sees that when looking only at their own events, so
+ * the sum across users stays twice the number of pairs, which is what the admin dashboard's
+ * cumulative friend-connections panel already counts off community.friendships.
+ *
+ * The inviter's row is the first event in this system attributed to somebody who did not make the
+ * request. user_id is still a real account the backend resolved itself, so account deletion still
+ * sweeps it by user_id like every other row.
+ *
+ * Ending a friendship emits nothing because the backend has no delete path for community.friendships
+ * today, which makes that cumulative chart a running sum that stops being correct the day one is
+ * added.
+ */
+export async function recordFriendshipCreatedAnalytics(
+  friendship: FriendshipCreatedFact,
+): Promise<void> {
+  // The accepter first because the request is theirs. Each emission swallows its own failure, so the
+  // inviter's event is still attempted when the accepter's write is the one that is lost.
+  await emitFriendshipCreatedForViewer(friendship, friendship.accepterUserId);
+  await emitFriendshipCreatedForViewer(friendship, friendship.inviterUserId);
+}
+
+async function emitFriendshipCreatedForViewer(
+  friendship: FriendshipCreatedFact,
+  viewerUserId: string,
+): Promise<void> {
+  await emitServerDerivedProductAnalyticsEvent({
+    // One id per directed row. An invitation is single use and a repeat acceptance is refused, so
+    // this producer is reached once per row; deriving the id from the row keeps that true for
+    // anything that reconstructs the same rows later.
+    eventId: deriveServerDerivedProductAnalyticsEventId(
+      "friendship_created",
+      [friendship.friendInvitationId, viewerUserId],
+    ),
+    eventName: "friendship_created",
+    // The database dated both directed rows itself, so this is when the friendship happened and
+    // when the backend learned of it alike.
+    occurredAt: friendship.createdAt,
+    serverReceivedAt: friendship.createdAt,
+    userId: viewerUserId,
+    subjectUserId: null,
+    guestSessionId: null,
+    // community.friendships is account-scoped and names no workspace.
+    workspaceId: null,
+    // Same derivation as the invitation above: no workspace and therefore no replica row, no guest
+    // session on these routes, and the headers are a client claim. The inviter's row makes the point
+    // twice over, because no client of theirs is involved in this moment at all.
+    platform: null,
+    properties: {},
+    details: null,
+  });
+}

--- a/apps/backend/src/community/friendInvitations.test.ts
+++ b/apps/backend/src/community/friendInvitations.test.ts
@@ -7,6 +7,10 @@ import type {
   UserDatabaseScope,
 } from "../database";
 import { HttpError } from "../shared/errors";
+import type {
+  FriendInvitationCreatedFact,
+  FriendshipCreatedFact,
+} from "./analytics";
 import {
   acceptFriendInvitationWithDependencies,
   createFriendInvitationWithDependencies,
@@ -54,6 +58,8 @@ type MutableFriendInvitationState = {
   previewRows: Array<PreviewInvitationFixtureRow>;
   acceptRows: Array<AcceptInvitationFixtureRow>;
   existingFriendDisplayName: string | null;
+  invitationAnalytics: Array<FriendInvitationCreatedFact>;
+  friendshipAnalytics: Array<FriendshipCreatedFact>;
   operationOrder: Array<string>;
   queries: Array<RecordedQuery>;
   scopes: Array<UserDatabaseScope>;
@@ -61,9 +67,12 @@ type MutableFriendInvitationState = {
   requestedTokenByteCounts: Array<number>;
 };
 
+const createdAt = new Date("2026-06-15T10:00:00.000Z");
 const expiresAt = new Date("2026-06-17T10:00:00.000Z");
+const friendshipCreatedAt = new Date("2026-06-16T09:00:00.000Z");
 const inviterPublicProfileId = "00000000-0000-4000-8000-0000000000a1";
 const inviteePublicProfileId = "00000000-0000-4000-8000-0000000000b2";
+const acceptedInvitationId = "00000000-0000-4000-8000-0000000000c3";
 
 function createQueryResult<Row extends QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
   return {
@@ -83,6 +92,8 @@ function createFriendInvitationState(): MutableFriendInvitationState {
     previewRows: [],
     acceptRows: [],
     existingFriendDisplayName: null,
+    invitationAnalytics: [],
+    friendshipAnalytics: [],
     operationOrder: [],
     queries: [],
     scopes: [],
@@ -123,13 +134,18 @@ function createFriendInvitationExecutor(state: MutableFriendInvitationState): Da
 
       if (text.startsWith("INSERT INTO community.friend_invitations")) {
         state.operationOrder.push("insert");
+        const friendInvitationId = readStringParam(params, 0, "friendInvitationId");
         state.createdInvitations.push({
-          invitationId: readStringParam(params, 0, "friendInvitationId"),
+          invitationId: friendInvitationId,
           inviterUserId: readStringParam(params, 1, "inviterUserId"),
           inviteTokenHash: readStringParam(params, 2, "inviteTokenHash"),
           inviteeDisplayName: readStringParam(params, 3, "inviteeDisplayName"),
         });
-        return createQueryResult([{ expires_at: expiresAt }]) as unknown as pg.QueryResult<Row>;
+        return createQueryResult([{
+          friend_invitation_id: friendInvitationId,
+          created_at: createdAt,
+          expires_at: expiresAt,
+        }]) as unknown as pg.QueryResult<Row>;
       }
 
       if (text.includes("community.preview_friend_invitation")) {
@@ -140,6 +156,25 @@ function createFriendInvitationExecutor(state: MutableFriendInvitationState): Da
       if (text.includes("community.accept_friend_invitation")) {
         state.operationOrder.push("accept");
         return createQueryResult(state.acceptRows) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text === "SAVEPOINT friendship_analytics_fact") {
+        state.operationOrder.push("savepoint");
+        return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text === "RELEASE SAVEPOINT friendship_analytics_fact") {
+        state.operationOrder.push("release_savepoint");
+        return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("created_from_invitation_id")) {
+        state.operationOrder.push("friendship_fact");
+        return createQueryResult([{
+          friend_user_id: "user-inviter",
+          created_from_invitation_id: acceptedInvitationId,
+          created_at: friendshipCreatedAt,
+        }]) as unknown as pg.QueryResult<Row>;
       }
 
       if (text.includes("FROM community.friendships")) {
@@ -181,6 +216,12 @@ function createFriendInvitationDependencies(
         userId: state.currentProfileUserId,
         publicProfileId: "00000000-0000-4000-8000-000000000001",
       };
+    },
+    recordFriendInvitationCreatedAnalyticsFn: async (invitation) => {
+      state.invitationAnalytics.push(invitation);
+    },
+    recordFriendshipCreatedAnalyticsFn: async (friendship) => {
+      state.friendshipAnalytics.push(friendship);
     },
     randomBytesFn: (byteCount) => {
       state.requestedTokenByteCounts.push(byteCount);
@@ -225,6 +266,11 @@ test("createFriendInvitation stores only the token hash and returns the raw toke
   assert.deepEqual(state.scopes, [{ userId: "user-1" }]);
   assert.deepEqual(state.operationOrder, ["ensure", "lock", "count", "insert"]);
   assert.deepEqual(state.requestedTokenByteCounts, [friendInviteTokenByteLength]);
+  assert.deepEqual(state.invitationAnalytics, [{
+    friendInvitationId: "00000000-0000-4000-8000-000000000099",
+    inviterUserId: "user-1",
+    createdAt,
+  }]);
 
   const createdInvitation = state.createdInvitations[0];
   assert.notEqual(createdInvitation, undefined);
@@ -306,8 +352,25 @@ test("acceptFriendInvitation returns accepted after ensuring the invitee public 
 
   assert.deepEqual(response, { status: "accepted" });
   assert.deepEqual(state.scopes, [{ userId: "user-1" }]);
-  assert.deepEqual(state.operationOrder, ["ensure", "accept"]);
+  // The analytics-only read is bracketed by its savepoint, so a failure of it can be swallowed
+  // without leaving the acceptance's transaction aborted.
+  assert.deepEqual(state.operationOrder, [
+    "ensure",
+    "accept",
+    "savepoint",
+    "friendship_fact",
+    "release_savepoint",
+  ]);
   assert.deepEqual(state.queries[0]?.params, [hashFriendInviteToken("raw-token"), "Alex"]);
+  assert.deepEqual(state.queries[2]?.params, ["user-1", inviterPublicProfileId]);
+  // One fact naming both directed community.friendships rows, so the producer emits one event for
+  // the accepter and one for the inviter who did not make this request.
+  assert.deepEqual(state.friendshipAnalytics, [{
+    friendInvitationId: acceptedInvitationId,
+    inviterUserId: "user-inviter",
+    accepterUserId: "user-1",
+    createdAt: friendshipCreatedAt,
+  }]);
 });
 
 test("acceptFriendInvitation rejects self invite links with a clear typed error", async () => {
@@ -361,6 +424,7 @@ test("acceptFriendInvitation returns the existing stored display name for alread
     existingFriendDisplayName: "Stored Alex",
   });
   assert.deepEqual(state.operationOrder, ["ensure", "accept", "existing_friend"]);
+  assert.deepEqual(state.friendshipAnalytics, []);
 });
 
 test("acceptFriendInvitation maps inactive and already-accepted links to inactive", async () => {

--- a/apps/backend/src/community/friendInvitations.ts
+++ b/apps/backend/src/community/friendInvitations.ts
@@ -6,8 +6,19 @@ import {
   type SqlValue,
   type UserDatabaseScope,
 } from "../database";
+import { getDatabaseErrorFields } from "../database/transient";
 import { unsafeQuery } from "../database/unsafe";
+import {
+  captureBackendWarning,
+  createBackendObservationScope,
+} from "../observability/sentry";
 import { HttpError } from "../shared/errors";
+import {
+  recordFriendInvitationCreatedAnalytics,
+  recordFriendshipCreatedAnalytics,
+  type FriendInvitationCreatedFact,
+  type FriendshipCreatedFact,
+} from "./analytics";
 import {
   ensurePublicProfileIdForCurrentUserInExecutor,
   type CurrentUserPublicProfileId,
@@ -17,6 +28,10 @@ export const activeFriendInvitationLimit = 20;
 export const friendInvitationDisplayNameMaxLength = 30;
 export const friendInviteTokenByteLength = 32;
 export const friendInviteUrlBase = "https://app.flashcards-open-source-app.com/invite";
+
+// A savepoint name is an identifier and cannot be parameterized, so it is this fixed literal and
+// nothing a request supplied ever reaches the statements built from it.
+const friendshipAnalyticsFactSavepoint = "friendship_analytics_fact";
 
 const displayNameControlCharacterPattern = /[\u0000-\u001F\u007F]/u;
 
@@ -59,10 +74,18 @@ type EnsureCurrentUserPublicProfileFn = (
   executor: DatabaseExecutor,
 ) => Promise<CurrentUserPublicProfileId>;
 
+type RecordFriendInvitationCreatedAnalyticsFn = (
+  invitation: FriendInvitationCreatedFact,
+) => Promise<void>;
+
+type RecordFriendshipCreatedAnalyticsFn = (friendship: FriendshipCreatedFact) => Promise<void>;
+
 export type FriendInvitationServiceDependencies = Readonly<{
   transactionWithUserScopeFn: UserScopedTransactionFn;
   unsafeQueryFn: UnsafeQueryFn;
   ensureCurrentUserPublicProfileFn: EnsureCurrentUserPublicProfileFn;
+  recordFriendInvitationCreatedAnalyticsFn: RecordFriendInvitationCreatedAnalyticsFn;
+  recordFriendshipCreatedAnalyticsFn: RecordFriendshipCreatedAnalyticsFn;
   randomBytesFn: (byteCount: number) => Buffer;
   randomUuidFn: () => string;
   inviteUrlBase: string;
@@ -74,7 +97,21 @@ type ActiveInvitationCountRow = pg.QueryResultRow & Readonly<{
 }>;
 
 type CreatedInvitationRow = pg.QueryResultRow & Readonly<{
+  friend_invitation_id: string;
+  created_at: Date | string;
   expires_at: Date | string;
+}>;
+
+type CreatedFriendshipRow = pg.QueryResultRow & Readonly<{
+  friend_user_id: string;
+  created_from_invitation_id: string;
+  created_at: Date | string;
+}>;
+
+type InsertedFriendInvitation = Readonly<{
+  friendInvitationId: string;
+  createdAt: Date;
+  expiresAt: string;
 }>;
 
 type PreviewInvitationRow = pg.QueryResultRow & Readonly<{
@@ -96,6 +133,8 @@ export const defaultFriendInvitationServiceDependencies: FriendInvitationService
   transactionWithUserScopeFn: transactionWithUserScope,
   unsafeQueryFn: unsafeQuery,
   ensureCurrentUserPublicProfileFn: ensurePublicProfileIdForCurrentUserInExecutor,
+  recordFriendInvitationCreatedAnalyticsFn: recordFriendInvitationCreatedAnalytics,
+  recordFriendshipCreatedAnalyticsFn: recordFriendshipCreatedAnalytics,
   randomBytesFn: randomBytes,
   randomUuidFn: randomUUID,
   inviteUrlBase: friendInviteUrlBase,
@@ -144,13 +183,17 @@ function createFriendInviteUrl(inviteUrlBase: string, rawInviteToken: string): s
   return `${inviteUrlBase}/${rawInviteToken}`;
 }
 
-function normalizeTimestamp(value: Date | string, fieldName: string): string {
+function normalizeTimestampDate(value: Date | string, fieldName: string): Date {
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) {
     throw new Error(`Invalid friend invitation timestamp for ${fieldName}: ${String(value)}.`);
   }
 
-  return date.toISOString();
+  return date;
+}
+
+function normalizeTimestamp(value: Date | string, fieldName: string): string {
+  return normalizeTimestampDate(value, fieldName).toISOString();
 }
 
 function normalizeActiveInvitationCount(value: number | string): number {
@@ -218,13 +261,13 @@ async function insertFriendInvitationInExecutor(
   inviteTokenHash: string,
   inviteeDisplayName: string,
   dependencies: FriendInvitationServiceDependencies,
-): Promise<string> {
+): Promise<InsertedFriendInvitation> {
   const result = await executor.query<CreatedInvitationRow>(
     [
       "INSERT INTO community.friend_invitations",
       "(friend_invitation_id, inviter_user_id, invite_token_hash, invitee_display_name_for_inviter, expires_at)",
       "VALUES ($1, $2, $3, $4, now() + interval '2 days')",
-      "RETURNING expires_at",
+      "RETURNING friend_invitation_id, created_at, expires_at",
     ].join(" "),
     [dependencies.randomUuidFn(), inviterUserId, inviteTokenHash, inviteeDisplayName],
   );
@@ -234,7 +277,11 @@ async function insertFriendInvitationInExecutor(
     throw new Error(`Failed to create friend invitation for inviter user ${inviterUserId}.`);
   }
 
-  return normalizeTimestamp(row.expires_at, "expires_at");
+  return {
+    friendInvitationId: row.friend_invitation_id,
+    createdAt: normalizeTimestampDate(row.created_at, "created_at"),
+    expiresAt: normalizeTimestamp(row.expires_at, "expires_at"),
+  };
 }
 
 function assertActiveInvitationLimitNotReached(activeInvitationCount: number, activeInviteLimit: number): void {
@@ -249,6 +296,16 @@ function assertActiveInvitationLimitNotReached(activeInvitationCount: number, ac
   );
 }
 
+/**
+ * Reads the display name an existing friendship already stores, which is the whole already_friends
+ * response.
+ *
+ * Deliberately not wrapped in the savepoint readCreatedFriendshipFactInExecutor below uses, even
+ * though the two reads sit next to each other over the same table with the same scoping. This one is
+ * product-required and its result is what the caller answers with, so a failure here has to fail the
+ * request. The savepoint next door exists only because that read serves analytics, which must never
+ * be what fails a user operation.
+ */
 async function readExistingFriendDisplayNameInExecutor(
   executor: DatabaseExecutor,
   viewerUserId: string,
@@ -273,6 +330,131 @@ async function readExistingFriendDisplayNameInExecutor(
   }
 
   return existingFriendDisplayName;
+}
+
+/**
+ * Reports one acceptance whose friendship_created events were dropped before either of them was
+ * attempted.
+ *
+ * Named after the skipped fact rather than after a failed write, because it is the opposite of
+ * product_analytics_server_event_write_failed: no row reached the writer at all. Both directed
+ * events are derived from the single row this reports on, so they are always lost together, and the
+ * acceptance itself still succeeded, which leaves this warning as the only trace either was owed.
+ */
+function captureFriendshipCreatedAnalyticsSkipped(
+  accepterUserId: string,
+  reason: "friendship_row_missing" | "friendship_row_read_failed",
+  error: unknown,
+): void {
+  const errorDetails = error === null ? null : getDatabaseErrorFields(error);
+  captureBackendWarning({
+    action: "friendship_created_analytics_skipped",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      accepterUserId,
+      // community.friendships is account-scoped, so there is no workspace, and the accept route
+      // takes only signed-in human transport, so there is no guest session to correlate this with.
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      reason,
+      sqlState: errorDetails?.sqlState ?? null,
+      errorClass: errorDetails?.errorClass ?? null,
+      errorMessage: errorDetails?.errorMessage ?? null,
+    },
+  });
+}
+
+async function selectCreatedFriendshipFactInExecutor(
+  executor: DatabaseExecutor,
+  accepterUserId: string,
+  inviterPublicProfileId: string,
+): Promise<FriendshipCreatedFact | null> {
+  const result = await executor.query<CreatedFriendshipRow>(
+    [
+      "SELECT friend_user_id, created_from_invitation_id, created_at",
+      "FROM community.friendships",
+      "WHERE viewer_user_id = $1",
+      "AND friend_public_profile_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [accepterUserId, inviterPublicProfileId],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    return null;
+  }
+
+  return {
+    friendInvitationId: row.created_from_invitation_id,
+    inviterUserId: row.friend_user_id,
+    accepterUserId,
+    createdAt: normalizeTimestampDate(row.created_at, "created_at"),
+  };
+}
+
+/**
+ * Reads the accepter's own directed friendship row, which is the only place the accepter may learn
+ * the invitation id and the inviter's user id from.
+ *
+ * community.accept_friend_invitation returns public profile ids only, and the SELECT policy on
+ * community.friend_invitations admits the inviter alone and only while accepted_at is NULL, so the
+ * invitation row is unreadable here by design. The accepter's community.friendships row carries the
+ * same two ids and is theirs to read.
+ *
+ * The read runs inside the acceptance's own transaction, which is the cheapest place those rows are
+ * readable, and the savepoint is what keeps that from coupling the acceptance to an analytics-only
+ * statement. A plain try/catch would be worse than no guard at all: these routes take the
+ * non-deadline path, whose commitTransaction issues COMMIT and reports success without inspecting
+ * the returned command, so a swallowed statement error would leave the transaction aborted and
+ * report an acceptance that Postgres had silently turned into a ROLLBACK. ROLLBACK TO SAVEPOINT
+ * clears that aborted state instead, which is what makes swallowing the failure safe here: the
+ * acceptance's own statements survive it and COMMIT still commits them.
+ */
+async function readCreatedFriendshipFactInExecutor(
+  executor: DatabaseExecutor,
+  accepterUserId: string,
+  inviterPublicProfileId: string,
+): Promise<FriendshipCreatedFact | null> {
+  // Outside the guard on purpose, as is the RELEASE below. Both can only fail on a transaction that
+  // can no longer commit anyway, and swallowing a failed SAVEPOINT would leave nothing to roll back
+  // to, which is the aborted-transaction hazard this function exists to avoid.
+  await executor.query(`SAVEPOINT ${friendshipAnalyticsFactSavepoint}`, []);
+
+  let friendship: FriendshipCreatedFact | null;
+  try {
+    friendship = await selectCreatedFriendshipFactInExecutor(
+      executor,
+      accepterUserId,
+      inviterPublicProfileId,
+    );
+  } catch (error) {
+    await executor.query(`ROLLBACK TO SAVEPOINT ${friendshipAnalyticsFactSavepoint}`, []);
+    captureFriendshipCreatedAnalyticsSkipped(accepterUserId, "friendship_row_read_failed", error);
+    return null;
+  }
+
+  await executor.query(`RELEASE SAVEPOINT ${friendshipAnalyticsFactSavepoint}`, []);
+
+  if (friendship === null) {
+    // Unreachable today: community.accept_friend_invitation inserted this exact row in this
+    // transaction before it reported the acceptance, and the read's two predicates match it exactly.
+    // It gives up the fact instead of throwing because the acceptance has already happened and
+    // analytics must never be what takes it back, so the warning is what keeps that from becoming a
+    // silent loss of both events if the premise ever stops holding.
+    captureFriendshipCreatedAnalyticsSkipped(accepterUserId, "friendship_row_missing", null);
+  }
+
+  return friendship;
 }
 
 function assertAcceptProfileIdsPresent(
@@ -330,7 +512,7 @@ export async function createFriendInvitationWithDependencies(
   assertValidActiveInviteLimit(dependencies.activeInviteLimit);
   const inviteeDisplayName = parseFriendInvitationDisplayName(input.inviteeDisplayName, "inviteeDisplayName");
 
-  return dependencies.transactionWithUserScopeFn({ userId: input.userId }, async (executor) => {
+  const created = await dependencies.transactionWithUserScopeFn({ userId: input.userId }, async (executor) => {
     const currentProfile = await dependencies.ensureCurrentUserPublicProfileFn(executor);
     assertCurrentUserProfileMatchesRequestUser(currentProfile, input.userId);
 
@@ -340,7 +522,7 @@ export async function createFriendInvitationWithDependencies(
 
     const rawInviteToken = createRawFriendInviteToken(dependencies);
     const inviteTokenHash = hashFriendInviteToken(rawInviteToken);
-    const expiresAt = await insertFriendInvitationInExecutor(
+    const invitation = await insertFriendInvitationInExecutor(
       executor,
       input.userId,
       inviteTokenHash,
@@ -349,10 +531,23 @@ export async function createFriendInvitationWithDependencies(
     );
 
     return {
-      inviteUrl: createFriendInviteUrl(dependencies.inviteUrlBase, rawInviteToken),
-      expiresAt,
+      invitation,
+      response: {
+        inviteUrl: createFriendInviteUrl(dependencies.inviteUrlBase, rawInviteToken),
+        expiresAt: invitation.expiresAt,
+      },
     };
   });
+
+  // Emitted after the transaction committed, so the row only ever reports a link the inviter really
+  // got back. The emission never throws.
+  await dependencies.recordFriendInvitationCreatedAnalyticsFn({
+    friendInvitationId: created.invitation.friendInvitationId,
+    inviterUserId: input.userId,
+    createdAt: created.invitation.createdAt,
+  });
+
+  return created.response;
 }
 
 export async function createFriendInvitation(
@@ -407,7 +602,7 @@ export async function acceptFriendInvitationWithDependencies(
   const inviterDisplayName = parseFriendInvitationDisplayName(input.inviterDisplayName, "inviterDisplayName");
   const inviteTokenHash = hashFriendInviteToken(input.rawInviteToken);
 
-  return dependencies.transactionWithUserScopeFn({ userId: input.userId }, async (executor) => {
+  const accepted = await dependencies.transactionWithUserScopeFn({ userId: input.userId }, async (executor) => {
     const currentProfile = await dependencies.ensureCurrentUserPublicProfileFn(executor);
     assertCurrentUserProfileMatchesRequestUser(currentProfile, input.userId);
 
@@ -424,8 +619,36 @@ export async function acceptFriendInvitationWithDependencies(
       throw new Error("community.accept_friend_invitation returned no row.");
     }
 
-    return mapAcceptInvitationRow(executor, input.userId, row);
+    const response = await mapAcceptInvitationRow(executor, input.userId, row);
+    if (response.status !== "accepted") {
+      return { response, friendship: null };
+    }
+
+    assertAcceptProfileIdsPresent(row);
+
+    // Read inside the acceptance's own transaction, which is the cheapest place these rows are
+    // readable, and behind a savepoint so this analytics-only read can never be what undoes the
+    // acceptance the same transaction already performed.
+    return {
+      response,
+      friendship: await readCreatedFriendshipFactInExecutor(
+        executor,
+        input.userId,
+        row.inviter_public_profile_id,
+      ),
+    };
   });
+
+  if (accepted.friendship !== null) {
+    // Emitted after the transaction committed, so the two rows only report a friendship the database
+    // kept. Both emissions never throw, so a lost analytics write cannot take the acceptance with
+    // it. One of the two is the inviter's, which makes it the first event in this system attributed
+    // to somebody who did not make the request; recordFriendshipCreatedAnalytics says why account
+    // deletion still reaches it.
+    await dependencies.recordFriendshipCreatedAnalyticsFn(accepted.friendship);
+  }
+
+  return accepted.response;
 }
 
 export async function acceptFriendInvitation(

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -106,6 +106,7 @@ export type {
   DatabaseTransientRetryDetails,
   FeedbackEmailFailureDetails,
   FeedbackEmailRetryDetails,
+  FriendshipCreatedAnalyticsSkippedDetails,
   GeneratedMediaPromotionBatchDetails,
   GlobalMetricsS3RetryDetails,
   GlobalMetricsSnapshotFailureDetails,

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -482,6 +482,19 @@ export type CatalogDeckInstalledAnalyticsSkippedDetails = Readonly<{
   errorMessage: string | null;
 }>;
 
+// A deliberate skip, not a dropped write: the acceptance committed and neither friendship_created
+// row was attempted, because the directed community.friendships row both events are derived from
+// could not be read. Reported under its own action so it never looks like
+// product_analytics_server_event_write_failed, which means the opposite - a row that was attempted
+// and rejected. friendship_row_read_failed is the savepoint-guarded read failing; the error fields
+// are null for friendship_row_missing, where the read succeeded and returned nothing.
+export type FriendshipCreatedAnalyticsSkippedDetails = Readonly<{
+  reason: "friendship_row_missing" | "friendship_row_read_failed";
+  sqlState: string | null;
+  errorClass: string | null;
+  errorMessage: string | null;
+}>;
+
 export type MigrationFailureDetails = Readonly<{
   migrationSurface: "lambda";
   operation: "run_migrations";
@@ -526,6 +539,7 @@ export type OperationsWarningEvent =
   | EventByAction<"product_analytics_server_event_write_failed", ProductAnalyticsServerEventWriteFailureDetails>
   | EventByAction<"product_analytics_identity_link_write_failed", ProductAnalyticsIdentityLinkWriteFailureDetails>
   | EventByAction<"catalog_deck_installed_analytics_skipped", CatalogDeckInstalledAnalyticsSkippedDetails>
+  | EventByAction<"friendship_created_analytics_skipped", FriendshipCreatedAnalyticsSkippedDetails>
   | (EventByAction<
     "progress_active_days_backfill_candidate_failed",
     ProgressActiveDaysBackfillCandidateFailureDetails


### PR DESCRIPTION
Creating an invite link and accepting one are now product-analytics events. An acceptance emits **two**, one per directed `community.friendships` row, so the person who sent the invitation sees a new friend in their own history even though the request came from the other side. That also keeps the sum across users equal to twice the number of pairs, which is what the existing admin chart counts.

**The accepter cannot read the invitation it just accepted.** The RLS policy admits that row to the inviter alone, and only while it is still pending. The fact therefore comes from the accepter's own friendships row, which carries the inviter, the invitation id and the timestamp together.

**That read exists only to produce analytics, so it must not be able to undo an acceptance the database already performed** — and a plain try/catch would have been *worse* than leaving it unguarded. On this path `commitTransaction` issues `COMMIT` without inspecting the result, so swallowing a failed statement would report an acceptance that Postgres had silently converted to a rollback. A savepoint is what makes swallowing safe: `ROLLBACK TO SAVEPOINT` clears the aborted state, the failure is recorded as a warning, and `COMMIT` still commits the acceptance.

The neighbouring display-name read keeps the opposite treatment on purpose — it is product-required and its result is the response, so it *should* fail the transaction. Both now say why they differ, because the difference is invisible otherwise.

Both events carry no platform. A community action has no replica behind it, and the only thing naming a platform on these routes is a request header, which is a client claim a server-derived row must not repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)