### PR TITLE
Separate actionable analytics delivery warnings

### DIFF
--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -852,6 +852,16 @@ export function captureWebWarning(event: WebWarningEvent): void {
     applyObservationScope(scope, event.scope, event.action);
     scope.setLevel("warning");
     scope.setContext("web.warning", detailsToContext(event.details));
+
+    if (event.action === "analytics_delivery_degraded") {
+      scope.setTag("web.warning_kind", event.details.eventName);
+      if (event.details.eventName !== "analytics_queue_discarded_on_reset") {
+        scope.setFingerprint(["{{ default }}", event.action, event.details.eventName]);
+        Sentry.captureMessage(`web.${event.action}.${event.details.eventName}`);
+        return;
+      }
+    }
+
     Sentry.captureMessage(`web.${event.action}`);
   });
 }


### PR DESCRIPTION
## Summary
- keep expected analytics queue resets in the existing Sentry warning group
- split actionable analytics delivery failures into stable per-kind issue groups
- tag analytics delivery warnings with their warning kind

## Validation
- fresh static review: clean
- cloud PR checks pending