### PR TITLE
Say what three fragile backend claims actually depend on

### DIFF
--- a/apps/backend/src/productAnalytics/writer.ts
+++ b/apps/backend/src/productAnalytics/writer.ts
@@ -24,7 +24,10 @@ const analyticsPoolConnectionTimeoutMs = 2_000;
 
 // pg-pool answers a failed acquisition with a bare Error carrying no code and no SQLSTATE, so it
 // matches nothing isTransientDatabaseError recognises and would otherwise reach a caller as an
-// unclassified failure. The message is the only thing that names it.
+// unclassified failure. The message is the only thing that names it, and it is pg's wording rather
+// than a contract: a pg upgrade that rewords it makes this match fail silently, so the acquisition
+// timeout would take the 503 branch below and the 429 docs/auth-service.md documents for it would
+// never be raised. Re-check the string against pg-pool on every pg upgrade.
 const analyticsPoolAcquisitionTimeoutMessage = "timeout exceeded when trying to connect";
 
 type ProductAnalyticsParameterValue = string | number | Date | null;

--- a/apps/backend/src/routes/guestAuth.test.ts
+++ b/apps/backend/src/routes/guestAuth.test.ts
@@ -232,7 +232,7 @@ test("POST /guest-auth/session forwards an idempotency key and defaults it to ab
 // a client might reach for are refused at the boundary rather than stored. The check is only that
 // floor: a hex-normalised install id would pass it, which is why per-attempt randomness stays a
 // client obligation in docs/auth-service.md.
-test("POST /guest-auth/session rejects an idempotency key that is not a random token", async () => {
+test("POST /guest-auth/session rejects an idempotency key outside the required token shape", async () => {
   let created = false;
   const app = createGuestAuthTestApp({
     authResult: createAuthResult("none"),

--- a/apps/backend/src/server/browserCors.ts
+++ b/apps/backend/src/server/browserCors.ts
@@ -27,6 +27,8 @@ export const browserCorsExposeHeaders = [
   "x-amz-apigw-id",
   "x-amzn-requestid",
   "x-chat-request-id",
+  // The web client reads Retry-After off every error response to pace its retries, and
+  // docs/auth-service.md documents the delay as travelling only here.
   "retry-after",
 ] as const;
 


### PR DESCRIPTION
Three places where the backend depends on something invisible, or says something it does not do. None is a bug today; each is a silent failure waiting for an unrelated change.

**A test title contradicted its own comment.** It claimed the server rejects an idempotency key that "is not a random token". The server cannot detect randomness — the check is a shape floor, and the comment directly above the test already said so. All four keys the test sends fail on shape. Retitled to what is actually asserted.

**The `429` hangs on a substring of `pg-pool`'s error message.** `pg-pool` throws a bare `Error` with no code and no SQLSTATE, so the message is the only thing naming a failed acquisition. The comment explained that much but not the consequence: reword it and the case silently takes the `503` branch instead, so the `429 ANALYTICS_WRITER_BUSY` that `docs/auth-service.md` documents for it is never raised, and the doc describes a path the code no longer takes. The comment says that now, at the constant a grep for the string lands on. Scoped to status and code — the delay is unaffected, since a `503` gets `Retry-After` too.

**`retry-after` sat in the browser CORS expose list with nothing saying why.** The web client reads that header off every error response to pace its retries, and the docs describe the delay as travelling only there.

An earlier version of that last comment also claimed removal had "no other symptom". Review found that false — a backend test asserts `retry-after` in the joined expose header — and worse, it was the clause a reader would act on: it would have invited treating that red test as an incidental assertion to delete. Removed rather than corrected, along with the temptation to pin the reason to the one path that prompted the item.

No behaviour change. Comments and one test title only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)