### PR TITLE
Let the database connections alarm see a one-minute burst

### DIFF
--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -191,14 +191,23 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
   });
   alertTopic.addSubscription(new snsSubscriptions.EmailSubscription(props.alertEmail));
 
+  // Connection saturation here is a burst: a spike lasts about a minute, so a 5-minute average
+  // is dominated by the idle minutes around it and two consecutive breaching periods never
+  // happen. DatabaseConnections has one-minute granularity, so the maximum of a single minute is
+  // the sharpest reading available. The API Lambda fleet is budgeted well below 70, and
+  // migrations, scheduled jobs, the reporting role, and admin sessions sit on top of it, so a
+  // minute above 70 means something outside the budget is holding connections while still
+  // leaving headroom under the instance ceiling.
   notifyAlertTopic(new cloudwatch.Alarm(scope, "DbConnectionsAlarm", {
     metric: props.db.metricDatabaseConnections({
-      period: cdk.Duration.minutes(5),
-      statistic: "Average",
+      period: cdk.Duration.minutes(1),
+      statistic: "Maximum",
     }),
-    threshold: 68,
-    evaluationPeriods: 2,
-    alarmDescription: "RDS connections above 80% capacity",
+    threshold: 70,
+    evaluationPeriods: 1,
+    alarmDescription:
+      "RDS open connections peaked above 70 within one minute, above the connection budget of " +
+      "the API Lambda fleet plus its known extra consumers, so connection exhaustion is close",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }), alertTopic);
 


### PR DESCRIPTION
`DbConnectionsAlarm` averaged `DatabaseConnections` over five minutes and required two consecutive breaching periods, so it stayed `OK` through both connection-saturation incidents on 2026-08-29 — the only alert that reached the inbox was the lagging API Gateway 5xx alarm, after users had already been served 503s.

Saturation here is sub-minute. In the 00:15 UTC incident all 47 failures landed inside the same millisecond. In the 06:40 UTC incident one five-minute window averaged about 72 and the next about 42, so exactly one period breached and the alarm never transitioned.

This takes the per-minute `Maximum` over a single period at 70 connections, which sits above the connection budget the API Lambda fleet is being held to and well below the ~112 instance ceiling, so it leads the failure instead of trailing it.

`treatMissingData`, every other alarm in the file, and the `ApiGateway5xxAlarm` backstop are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)