### PR TITLE
Remind desktop reviewers of the review hotkeys on hover

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -931,6 +931,10 @@ const arCatalog: TranslationCatalog = {
       good: "جيد",
       hard: "صعب",
     },
+    shortcuts: {
+      hint: "اضغط {{key}}",
+      spaceKey: "مسافة",
+    },
     sides: {
       back: "الخلف",
       front: "الأمام",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -931,6 +931,10 @@ const deCatalog: TranslationCatalog = {
       good: "Gut",
       hard: "Schwer",
     },
+    shortcuts: {
+      hint: "Drücke {{key}}",
+      spaceKey: "Leertaste",
+    },
     sides: {
       back: "Rückseite",
       front: "Vorderseite",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -929,6 +929,10 @@ const enCatalog = {
       good: "Good",
       hard: "Hard",
     },
+    shortcuts: {
+      hint: "Press {{key}}",
+      spaceKey: "Space",
+    },
     sides: {
       back: "Back",
       front: "Front",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -931,6 +931,10 @@ const esEsCatalog: TranslationCatalog = {
       good: "Bien",
       hard: "Difícil",
     },
+    shortcuts: {
+      hint: "Pulsa {{key}}",
+      spaceKey: "Espacio",
+    },
     sides: {
       back: "Reverso",
       front: "Frente",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -931,6 +931,10 @@ const esMxCatalog: TranslationCatalog = {
       good: "Bien",
       hard: "Difícil",
     },
+    shortcuts: {
+      hint: "Presiona {{key}}",
+      spaceKey: "Espacio",
+    },
     sides: {
       back: "Reverso",
       front: "Frente",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -931,6 +931,10 @@ const hiCatalog: TranslationCatalog = {
       good: "अच्छा",
       hard: "कठिन",
     },
+    shortcuts: {
+      hint: "{{key}} दबाएँ",
+      spaceKey: "स्पेस",
+    },
     sides: {
       back: "पीछे",
       front: "सामने",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -931,6 +931,10 @@ export const jaCatalog = {
       good: "良い",
       hard: "難しい",
     },
+    shortcuts: {
+      hint: "{{key}} を押す",
+      spaceKey: "スペース",
+    },
     sides: {
       back: "裏面",
       front: "表面",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -931,6 +931,10 @@ export const ruCatalog = {
       good: "Хорошо",
       hard: "Трудно",
     },
+    shortcuts: {
+      hint: "Нажмите {{key}}",
+      spaceKey: "Пробел",
+    },
     sides: {
       back: "Обратная сторона",
       front: "Лицевая сторона",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -931,6 +931,10 @@ export const zhHansCatalog = {
       good: "良好",
       hard: "困难",
     },
+    shortcuts: {
+      hint: "按 {{key}}",
+      spaceKey: "空格",
+    },
     sides: {
       back: "背面",
       front: "正面",

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -8,6 +8,7 @@ import type { Card } from "../../../types";
 import type { ReviewLoadingSnapshot } from "../../shared/loadingSnapshots";
 import { formatTagSummary } from "../../shared/featureFormatting";
 import { ReviewCardSide, ReviewCardSpeechButton, ReviewEditIcon } from "./card/ReviewCardSide";
+import { reviewRatingShortcutKeys } from "../input/reviewShortcutKeys";
 import type { ReviewButtonOption } from "./reviewRatingOptions";
 import type { ReviewSpeechSide } from "../speech/reviewSpeech";
 import {
@@ -19,6 +20,8 @@ import {
 } from "./reviewScreenTypes";
 
 const REVIEW_BUTTONS_PER_COLUMN = 2;
+const REVIEW_SHORTCUT_HINT_KEY_TOKEN = "{{key}}";
+const REVIEW_REVEAL_SHORTCUT_ARIA_KEY = "Space";
 const REVIEW_SCROLL_INTO_VIEW_OPTIONS = {
   behavior: "instant",
   block: "start",
@@ -89,7 +92,25 @@ type ReviewRatingButtonColumnProps = Readonly<{
   options: ReadonlyArray<ReviewButtonOption>;
 }>;
 
+type ReviewShortcutHintProps = Readonly<{
+  keyLabel: string;
+}>;
+
 function handleDisabledSpeechToggle(): void {
+}
+
+function ReviewShortcutHint(props: ReviewShortcutHintProps): ReactElement {
+  const { keyLabel } = props;
+  const { t } = useI18n();
+  const [hintPrefix, hintSuffix] = t("reviewScreen.shortcuts.hint").split(REVIEW_SHORTCUT_HINT_KEY_TOKEN);
+
+  return (
+    <span className="review-shortcut-hint" aria-hidden="true">
+      {hintPrefix}
+      <kbd className="review-shortcut-hint-key">{keyLabel}</kbd>
+      {hintSuffix}
+    </span>
+  );
 }
 
 function ReviewRepetitionIcon(): ReactElement {
@@ -256,12 +277,14 @@ function ReviewRatingButtonColumn(props: ReviewRatingButtonColumnProps): ReactEl
           key={option.rating}
           type="button"
           className="rating-btn"
+          aria-keyshortcuts={reviewRatingShortcutKeys[option.rating]}
           disabled={isSubmitting}
           onClick={() => onReview(option.rating)}
           data-testid={`review-rate-${option.testId}`}
         >
           <span className="rating-btn-title">{option.title}</span>
           <span className="rating-btn-subtitle">{option.intervalDescription}</span>
+          <ReviewShortcutHint keyLabel={reviewRatingShortcutKeys[option.rating]} />
         </button>
       ))}
     </div>
@@ -416,10 +439,12 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
           <button
             type="button"
             className="primary-btn review-reveal-btn"
+            aria-keyshortcuts={REVIEW_REVEAL_SHORTCUT_ARIA_KEY}
             onClick={onRevealAnswer}
             data-testid="review-reveal-answer"
           >
             {t("reviewScreen.actions.revealAnswer")}
+            <ReviewShortcutHint keyLabel={t("reviewScreen.shortcuts.spaceKey")} />
           </button>
         )}
       </div>

--- a/apps/web/src/screens/review/input/reviewShortcutKeys.ts
+++ b/apps/web/src/screens/review/input/reviewShortcutKeys.ts
@@ -1,0 +1,17 @@
+import type { ReviewRating } from "../../../../../backend/src/scheduling";
+
+export const reviewRevealShortcutKey = " ";
+
+export const reviewRatingShortcutKeys: Readonly<Record<ReviewRating, string>> = {
+  0: "1",
+  1: "2",
+  2: "3",
+  3: "4",
+};
+
+export const reviewShortcutRatingsByKey: Readonly<Record<string, ReviewRating>> = {
+  [reviewRatingShortcutKeys[0]]: 0,
+  [reviewRatingShortcutKeys[1]]: 1,
+  [reviewRatingShortcutKeys[2]]: 2,
+  [reviewRatingShortcutKeys[3]]: 3,
+};

--- a/apps/web/src/screens/review/input/useReviewKeyboardShortcuts.ts
+++ b/apps/web/src/screens/review/input/useReviewKeyboardShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent } from "react";
 import type { Card } from "../../../types";
+import { reviewRevealShortcutKey, reviewShortcutRatingsByKey } from "./reviewShortcutKeys";
 
 type UseReviewKeyboardShortcutsParams = Readonly<{
   handleReview: (card: Card, rating: 0 | 1 | 2 | 3) => Promise<void>;
@@ -14,13 +15,6 @@ type UseReviewKeyboardShortcutsParams = Readonly<{
   selectedCard: Card | null;
   setIsAnswerVisible: (value: boolean) => void;
 }>;
-
-const reviewShortcutRatingsByKey: Readonly<Record<string, 0 | 1 | 2 | 3>> = {
-  "1": 0,
-  "2": 1,
-  "3": 2,
-  "4": 3,
-};
 
 function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -65,7 +59,7 @@ export function useReviewKeyboardShortcuts(params: UseReviewKeyboardShortcutsPar
       return;
     }
 
-    if (event.key === " ") {
+    if (event.key === reviewRevealShortcutKey) {
       onShortcutInputStart();
       if (isAnswerVisible) {
         return;

--- a/apps/web/src/styles/features/review/review-rating-controls.css
+++ b/apps/web/src/styles/features/review/review-rating-controls.css
@@ -71,3 +71,64 @@
   opacity: 0.55;
   cursor: default;
 }
+
+/* Keyboard shortcut hints exist only for desktop pointers. */
+.review-shortcut-hint {
+  display: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .rating-btn,
+  .review-reveal-btn {
+    position: relative;
+  }
+
+  .review-shortcut-hint {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    padding: 4px 8px;
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius-xs);
+    background: var(--surface-elevated);
+    box-shadow: var(--shadow-soft);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 18px;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  .review-shortcut-hint-key {
+    display: inline-block;
+    min-width: 18px;
+    padding: 0 5px;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: calc(var(--radius-xs) / 2);
+    background: var(--surface-hover);
+    box-shadow: 0 1px 0 var(--panel-border-strong);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 16px;
+    text-align: center;
+  }
+
+  .rating-btn:not(:disabled):hover,
+  .rating-btn:not(:disabled):focus-visible,
+  .review-reveal-btn:not(:disabled):hover,
+  .review-reveal-btn:not(:disabled):focus-visible {
+    z-index: 2;
+  }
+
+  .rating-btn:not(:disabled):hover > .review-shortcut-hint,
+  .rating-btn:not(:disabled):focus-visible > .review-shortcut-hint,
+  .review-reveal-btn:not(:disabled):hover > .review-shortcut-hint,
+  .review-reveal-btn:not(:disabled):focus-visible > .review-shortcut-hint {
+    display: block;
+  }
+}


### PR DESCRIPTION
On desktop web only, hovering or keyboard-focusing a review action button now shows a small tooltip above it: `Нажмите [Пробел]` / `Press [1]`, with the key drawn as a keycap. Mouse users get a standing reminder that the existing shortcuts are there.

- Space on **Reveal answer**, 1-4 on the four rating buttons (Again/Hard/Good/Easy by rating value, not by grid position).
- The key mapping moved into a shared `reviewShortcutKeys` module that both the keyboard hook and the hint read, so the two cannot drift.
- Pure CSS, no state and no new dependency: shown on `:hover` / `:focus-visible`, hidden for disabled buttons, and the whole thing lives behind `@media (hover: hover) and (pointer: fine)` so touch and mobile web are unchanged.
- Static: no press animation, no motion added.
- Buttons gained `aria-keyshortcuts`; the bubble is `aria-hidden` and `pointer-events: none`, so accessible names and click targets are unchanged.
- New `reviewScreen.shortcuts.*` strings translated in all nine catalogs; the Space key word is localized, the digits are not.

Web only. No new tests per repository policy; existing review tests select by `data-testid` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)