### PR TITLE
Derive the sign-in sub-routes from their prefix

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
@@ -125,11 +125,11 @@ data object SettingsAccountSignInEmailDestination {
 }
 
 data object SettingsAccountSignInCodeDestination {
-    const val route: String = "settings/account/sign-in/code"
+    const val route: String = "${SettingsAccountSignInEmailDestination.routePrefix}/code"
 }
 
 data object SettingsAccountPostAuthDestination {
-    const val route: String = "settings/account/sign-in/post-auth"
+    const val route: String = "${SettingsAccountSignInEmailDestination.routePrefix}/post-auth"
 }
 
 data object SettingsAccountLegalDestination {


### PR DESCRIPTION
`SettingsAccountSignInCodeDestination` and `SettingsAccountPostAuthDestination` spelled their paths out as independent literals. Two `startsWith` checks in `FlashcardsApp` match them through `SettingsAccountSignInEmailDestination.routePrefix`, and that is what holds the guest and feedback prompts back across the *whole* sign-in flow rather than only its first screen.

So editing the prefix alone would have quietly narrowed both gates: no crash, no log, just prompts appearing on top of a code-entry screen. Same silent-failure class as the rename that preceded this, one level down.

- Both emitted route strings are byte-identical — verified by concatenation against the removed literals.
- Both constants stay `const val`: a `const val` initialiser may be a string template whose interpolations are themselves compile-time constants, and a qualified reference to a `const val` member of another `object` is one.
- The literal `settings/account/sign-in` now appears exactly once in the whole repository, so there is no second copy left to drift.

No behaviour change.

Known and queued, not done here: `AppAnalyticsSupport.kt` matches route prefixes with its own hard-coded literals, decoupled from the destination constants that produce those routes — the same class again, in analytics mapping this item is scoped out of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)