### PR TITLE
Record card and deck creation as analytics facts

### DIFF
--- a/apps/backend/src/aiTools/agentSql/batchMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.ts
@@ -17,7 +17,7 @@ import {
   type DeckFilterDefinition,
   type UpdateDeckInput,
 } from "../../decks";
-import { transactionWithWorkspaceScope } from "../../database";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/contentCreations";
 import { HttpError } from "../../shared/errors";
 import type { LegacyEffortLevel } from "../../sync/contracts/legacyEffort";
 import { isLegacyEffortLevel } from "../../sync/contracts/legacyEffort";
@@ -241,7 +241,7 @@ export async function executeSqlMutationBatch(
     context.connectionId,
   );
 
-  return transactionWithWorkspaceScope({ userId: context.userId, workspaceId: context.workspaceId }, async (executor) => {
+  return transactionWithWorkspaceScopeReportingContentCreations({ userId: context.userId, workspaceId: context.workspaceId }, async (executor) => {
     let state: MutationBatchState = {
       cards: await listCardsInExecutor(executor, context.workspaceId),
       decks: await listDecksInExecutor(executor, context.workspaceId),

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -3,6 +3,10 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../database";
+import {
+  collectContentCreation,
+  transactionWithWorkspaceScopeReportingContentCreations,
+} from "../productAnalytics/contentCreations";
 import { HttpError } from "../shared/errors";
 import {
   incomingLwwMetadataWins,
@@ -295,6 +299,15 @@ export async function upsertCardSnapshotInExecutor(
     } else {
       const insertedCard = mapCard(insertedRow);
       const changeId = await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, insertedCard);
+      // The insert above is ON CONFLICT DO NOTHING, so a returned row is a genuine creation. The
+      // conflict branch below is the one that turns out to be an upsert of a card that already
+      // existed, and the LWW-lost branch after it writes nothing at all.
+      collectContentCreation(executor, {
+        entityType: "card",
+        entityId: insertedCard.cardId,
+        workspaceId,
+        clientUpdatedAt: insertedCard.clientUpdatedAt,
+      });
 
       return {
         card: insertedCard,
@@ -369,7 +382,7 @@ export async function upsertCardSnapshot(
   input: CardSnapshotInput,
   metadata: CardMutationMetadata,
 ): Promise<CardMutationResult> {
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => (
+  return transactionWithWorkspaceScopeReportingContentCreations({ userId, workspaceId }, async (executor) => (
     upsertCardSnapshotInExecutor(executor, workspaceId, input, metadata)
   ));
 }
@@ -419,6 +432,13 @@ export async function createCardInExecutor(
 
   const card = mapCard(row);
   await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
+  // This path inserts unconditionally on a freshly minted card id, so it is always a creation.
+  collectContentCreation(executor, {
+    entityType: "card",
+    entityId: card.cardId,
+    workspaceId,
+    clientUpdatedAt: card.clientUpdatedAt,
+  });
   return card;
 }
 
@@ -428,7 +448,7 @@ export async function createCard(
   input: CreateCardInput,
   metadata: CardMutationMetadata,
 ): Promise<Card> {
-  return transactionWithWorkspaceScope(
+  return transactionWithWorkspaceScopeReportingContentCreations(
     { userId, workspaceId },
     async (executor) => createCardInExecutor(executor, workspaceId, input, metadata),
   );
@@ -441,7 +461,7 @@ export async function createCards(
 ): Promise<ReadonlyArray<Card>> {
   validateCardBatchCount(items.length);
 
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+  return transactionWithWorkspaceScopeReportingContentCreations({ userId, workspaceId }, async (executor) => {
     const createdCards: Array<Card> = [];
     for (const item of items) {
       createdCards.push(await createCardInExecutor(executor, workspaceId, item.input, item.metadata));
@@ -499,6 +519,10 @@ export async function updateCardInExecutor(
   return card;
 }
 
+// The card update and delete transactions below stay on the plain scoped transaction, because
+// updateCardInExecutor and deleteCardInExecutor write their own UPDATE against a row they already
+// required to exist and never reach the snapshot upsert's insert branch, so they can collect no
+// creation to report.
 export async function updateCard(
   userId: string,
   workspaceId: string,

--- a/apps/backend/src/catalog/distribution/install/persistence.ts
+++ b/apps/backend/src/catalog/distribution/install/persistence.ts
@@ -330,6 +330,13 @@ async function insertWorkspaceMediaAssetForCatalogInstallInExecutor(
   );
 }
 
+// An installed card is written here with this file's own SQL rather than through the card mutation
+// helpers, so it never reaches the card_created producer and no card_created row is emitted for it,
+// even though the install does record a sync.hot_changes row per card like any other write. That is
+// deliberate: installing a deck someone else authored is not authoring, and the install itself is
+// already reported once as catalog_deck_installed carrying card_count. It is written down because a
+// later backfill that reconstructs creations from sync.hot_changes would otherwise disagree with the
+// live stream by a whole deck for every install.
 async function insertWorkspaceCardForCatalogInstallInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,

--- a/apps/backend/src/decks/index.ts
+++ b/apps/backend/src/decks/index.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
   queryWithWorkspaceScopeReadOnly,
-  transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../database";
 import { HttpError } from "../shared/errors";
@@ -33,6 +32,10 @@ import {
 import type { LegacyEffortLevel } from "../sync/contracts/legacyEffort";
 import { isLegacyEffortLevel } from "../sync/contracts/legacyEffort";
 import { appendLegacyEffortTag } from "../cards/shared";
+import {
+  collectContentCreation,
+  transactionWithWorkspaceScopeReportingContentCreations,
+} from "../productAnalytics/contentCreations";
 
 type TimestampValue = Date | string;
 type ErrorFactory = (message: string) => Error;
@@ -603,7 +606,7 @@ export async function createDeck(
   input: CreateDeckInput,
   metadata: DeckMutationMetadata,
 ): Promise<Deck> {
-  return transactionWithWorkspaceScope(
+  return transactionWithWorkspaceScopeReportingContentCreations(
     { userId, workspaceId },
     async (executor) => createDeckInExecutor(executor, workspaceId, input, metadata),
   );
@@ -661,6 +664,15 @@ export async function upsertDeckSnapshotInExecutor(
     if (insertedRow !== undefined) {
       const insertedDeck = mapDeck(insertedRow);
       const changeId = await recordDeckSyncChange(executor, workspaceId, hotChangeWriteLock, insertedDeck);
+      // The insert above is ON CONFLICT DO NOTHING, so a returned row is a genuine creation. Every
+      // other branch resolves the conflict and continues as an update of a deck that already
+      // existed, which is also how deleteDeckInExecutor's soft delete reaches this function.
+      collectContentCreation(executor, {
+        entityType: "deck",
+        entityId: insertedDeck.deckId,
+        workspaceId,
+        clientUpdatedAt: insertedDeck.clientUpdatedAt,
+      });
 
       return {
         deck: insertedDeck,
@@ -757,7 +769,7 @@ export async function upsertDeckSnapshot(
   input: DeckSnapshotInput,
   metadata: DeckMutationMetadata,
 ): Promise<DeckMutationResult> {
-  return transactionWithWorkspaceScope(
+  return transactionWithWorkspaceScopeReportingContentCreations(
     { userId, workspaceId },
     async (executor) => upsertDeckSnapshotInExecutor(executor, workspaceId, input, metadata),
   );
@@ -827,6 +839,10 @@ export async function updateDeckInExecutor(
   return result.deck;
 }
 
+// The deck update and delete transactions report creations too, unlike the card ones. Both of them
+// reach upsertDeckSnapshotInExecutor, so the only thing keeping them off its insert branch is the
+// 404 they raise for a deck that is already gone; opening them the same way costs nothing and means
+// a change to that guard cannot silently stop a creation from being reported.
 export async function updateDeck(
   userId: string,
   workspaceId: string,
@@ -834,7 +850,7 @@ export async function updateDeck(
   input: UpdateDeckInput,
   metadata: DeckMutationMetadata,
 ): Promise<Deck> {
-  return transactionWithWorkspaceScope(
+  return transactionWithWorkspaceScopeReportingContentCreations(
     { userId, workspaceId },
     async (executor) => updateDeckInExecutor(executor, workspaceId, deckId, input, metadata),
   );
@@ -887,7 +903,7 @@ export async function deleteDeck(
   deckId: string,
   metadata: DeckMutationMetadata,
 ): Promise<Deck> {
-  return transactionWithWorkspaceScope(
+  return transactionWithWorkspaceScopeReportingContentCreations(
     { userId, workspaceId },
     async (executor) => deleteDeckInExecutor(executor, workspaceId, deckId, metadata),
   );
@@ -900,7 +916,7 @@ export async function createDecks(
 ): Promise<ReadonlyArray<Deck>> {
   validateDeckBatchCount(items.length);
 
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+  return transactionWithWorkspaceScopeReportingContentCreations({ userId, workspaceId }, async (executor) => {
     const createdDecks: Array<Deck> = [];
     for (const item of items) {
       createdDecks.push(await createDeckInExecutor(executor, workspaceId, item.input, item.metadata));
@@ -918,7 +934,7 @@ export async function updateDecks(
   validateDeckBatchCount(items.length);
   validateUniqueDeckIds(items.map((item) => item.deckId));
 
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+  return transactionWithWorkspaceScopeReportingContentCreations({ userId, workspaceId }, async (executor) => {
     const updatedDecks: Array<Deck> = [];
     for (const item of items) {
       updatedDecks.push(await updateDeckInExecutor(executor, workspaceId, item.deckId, item.input, item.metadata));
@@ -936,7 +952,7 @@ export async function deleteDecks(
   validateDeckBatchCount(items.length);
   validateUniqueDeckIds(items.map((item) => item.deckId));
 
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+  return transactionWithWorkspaceScopeReportingContentCreations({ userId, workspaceId }, async (executor) => {
     const deletedDeckIds: Array<string> = [];
     for (const item of items) {
       const deletedDeck = await deleteDeckInExecutor(executor, workspaceId, item.deckId, item.metadata);

--- a/apps/backend/src/guestAuth/index.ts
+++ b/apps/backend/src/guestAuth/index.ts
@@ -1,4 +1,5 @@
 import { unsafeTransaction } from "../database/unsafe";
+import { unsafeTransactionReportingContentCreations } from "../productAnalytics/contentCreations";
 import {
   deriveServerDerivedProductAnalyticsEventId,
   emitServerDerivedProductAnalyticsEvent,
@@ -158,7 +159,7 @@ export async function completeGuestUpgrade(
   selection: GuestUpgradeSelection,
   capabilities: GuestUpgradeCompleteCapabilities,
 ): Promise<GuestUpgradeCompletion> {
-  const completion = await unsafeTransaction(
+  const completion = await unsafeTransactionReportingContentCreations(
     async (executor) => completeGuestUpgradeInExecutor(
       executor,
       guestToken,
@@ -166,6 +167,16 @@ export async function completeGuestUpgrade(
       selection,
       capabilities,
     ),
+    // The merge re-creates the guest's cards and decks inside the target workspace, under the target
+    // scope, so the account that adopted them is the actor on those rows and not the guest that
+    // wrote them offline. For a card the guest had already created through the sync API that is
+    // invisible: the creation is keyed on the card id alone, so the merge's emission conflicts with
+    // the guest's original row and the fact keeps the guest identity, which resolves to the account
+    // through the upgrade link. It is only visible for a card that entered the guest workspace
+    // without ever being reported as created - a catalog install - where the merge is the first and
+    // only creation this stream ever sees for that card, and attributing it to the account that kept
+    // it is the intended answer.
+    (result) => result.targetUserId,
   );
   if (completion.outcome === "fresh_completion") {
     await recordGuestUpgradeCompletedAnalytics(completion);

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -120,6 +120,7 @@ export type {
   MultipartCompletionFailureReportBatchDetails,
   MultipartCompletionReconciliationBatchDetails,
   MultipartCompletionReconciliationTerminalFailureDetails,
+  ProductAnalyticsContentCreationDrainAbortedDetails,
   ProductAnalyticsIdentityLinkWriteFailureDetails,
   ProductAnalyticsServerEventWriteFailureDetails,
   ProgressActiveDaysBackfillCandidateFailureDetails,

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -456,11 +456,44 @@ export type FeedbackEmailFailureDetails = Readonly<{
 
 // errorClass and errorMessage describe the database failure the analytics writer wrapped, not the
 // wrapper: its own message is a fixed public string that would name every refused write the same.
+// eventName is the first event of the batch that was refused, and eventCount is how many events went
+// down with it, because the writer stores a batch or nothing. A producer that chunks an unbounded
+// number of facts raises this for the chunk that was refused, so the count is what that chunk lost
+// rather than everything the producer emitted; what the producer then did with the chunks it had not
+// reached yet is reported separately below.
 export type ProductAnalyticsServerEventWriteFailureDetails = Readonly<{
   eventName: string;
+  eventCount: number;
   sqlState: string | null;
   errorClass: string;
   errorMessage: string;
+}>;
+
+// Raised when a chunking producer stopped a drain with chunks left that it chose not to attempt. It
+// is a separate action from the write failure above because it means something the failure does not:
+// those events were never handed to the writer at all, so no
+// product_analytics_server_event_write_failed row accounts for them.
+//
+// The three counts partition everything the drain held, so a reader can see how much survived and
+// how much did not without reconstructing it from chunk sizes.
+export type ProductAnalyticsContentCreationDrainAbortedDetails = Readonly<{
+  // Which stop rule fired, because the two ask for opposite responses. "writer_refused" means the
+  // analytics writer turned a chunk down, so it is degraded or down and the failure below is the
+  // thing to read. "budget_exhausted" means every chunk it was handed was stored and the drain ran
+  // out of the wall clock its request could spare, so analytics is healthy and the drain was simply
+  // too large for one request - the answer there is a smaller transaction or a queue, not a writer
+  // fix.
+  reason: "writer_refused" | "budget_exhausted";
+  // Stored by the chunks that succeeded before the stop. Already committed and not at risk.
+  storedEventCount: number;
+  // The refused chunk itself, reported with its error by the write failure above. Always zero on a
+  // "budget_exhausted" stop, which has no failed chunk and therefore no paired write failure: the
+  // scope's workspace there names the first creation the drain did not reach.
+  failedEventCount: number;
+  // Never attempted. The drain stopped instead of paying the analytics timeouts once per remaining
+  // chunk, because that cost lands after the product transaction committed and can push the request
+  // past the API Gateway integration timeout.
+  skippedEventCount: number;
 }>;
 
 export type ProductAnalyticsIdentityLinkWriteFailureDetails = Readonly<{
@@ -524,6 +557,7 @@ export type OperationsWarningEvent =
   | EventByAction<"feedback_notification_email_failed", FeedbackEmailFailureDetails>
   | EventByAction<"reporting_read_only_transaction_rollback_failed", DatabaseRollbackFailureDetails>
   | EventByAction<"product_analytics_server_event_write_failed", ProductAnalyticsServerEventWriteFailureDetails>
+  | EventByAction<"product_analytics_content_creation_drain_aborted", ProductAnalyticsContentCreationDrainAbortedDetails>
   | EventByAction<"product_analytics_identity_link_write_failed", ProductAnalyticsIdentityLinkWriteFailureDetails>
   | EventByAction<"catalog_deck_installed_analytics_skipped", CatalogDeckInstalledAnalyticsSkippedDetails>
   | (EventByAction<

--- a/apps/backend/src/productAnalytics/contentCreations.ts
+++ b/apps/backend/src/productAnalytics/contentCreations.ts
@@ -4,10 +4,20 @@ import {
   type WorkspaceDatabaseScope,
 } from "../database";
 import { unsafeTransaction } from "../database/unsafe";
+// Report through `observability/runtime`, never through `observability/sentry`. Deck writes reach
+// this module from `decks/index.ts`, which the direct image ingestion Lambda pulls in through
+// `guestAuth/store/decks.ts`, and that bundle deliberately excludes the Sentry SDK -
+// `entrypoints/directImageIngestion/lambda.test.ts` asserts its import graph reaches no
+// `observability/sentry/capture`, `config` or `tracing` module. Both halves of this module are
+// reachable from there, the drain included, so the runtime indirection is what keeps that true
+// rather than any split. It costs the handlers that do initialize Sentry nothing:
+// `initializeBackendSentry` installs `captureBackendWarning` as the runtime sink, so the warning
+// below is the same Sentry warning there and the same structured CloudWatch record in the lean
+// handler.
 import {
-  captureBackendWarning,
+  captureBackendRuntimeWarning,
   createBackendObservationScope,
-} from "../observability/sentry";
+} from "../observability/runtime";
 import type { ProductAnalyticsEventName } from "./catalog";
 import {
   deriveServerDerivedProductAnalyticsEventId,
@@ -241,7 +251,7 @@ function reportAbandonedContentCreations(
     return;
   }
 
-  captureBackendWarning({
+  captureBackendRuntimeWarning({
     action: "product_analytics_content_creation_drain_aborted",
     scope: createBackendObservationScope(
       "backend-api",

--- a/apps/backend/src/productAnalytics/contentCreations.ts
+++ b/apps/backend/src/productAnalytics/contentCreations.ts
@@ -1,0 +1,425 @@
+import {
+  transactionWithWorkspaceScope,
+  type DatabaseExecutor,
+  type WorkspaceDatabaseScope,
+} from "../database";
+import { unsafeTransaction } from "../database/unsafe";
+import {
+  captureBackendWarning,
+  createBackendObservationScope,
+} from "../observability/sentry";
+import type { ProductAnalyticsEventName } from "./catalog";
+import {
+  deriveServerDerivedProductAnalyticsEventId,
+  emitServerDerivedProductAnalyticsEvents,
+  type ServerDerivedProductAnalyticsEvent,
+} from "./serverEvents";
+import { productAnalyticsMaxEventAgeMs } from "./validation";
+
+export type ContentCreationEntityType = "card" | "deck";
+
+/**
+ * One card or deck that a product transaction brought into existence.
+ *
+ * Only creations are reported here. An update is deliberately not a fact this producer knows about:
+ * the overwhelming majority of writes that reach content.cards are reviews rescheduling a card, a
+ * workspace progress reset touching every card in the library at once, or background media
+ * settlement with no person acting at all, so a single "content was written" event would have
+ * counted review volume under an authoring name. Deciding what counts as an authoring update is its
+ * own question; a creation has no such ambiguity, because none of those paths ever inserts a row.
+ */
+export type ContentCreation = Readonly<{
+  entityType: ContentCreationEntityType;
+  // The row's own id, always a canonical UUID because it is read back from a uuid column.
+  entityId: string;
+  workspaceId: string;
+  // sync.hot_changes.client_updated_at for the write that created the row, as an ISO string.
+  clientUpdatedAt: string;
+}>;
+
+const contentCreationEventNames: Readonly<
+  Record<ContentCreationEntityType, ProductAnalyticsEventName>
+> = {
+  card: "card_created",
+  deck: "deck_created",
+};
+
+// Creations observed inside one open transaction, keyed by the executor that is running it.
+//
+// Nothing is emitted while the transaction is open. Every content write holds
+// sync.workspace_sync_metadata FOR UPDATE for the whole mutation, the analytics writer opens its
+// own transaction on its own pool connection to store a row, and the sync push and bootstrap loops
+// are unbounded, so emitting inline would have held the workspace's hot-change lock across one
+// extra analytics transaction per created row. The same connection split is why an inline emission
+// could not be rolled back with the product write: the analytics row commits first, so a product
+// transaction that failed afterwards would have left permanent rows on an append-only table for
+// cards that never existed.
+//
+// The buffer is created on first use and dropped when the executor is, so a transaction that throws
+// leaves nothing behind and a caller that never flushes reports nothing rather than reporting
+// something wrong.
+const collectedContentCreations = new WeakMap<DatabaseExecutor, Array<ContentCreation>>();
+
+/**
+ * Records that this transaction created one card or deck, to be reported once it commits.
+ *
+ * Callers must only reach this from a branch that genuinely inserted the row. Both snapshot upserts
+ * insert with `ON CONFLICT DO NOTHING ... RETURNING`, so a returned row is a real insert and the
+ * conflict branches below it continue as updates of a row that already existed; the direct create
+ * paths insert unconditionally on a freshly minted id. The LWW-lost branches return early with
+ * `applied: false` and write no hot change at all, so they never get here.
+ *
+ * The creations only reach analytics through a transaction opened by one of the wrappers below.
+ */
+export function collectContentCreation(
+  executor: DatabaseExecutor,
+  creation: ContentCreation,
+): void {
+  const collected = collectedContentCreations.get(executor);
+  if (collected === undefined) {
+    collectedContentCreations.set(executor, [creation]);
+    return;
+  }
+
+  collected.push(creation);
+}
+
+/**
+ * The moment the person made the change, corrected for the device clock that reported it.
+ *
+ * client_updated_at is a client timestamp with no constraint of any kind behind it, and an
+ * offline-first write can legitimately be days older than the sync that carried it, so the value is
+ * kept only where it is plausible: within the same 30-day window the live client ingest accepts, and
+ * never after the server clock. Outside that window the server clock is used instead, which loses
+ * the offline interval but keeps a broken device clock from parking events on an arbitrary day
+ * forever on an append-only table.
+ */
+function resolveContentCreationOccurredAt(clientUpdatedAt: string, recordedAt: Date): Date {
+  const clientUpdatedAtMs = new Date(clientUpdatedAt).getTime();
+  if (Number.isNaN(clientUpdatedAtMs)) {
+    return recordedAt;
+  }
+
+  if (clientUpdatedAtMs > recordedAt.getTime()) {
+    return recordedAt;
+  }
+
+  if (clientUpdatedAtMs < recordedAt.getTime() - productAnalyticsMaxEventAgeMs) {
+    return recordedAt;
+  }
+
+  return new Date(clientUpdatedAtMs);
+}
+
+function toContentCreationEvent(
+  creation: ContentCreation,
+  actorUserId: string,
+  recordedAt: Date,
+): ServerDerivedProductAnalyticsEvent {
+  const eventName = contentCreationEventNames[creation.entityType];
+  return {
+    // Keyed on the row id alone. There is only ever one creation per row, so any path that reaches
+    // this producer again for the same row - a replayed sync push, a guest merge - derives the same
+    // id and conflicts on event_id in the writer instead of counting a second creation. Only a path
+    // that preserves the row id dedupes this way: the workspace-package import mints a fresh card id
+    // per card, so a re-import is genuinely new cards and correctly counts new creations.
+    eventId: deriveServerDerivedProductAnalyticsEventId(eventName, [creation.entityId]),
+    eventName,
+    occurredAt: resolveContentCreationOccurredAt(creation.clientUpdatedAt, recordedAt),
+    // The server clock, read once in Node after the product transaction committed and shared by
+    // every event of one drain. It is deliberately not the same instant as
+    // sync.hot_changes.recorded_at for the same write: that column defaults to now(), which in
+    // Postgres is the transaction's start timestamp, so every hot change a 5,000-card import wrote
+    // carries one instant while these rows carry a later one, ahead of it by the whole transaction.
+    // What stays recoverable from this row is the client skew, as the difference against occurred_at.
+    serverReceivedAt: recordedAt,
+    // The identity the transaction wrote as, named by the caller that opened it rather than looked
+    // up here.
+    //
+    // It is written into both identity columns. For a guest that is exactly what a guest-transport
+    // ingest request stores, and it is what lets a guest's content follow the account afterwards:
+    // analytics.product_events_resolved reads the guest upgrade link through subject_user_id, so
+    // without it every card written before signing up would stay stranded on the guest identity. For
+    // an account the two columns differ only when a Cognito subject was merged, where an ingest row
+    // keeps the pre-merge subject here and this row keeps the authoritative id instead. That cannot
+    // change how either row resolves: the only link keyed on subject_user_id is a guest upgrade, and
+    // no account's authoritative id is ever a merged-away guest user id.
+    userId: actorUserId,
+    subjectUserId: actorUserId,
+    // The guest session behind the write is an auth-layer value this path never sees; the caller
+    // names the acting user and nothing else. A guest's rows are still identifiable as one actor
+    // through subject_user_id above, so what is lost here is the guest/account split on the row
+    // itself, not the attribution.
+    guestSessionId: null,
+    workspaceId: creation.workspaceId,
+    // Null, and deliberately not derived. The only stored platform reachable from a content write is
+    // sync.workspace_replicas.platform for the replica that made it, and that column may never be
+    // read without actor_kind on the same row: the AI chat writes cards through a replica hardcoded
+    // to 'web' that describes no device, the machine API's agent_connection replica stores 'web'
+    // while being no browser, and workspace_seed and workspace_reset store 'system'. Cards and decks
+    // really are written by all of those, so this is the producer most likely to be handed a
+    // misleading replica. Reading the row would also cost one query per created row, which this path
+    // must not add. A missing platform leaves these rows out of a per-platform breakdown; a guessed
+    // one would file them under a platform they never had, permanently.
+    platform: null,
+    properties: {},
+    // Provenance about how a row was produced belongs to the backfill that reconstructs history.
+    // A write observed as it happens has none.
+    details: null,
+  };
+}
+
+// The most creations this producer hands the analytics writer in one statement.
+//
+// A drain is bounded by nothing a person chose: a workspace-package import applies up to
+// workspacePackageImportZipDefaultMaxCards (5,000) cards in one transaction, and a bootstrap push or
+// a guest merge is bounded only by the request body. Every batch the writer receives is a single
+// unnest statement run under SET LOCAL statement_timeout = '2s' on a pool that refuses an
+// acquisition after 2s, and the largest batch that path has ever carried is the client ingest cap of
+// 50 events, so one unbounded statement would put the biggest and most valuable drains - a first
+// full-library bootstrap, a whole-history guest merge - behind the single timeout that loses all of
+// them at once. Chunking bounds what one refusal can cost while keeping the per-row transaction cost
+// that batching exists to avoid: one analytics transaction per 500 creations, not one per creation.
+//
+// Chunking is only safe together with both of the drain's stop rules. A chunk count is a multiplier
+// on the analytics timeouts, and it is paid after the product transaction committed, so a drain that
+// continued through every chunk would let a degraded analytics pool time out the product request
+// itself. Refusal is not the only way that happens: a chunk that is slow but still finishes inside
+// the writer's statement timeout answers "stored", so a stop rule keyed on refusal alone would carry
+// the full multiplier. The drain therefore stops at the first refusal and again once its wall-clock
+// budget is spent. See contentCreationDrainBudgetMs and emitCollectedContentCreations.
+const contentCreationEmitChunkSize = 500;
+
+// The wall clock a drain may spend before it gives up whatever it has not reached.
+//
+// The chunk count this bounds is bounded by nothing a person chose - a bootstrap push or a guest
+// merge has no cap on it at all - and slow-but-stored chunks pay the analytics timeouts just as
+// refused ones do, so without a clock the drain's cost scales with the entry count.
+//
+// The budget is read before each chunk, so the drain's real ceiling is this plus the one chunk
+// already in flight, which costs at most ~4s: up to analyticsPoolConnectionTimeoutMs (2s) acquiring
+// an analytics connection, then up to 2s under the writer's statement timeout. That is ~8s of drain.
+// The request paying it has publicRestApiDefaultIntegrationTimeoutSeconds (29s) before API Gateway
+// abandons the integration and returns a 504 for a transaction that committed, and the drain is not
+// the last thing on that clock: a guest upgrade goes on to write an identity link and then its own
+// event, two more sequential analytics transactions worth up to ~8s together. Worst case that still
+// leaves ~13s for the guest merge itself, and ~21s for a workspace-package import, which pays no
+// such tail.
+//
+// The bound is not lossy at any realistic size. A healthy chunk is one unnest insert on a warm
+// pooled connection, so the ten chunks of the largest bounded transaction - a 5,000-card import -
+// cost well under a second together, and 4s covers tens of thousands of creations before anything is
+// skipped. A drain that cannot finish inside it is one that was already threatening its request.
+const contentCreationDrainBudgetMs = 4_000;
+
+/**
+ * Names the creations the drain gave up on, so an aborted drain is legible rather than silent.
+ *
+ * The reason says which of the two stop rules fired, because they call for opposite responses:
+ * "writer_refused" means the analytics writer turned a chunk down and is degraded or down, while
+ * "budget_exhausted" means every chunk it answered was stored and the drain was simply larger than
+ * one request's clock can carry. Only "writer_refused" has a paired
+ * product_analytics_server_event_write_failed carrying the error, and only it can report a non-zero
+ * failedEventCount.
+ *
+ * The skip guard only ever fires for a refusal: a budget stop is decided before an unreached chunk,
+ * so it always has something to name. A refusal of the last chunk abandoned nothing, and the write
+ * failure that chunk already raised is the whole story, so a transaction small enough to fit one
+ * chunk - which is almost all of them - still produces exactly one warning for one refusal.
+ */
+function reportAbandonedContentCreations(
+  abandoned: Readonly<{
+    reason: "writer_refused" | "budget_exhausted";
+    actorUserId: string;
+    workspaceId: string | null;
+    storedEventCount: number;
+    failedEventCount: number;
+    skippedEventCount: number;
+  }>,
+): void {
+  if (abandoned.skippedEventCount <= 0) {
+    return;
+  }
+
+  captureBackendWarning({
+    action: "product_analytics_content_creation_drain_aborted",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      abandoned.actorUserId,
+      abandoned.workspaceId,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      reason: abandoned.reason,
+      storedEventCount: abandoned.storedEventCount,
+      failedEventCount: abandoned.failedEventCount,
+      skippedEventCount: abandoned.skippedEventCount,
+    },
+  });
+}
+
+/**
+ * Reports the creations the committed transaction collected, in chunks of at most
+ * contentCreationEmitChunkSize, stopping at the first chunk the analytics writer refuses or once
+ * contentCreationDrainBudgetMs of wall clock is spent, whichever comes first.
+ *
+ * A chunk is one analytics transaction on one analytics connection, and the chunks are awaited in
+ * sequence, so this producer holds one connection at a time however large the transaction was. A
+ * sync bootstrap pushes an entire library in one request and every entry of it is a creation, so one
+ * emission per row would instead mean thousands of sequential analytics transactions after the
+ * commit.
+ *
+ * Analytics is best effort and a content write is not: a chunk is swallowed and logged by
+ * emitServerDerivedProductAnalyticsEvents rather than raised, which is what keeps a rejected row
+ * from surfacing as a failed card creation. Neither stop can discard the chunks already stored
+ * before it either - those are committed and stay committed.
+ *
+ * What both stops give up is the rest of the drain, for the same reason. A chunk costs up to 2s
+ * waiting for an analytics pool connection plus up to 2s under the writer's statement timeout, and
+ * continuing pays that again per remaining chunk while the product transaction has already
+ * committed. A 5,000-card import is ten chunks, and a bootstrap push or a guest merge has no chunk
+ * cap at all, so an unstopped drain would push the request past the 29s API Gateway integration
+ * timeout. The caller would then see a 504 for an import that committed, and retry it - and an
+ * import mints a fresh card id per card, so the retry duplicates the whole library. Analytics must
+ * never be able to cost a person their content.
+ *
+ * The two stops answer the two ways that happens, and are reported apart because they mean different
+ * things. A refusal - the writer degraded or down - is detected on the outcome. Chunks that are
+ * merely slow are never refused at all: each one answers "stored" just inside the writer's statement
+ * timeout while still spending the request's clock, so only the elapsed time catches them. Chunking
+ * still does what it was added for under both: everything stored before the stop is kept, rather
+ * than one timeout losing a whole full-library bootstrap at once.
+ *
+ * A refused chunk raises its own write failure carrying its length as eventCount; the remainder of
+ * either stop is named by reportAbandonedContentCreations, whose three counts partition everything
+ * the drain held, so both halves of an aborted drain are reported and neither is inferred from the
+ * other. The drain runs before the request returns rather than being deferred, because a Lambda
+ * container is frozen and killed unpredictably and anything left buffered across that would be lost
+ * silently.
+ */
+async function emitCollectedContentCreations(
+  executor: DatabaseExecutor,
+  actorUserId: string,
+): Promise<void> {
+  const collected = collectedContentCreations.get(executor);
+  if (collected === undefined) {
+    return;
+  }
+
+  collectedContentCreations.delete(executor);
+  // One clock read, used for both of the roles it serves here: the server timestamp every event of
+  // this drain carries, and the instant the drain's own budget starts running from.
+  const drainStartedAtMs = Date.now();
+  const recordedAt = new Date(drainStartedAtMs);
+  for (
+    let chunkStart = 0;
+    chunkStart < collected.length;
+    chunkStart += contentCreationEmitChunkSize
+  ) {
+    if (Date.now() - drainStartedAtMs >= contentCreationDrainBudgetMs) {
+      reportAbandonedContentCreations({
+        reason: "budget_exhausted",
+        actorUserId,
+        // The first creation this drain will not reach. Unlike a refusal there is no paired write
+        // failure naming a row, so this is the only workspace the stop reports.
+        workspaceId: collected[chunkStart]?.workspaceId ?? null,
+        storedEventCount: chunkStart,
+        // Every chunk the writer was handed was stored, so nothing failed. The loop condition puts
+        // at least one creation behind this point, so the stop is never silently dropped by the skip
+        // guard in the reporter.
+        failedEventCount: 0,
+        skippedEventCount: collected.length - chunkStart,
+      });
+      return;
+    }
+
+    const chunk = collected.slice(chunkStart, chunkStart + contentCreationEmitChunkSize);
+    // Never rejects: the writer's refusal comes back as an outcome, so this await cannot throw into
+    // a caller whose product transaction has already committed.
+    const outcome = await emitServerDerivedProductAnalyticsEvents(
+      chunk.map((creation) => toContentCreationEvent(creation, actorUserId, recordedAt)),
+    );
+    if (outcome === "stored") {
+      continue;
+    }
+
+    reportAbandonedContentCreations({
+      reason: "writer_refused",
+      actorUserId,
+      // The refused chunk's first creation, which is the row its write failure named too.
+      workspaceId: chunk[0]?.workspaceId ?? null,
+      storedEventCount: chunkStart,
+      failedEventCount: chunk.length,
+      skippedEventCount: collected.length - chunkStart - chunk.length,
+    });
+    return;
+  }
+}
+
+// The executor the transaction ran on, carried out alongside its result purely so the creations it
+// collected can be drained afterwards. It is only ever used as the WeakMap key above: the pool
+// client behind it is released once the transaction returns, and nothing here queries it.
+type CommittedTransaction<Result> = Readonly<{
+  executor: DatabaseExecutor;
+  result: Result;
+}>;
+
+async function runTransactionReportingContentCreations<Result>(
+  openTransaction: (
+    body: (executor: DatabaseExecutor) => Promise<CommittedTransaction<Result>>,
+  ) => Promise<CommittedTransaction<Result>>,
+  body: (executor: DatabaseExecutor) => Promise<Result>,
+  resolveActorUserId: (result: Result) => string,
+): Promise<Result> {
+  // The transaction returns only after its COMMIT succeeded, so nothing is reported for a
+  // transaction that threw: it never reaches this line and its buffer is dropped with its executor.
+  const committed = await openTransaction(async (executor) => ({
+    executor,
+    result: await body(executor),
+  }));
+  await emitCollectedContentCreations(committed.executor, resolveActorUserId(committed.result));
+  return committed.result;
+}
+
+/**
+ * Opens one workspace-scoped product transaction and reports the cards and decks it created.
+ *
+ * Every transaction that can reach a card or deck insert must be opened through this instead of
+ * transactionWithWorkspaceScope, otherwise its creations are collected and then dropped. The scope's
+ * own user is the actor, because it is the identity every statement in the transaction runs as.
+ */
+export async function transactionWithWorkspaceScopeReportingContentCreations<Result>(
+  scope: WorkspaceDatabaseScope,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
+  return runTransactionReportingContentCreations<Result>(
+    (body) => transactionWithWorkspaceScope(scope, body),
+    callback,
+    () => scope.userId,
+  );
+}
+
+/**
+ * The same, for a privileged transaction that applies its scopes itself.
+ *
+ * The actor is resolved from the transaction's result because such a transaction has no single scope
+ * to read it from: the guest upgrade opens unscoped, works under the guest scope, and only then
+ * re-scopes to the account it is merging into.
+ */
+export async function unsafeTransactionReportingContentCreations<Result>(
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+  resolveActorUserId: (result: Result) => string,
+): Promise<Result> {
+  return runTransactionReportingContentCreations<Result>(
+    (body) => unsafeTransaction(body),
+    callback,
+    resolveActorUserId,
+  );
+}

--- a/apps/backend/src/productAnalytics/serverEvents.ts
+++ b/apps/backend/src/productAnalytics/serverEvents.ts
@@ -176,14 +176,52 @@ function createServerDerivedProductAnalyticsRow(
   };
 }
 
-// Analytics is best effort by definition and the product operation that produced the fact is not, so
-// a failed emission is logged with its error text and never propagated. This is also what keeps a
-// local AUTH_MODE=none run working, where a non-UUID user id fails the uuid cast in the database.
+// The outcome below is deliberately discarded here, and this signature stays void so the call sites
+// that report a single fact are unaffected: a producer of one fact has nothing left to stop for.
 export async function emitServerDerivedProductAnalyticsEvent(
   event: ServerDerivedProductAnalyticsEvent,
 ): Promise<void> {
+  await emitServerDerivedProductAnalyticsEvents([event]);
+}
+
+/**
+ * Whether one batch reached analytics.product_events.
+ *
+ * Deliberately not a boolean. A caller that reacts to a refusal reads "dropped" and nothing else, so
+ * a batch with nothing in it - which stores nothing and refuses nothing - reports "stored" and can
+ * never be read as a write the database turned down.
+ */
+export type ServerDerivedProductAnalyticsEmitOutcome = "stored" | "dropped";
+
+// Analytics is best effort by definition and the product operation that produced the fact is not, so
+// a failed emission is logged with its error text and never propagated. This is also what keeps a
+// local AUTH_MODE=none run working, where a non-UUID user id fails the uuid cast in the database.
+//
+// The outcome is returned, never raised: this function still has no rejection path at all. Its
+// callers run after a product transaction committed, so a thrown refusal would surface as a failed
+// card creation, which is the one thing this path exists to prevent. Returning it instead is what
+// lets a producer part-way through an unbounded sequence of batches stop rather than pay the
+// writer's connection and statement timeouts again for every batch it has left.
+//
+// A producer that observes many facts inside one product operation emits them here as one batch. The
+// insert is a single unnest statement whose parameter count does not grow with the batch, so the
+// whole batch costs one analytics transaction on one pooled connection, while one call per fact
+// would cost that per row and the loops behind these producers are unbounded. The batch stores or
+// fails as a unit, and the warning below names the first event and how many were lost with it. That
+// one statement runs under the writer's 2s statement timeout, so a producer whose fact count is
+// itself unbounded chunks its facts and calls this once per chunk rather than handing over a batch
+// no timeout can finish.
+export async function emitServerDerivedProductAnalyticsEvents(
+  events: ReadonlyArray<ServerDerivedProductAnalyticsEvent>,
+): Promise<ServerDerivedProductAnalyticsEmitOutcome> {
+  const event = events[0];
+  if (event === undefined) {
+    return "stored";
+  }
+
   try {
-    await insertProductAnalyticsEvents([createServerDerivedProductAnalyticsRow(event)]);
+    await insertProductAnalyticsEvents(events.map(createServerDerivedProductAnalyticsRow));
+    return "stored";
   } catch (error) {
     // Read through the database boundary fields rather than off the error itself. The analytics
     // writer answers a refused connection with its own HttpError whose message is a fixed public
@@ -209,11 +247,13 @@ export async function emitServerDerivedProductAnalyticsEvent(
       ),
       details: {
         eventName: event.eventName,
+        eventCount: events.length,
         sqlState: errorDetails.sqlState,
         errorClass: errorDetails.errorClass,
         errorMessage: errorDetails.errorMessage,
       },
     });
+    return "dropped";
   }
 }
 

--- a/apps/backend/src/productAnalytics/serverEvents.ts
+++ b/apps/backend/src/productAnalytics/serverEvents.ts
@@ -1,9 +1,15 @@
 import { createHash, randomUUID } from "node:crypto";
 import { getDatabaseErrorFields } from "../database/transient";
+// Report through `observability/runtime`, never through `observability/sentry`, for the reason
+// spelled out in contentCreations.ts: the content-creation drain calls the batch emission below, and
+// it runs inside the direct image ingestion Lambda's import graph, whose bundle must reach no
+// `observability/sentry/capture`, `config` or `tracing` module. The runtime sink is
+// `captureBackendWarning` wherever `initializeBackendSentry` ran, so nothing about these two
+// warnings changes for the handlers that do initialize Sentry.
 import {
-  captureBackendWarning,
+  captureBackendRuntimeWarning,
   createBackendObservationScope,
-} from "../observability/sentry";
+} from "../observability/runtime";
 import {
   productAnalyticsSchemaVersion,
   type ProductAnalyticsEventName,
@@ -228,7 +234,7 @@ export async function emitServerDerivedProductAnalyticsEvents(
     // string, so only these fields name the failure that actually happened; they fall back to the
     // error's own class and message when it carries none.
     const errorDetails = getDatabaseErrorFields(error);
-    captureBackendWarning({
+    captureBackendRuntimeWarning({
       action: "product_analytics_server_event_write_failed",
       scope: createBackendObservationScope(
         "backend-api",
@@ -275,7 +281,7 @@ export async function linkServerDerivedProductAnalyticsIdentity(
     });
   } catch (error) {
     const errorDetails = getDatabaseErrorFields(error);
-    captureBackendWarning({
+    captureBackendRuntimeWarning({
       action: "product_analytics_identity_link_write_failed",
       scope: createBackendObservationScope(
         "backend-api",

--- a/apps/backend/src/sync/replication/bootstrap.ts
+++ b/apps/backend/src/sync/replication/bootstrap.ts
@@ -3,6 +3,7 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../../database";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/contentCreations";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
 import { HttpError } from "../../shared/errors";
 import {
@@ -178,7 +179,7 @@ export async function processSyncBootstrap(
   input: SyncBootstrapInput,
 ): Promise<SyncBootstrapPullResult | SyncBootstrapPushResult> {
   if (input.mode === "push") {
-    return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    return transactionWithWorkspaceScopeReportingContentCreations({ userId, workspaceId }, async (executor) => {
       const replicaId = await ensureWorkspaceReplicaInExecutor(executor, {
         workspaceId,
         userId,

--- a/apps/backend/src/sync/replication/push.ts
+++ b/apps/backend/src/sync/replication/push.ts
@@ -6,10 +6,8 @@ import {
   createCurrentUserPublicProfileResolver,
   type CurrentUserPublicProfileResolver,
 } from "../../community/reviewActivityFacts";
-import {
-  transactionWithWorkspaceScope,
-  type DatabaseExecutor,
-} from "../../database";
+import type { DatabaseExecutor } from "../../database";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/contentCreations";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
 import { normalizeIsoTimestamp } from "../conflicts/lww";
 import { ensureWorkspaceReplicaInExecutor } from "../identity/replica";
@@ -331,7 +329,7 @@ export async function processSyncPush(
   userId: string,
   input: SyncPushInput,
 ): Promise<SyncPushResult> {
-  const operationResults = await transactionWithWorkspaceScope(
+  const operationResults = await transactionWithWorkspaceScopeReportingContentCreations(
     { userId, workspaceId },
     async (executor) => {
       const replicaId = await ensureWorkspaceReplicaInExecutor(executor, {

--- a/apps/backend/src/workspacePackages/import/apply/importCards.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importCards.ts
@@ -5,11 +5,11 @@ import {
   type CardMutationMetadata,
   type CreateCardInput,
 } from "../../../cards";
-import {
-  transactionWithWorkspaceScope,
-  type DatabaseExecutor,
-  type WorkspaceDatabaseScope,
+import type {
+  DatabaseExecutor,
+  WorkspaceDatabaseScope,
 } from "../../../database";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../../productAnalytics/contentCreations";
 import { HttpError } from "../../../shared/errors";
 import { workspacePackageImportZipDefaultMaxCards } from "../importZip";
 import {
@@ -215,6 +215,8 @@ export async function persistWorkspacePackageImportCards(
     transactionWithWorkspaceScopeFn: async (
       scope: WorkspaceDatabaseScope,
       callback: (executor: DatabaseExecutor) => Promise<WorkspacePackageImportCardPersistenceResult>,
-    ): Promise<WorkspacePackageImportCardPersistenceResult> => transactionWithWorkspaceScope(scope, callback),
+    ): Promise<WorkspacePackageImportCardPersistenceResult> => (
+      transactionWithWorkspaceScopeReportingContentCreations(scope, callback)
+    ),
   });
 }


### PR DESCRIPTION
Creating a card or a deck is now a product-analytics fact. **Only creation** — updates were removed from this change deliberately.

`card_updated` as first written would have meant review volume plus a small authoring tail: every graded answer, every card in a workspace progress reset, and every background image settlement writes a card. The catalog freezes those events with no properties, so the rows would have been permanently indistinguishable and no downstream query could have separated them. Deciding which writes count as authoring is a real question and gets its own change.

**Placement.** Facts are collected during the transaction and emitted after it commits, so nothing runs while the workspace hot-change lock is held, and a transaction that rolls back reports nothing at all. The acting user is a required parameter rather than something read back out of the connection — that is what makes a row nobody can be accountable for *unrepresentable* rather than merely unlikely.

**Two bounds matter more than they look.** The drain is chunked, because a 5,000-card import in one statement would meet an analytics writer that had never been handed more than fifty rows, and one timeout would lose a whole library's worth of facts. But chunking alone converts one slow write into ten — so the drain also stops on the first refusal *and* on a wall clock. Four seconds of budget plus one chunk in flight is a worst tail of about eight seconds; the request it rides on has twenty-nine. Without that second stop, a degraded analytics pool would return a 504 for an import that had already committed, and the retry — which mints new card ids — would duplicate the user's entire library.

**Nothing in that path can reject.** The writer swallows its own failures and answers `stored` or `dropped` instead, so an analytics problem stays an analytics problem and cannot reach a request whose work is already saved.

Catalog installs stay silent on purpose: installing a deck is not authoring it, and `catalog_deck_installed` already carries the card count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)