### PR TITLE
Give the database enough memory to stop swapping at rest

### DIFF
--- a/infra/aws/lib/database.ts
+++ b/infra/aws/lib/database.ts
@@ -42,7 +42,12 @@ export function database(scope: Construct, props: DatabaseProps): DatabaseResult
     engine: rds.DatabaseInstanceEngine.postgres({
       version: postgresEngineVersion,
     }),
-    instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO),
+    // On the previous MICRO class the instance swapped at baseline, not only under bursts:
+    // over a week at a median of 4 connections, SwapUsage stayed between 48 MB and 250 MB and
+    // never reached zero. SMALL doubles memory to 2 GiB. Memory is also the connection ceiling,
+    // because max_connections is derived from DBInstanceClassMemory rather than pinned in the
+    // parameter group, so the class is what gives the Lambda connection budget its headroom.
+    instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.SMALL),
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     securityGroups: [props.dbSg],


### PR DESCRIPTION
Measured over 2026-08-22 to 2026-08-29, at a **median of four connections**:

| Metric | min | median | max |
| --- | --- | --- | --- |
| `SwapUsage` | 48 MB | 87 MB | 250 MB |
| `FreeableMemory` | 55 MB | 94 MB | 197 MB |

Swap never reaches zero, so the instance swaps under ordinary load rather than only under the 29 August incident. During that incident's 110-connection burst, swap rose from 87 MB to 213 MB inside one minute and stayed elevated for six minutes after the burst ended.

`db.t4g.small` doubles memory to 2 GiB, which also roughly doubles the derived `max_connections` from ~112 to ~225. That gives the Lambda connection budget real headroom instead of ten connections of margin. `max_connections` stays derived from `DBInstanceClassMemory` rather than pinned, so the ceiling keeps tracking the hardware automatically.

### Rollout

`applyImmediately` stays `false`, so **CI will report success while the instance is still `db.t4g.micro`**. The actual resize, and its short single-AZ outage, happen at the next `sun:03:00-sun:03:30` UTC maintenance window. Three hourly scheduled jobs fire inside that window, so expect one or two self-resolving `metricErrors` alarm emails that Sunday.

RDS Proxy was considered and deliberately declined. No `SwapUsage` alarm is added yet, because baseline swap is currently non-zero and such an alarm would fire permanently; that is worth revisiting after the resize has actually taken effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)