### PR TITLE
Publish catalog media to the CDN that already serves the snapshot

### DIFF
--- a/apps/backend/src/catalog/distribution/public/dumpGeneration.ts
+++ b/apps/backend/src/catalog/distribution/public/dumpGeneration.ts
@@ -2,6 +2,7 @@ import { parsePublicOrigin } from "../../../shared/publicUrls";
 import type { BackendObservationScope } from "../../../observability/sentry";
 import { loadPublicCatalogSnapshot } from "./snapshot";
 import { writeCatalogDumpToS3, type CatalogDumpWriteResult } from "./dumpStorage";
+import { publishPublicCatalogMediaToCatalogDumpBucket } from "./mediaPublication";
 
 function getRequiredCatalogDumpEnv(envName: string): string {
   const value = process.env[envName];
@@ -16,6 +17,10 @@ function getRequiredCatalogDumpEnv(envName: string): string {
  * Builds the snapshot the public catalog dump publishes. The builder runs without
  * an HTTP request, so both public base URLs come from the environment instead of
  * the request URL the `GET /v1/catalog` route resolves them from.
+ *
+ * Media blobs are reconciled onto the CDN before the snapshot is written, and a
+ * failed reconcile fails the whole run, so a published snapshot never precedes
+ * the media objects it will reference.
  */
 export async function generateAndWriteCatalogDump(
   observationScope: BackendObservationScope,
@@ -29,5 +34,6 @@ export async function generateAndWriteCatalogDump(
     "PUBLIC_APP_BASE_URL",
   );
   const snapshot = await loadPublicCatalogSnapshot(publicApiBaseUrl, publicAppBaseUrl);
+  await publishPublicCatalogMediaToCatalogDumpBucket(observationScope);
   return writeCatalogDumpToS3(observationScope, snapshot);
 }

--- a/apps/backend/src/catalog/distribution/public/dumpStorage.ts
+++ b/apps/backend/src/catalog/distribution/public/dumpStorage.ts
@@ -7,7 +7,7 @@ import {
 import { HttpError } from "../../../shared/errors";
 import type { CatalogPublicSnapshot } from "../../types";
 
-type CatalogDumpStorageConfig = Readonly<{
+export type CatalogDumpStorageConfig = Readonly<{
   bucketName: string;
   cdnBaseUrl: string;
 }>;
@@ -38,12 +38,12 @@ const immutableCatalogDumpObjectKeyPattern = new RegExp(
   "u",
 );
 const catalogDumpContentType = "application/json; charset=utf-8";
-const immutableCatalogDumpCacheControl = "public, max-age=31536000, immutable";
+export const immutableCatalogDumpCacheControl = "public, max-age=31536000, immutable";
 const revalidatedCatalogDumpCacheControl = "public, max-age=60";
 
 let catalogDumpS3Client: S3Client | undefined;
 
-function getCatalogDumpS3Client(): S3Client {
+export function getCatalogDumpS3Client(): S3Client {
   if (catalogDumpS3Client !== undefined) {
     return catalogDumpS3Client;
   }
@@ -61,7 +61,7 @@ function getRequiredCatalogDumpEnv(envName: string): string {
   return value.trim();
 }
 
-function getCatalogDumpStorageConfig(): CatalogDumpStorageConfig {
+export function getCatalogDumpStorageConfig(): CatalogDumpStorageConfig {
   const cdnBaseUrl = getRequiredCatalogDumpEnv("CATALOG_DUMP_CDN_BASE_URL");
   return {
     bucketName: getRequiredCatalogDumpEnv("CATALOG_DUMP_S3_BUCKET_NAME"),
@@ -91,7 +91,7 @@ function getS3ErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function formatS3ErrorSummary(error: unknown): string {
+export function formatCatalogDumpS3ErrorSummary(error: unknown): string {
   const errorName = getS3ErrorName(error);
   const errorMessage = getS3ErrorMessage(error);
   const statusCode = getS3ErrorStatusCode(error);
@@ -99,8 +99,8 @@ function formatS3ErrorSummary(error: unknown): string {
   return `${errorName}${statusSuffix}: ${errorMessage}`;
 }
 
-async function runCatalogDumpS3OperationWithRetries<Result>(params: Readonly<{
-  operation: "get_object" | "put_object";
+export async function runCatalogDumpS3OperationWithRetries<Result>(params: Readonly<{
+  operation: "get_object" | "put_object" | "list_objects" | "copy_object" | "delete_object";
   observationScope: BackendObservationScope;
   bucketName: string;
   objectKey: string;
@@ -166,7 +166,7 @@ async function putCatalogDumpObjectWithRetries(params: Readonly<{
     });
   } catch (error) {
     throw new Error(
-      `Failed to write the public catalog dump to s3://${params.bucketName}/${params.objectKey}: ${formatS3ErrorSummary(error)}`,
+      `Failed to write the public catalog dump to s3://${params.bucketName}/${params.objectKey}: ${formatCatalogDumpS3ErrorSummary(error)}`,
     );
   }
 }
@@ -221,7 +221,7 @@ function createCatalogDumpPointerUnavailableError(
     : `s3://${config.bucketName}/${pointerCatalogDumpObjectKey}`;
   return new HttpError(
     503,
-    `Public catalog dump pointer is unavailable from ${location}: ${formatS3ErrorSummary(error)}`,
+    `Public catalog dump pointer is unavailable from ${location}: ${formatCatalogDumpS3ErrorSummary(error)}`,
     catalogDumpPointerUnavailableCode,
   );
 }

--- a/apps/backend/src/catalog/distribution/public/mediaPublication.ts
+++ b/apps/backend/src/catalog/distribution/public/mediaPublication.ts
@@ -1,0 +1,338 @@
+/**
+ * Publishes every public catalog media blob into the catalog dump bucket, so the
+ * CDN that already serves the snapshot serves the blobs it will reference too.
+ *
+ * The snapshot is an immutable artifact written with a one-year `Cache-Control`
+ * and embeds an absolute URL per media asset, so presigned S3 URLs cannot carry
+ * public catalog media: `downloadUrlExpiresSeconds` is one hour and an hour-long
+ * URL cannot live inside a year-immutable artifact. Workspace media is untouched
+ * and keeps its presigned flow.
+ *
+ * Objects are keyed by the blob's own `sha256`, matching how the snapshot itself
+ * is addressed. That deduplicates a blob shared across package versions, keeps
+ * every object immutable (a changed blob is a different key, so no invalidation
+ * is ever needed), and keeps the key unguessable from public catalog data.
+ *
+ * The pass is a full reconcile rather than an incremental one: it copies what is
+ * missing and deletes what is no longer public, so delisting actually withdraws
+ * the blob. It must complete fully or fail the whole dump run, because the
+ * snapshot write that follows assumes every blob it references already exists.
+ */
+import {
+  CopyObjectCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import type { DatabaseExecutor } from "../../../database";
+import { unsafeRepeatableReadReadOnlyTransaction } from "../../../database/core";
+import { getMediaAssetsStorageConfig } from "../../../mediaAssets/storage/config";
+import { buildMediaBlobStorageKey } from "../../../mediaAssets/storageKeys";
+import {
+  addBackendBreadcrumb,
+  type BackendObservationScope,
+} from "../../../observability/sentry";
+import { toSafeNumber } from "../../common";
+import { isPublicCatalogMediaDeliverable } from "../../publicMediaDelivery";
+import {
+  formatCatalogDumpS3ErrorSummary,
+  getCatalogDumpS3Client,
+  getCatalogDumpStorageConfig,
+  immutableCatalogDumpCacheControl,
+  runCatalogDumpS3OperationWithRetries,
+} from "./dumpStorage";
+
+/** Must stay in sync with the write grant in `infra/aws/lib/catalog-dump.ts`. */
+const catalogMediaObjectKeyPrefix = "catalog/media/";
+
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+
+export type CatalogPublicMediaBlob = Readonly<{
+  sha256: string;
+  storageKey: string;
+  mimeType: string;
+  sizeBytes: number;
+}>;
+
+export type CatalogPublicMediaPublicationResult = Readonly<{
+  bucketName: string;
+  desiredObjectCount: number;
+  copiedObjectCount: number;
+  deletedObjectCount: number;
+}>;
+
+type CatalogPublicMediaBlobRow = Readonly<{
+  sha256: string;
+  storage_key: string;
+  mime_type: string;
+  size_bytes: string | number;
+}>;
+
+/** Content-addressed key one public catalog media blob is published under. */
+export function buildCatalogMediaObjectKey(sha256: string): string {
+  return `${catalogMediaObjectKeyPrefix}${sha256.toLowerCase()}`;
+}
+
+/** Absolute CDN URL of one published public catalog media blob. */
+export function buildCatalogMediaCdnUrl(cdnBaseUrl: string, sha256: string): string {
+  const normalizedCdnBaseUrl = cdnBaseUrl.endsWith("/")
+    ? cdnBaseUrl.slice(0, -1)
+    : cdnBaseUrl;
+  return `${normalizedCdnBaseUrl}/${buildCatalogMediaObjectKey(sha256)}`;
+}
+
+function createCatalogMediaCopySource(bucketName: string, storageKey: string): string {
+  return `${bucketName}/${storageKey.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+function mapCatalogPublicMediaBlob(row: CatalogPublicMediaBlobRow): CatalogPublicMediaBlob {
+  // The published key is derived from `sha256`, so a value that is not a plain
+  // digest would decide an object key. Refuse it instead of publishing under it.
+  if (
+    sha256Pattern.test(row.sha256) === false
+    || row.storage_key !== buildMediaBlobStorageKey(row.sha256)
+  ) {
+    throw new Error(
+      `Published catalog media blob is outside private blob storage. sha256=${JSON.stringify(row.sha256)}`,
+    );
+  }
+
+  return {
+    sha256: row.sha256,
+    storageKey: row.storage_key,
+    mimeType: row.mime_type,
+    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
+  };
+}
+
+/**
+ * Distinct blobs the public catalog exposes: package media on published, listed
+ * versions of published, listed packages, plus published, listed collection
+ * covers. The status predicates mirror `media.ts` and `collectionMedia.ts` so the
+ * published set never differs from what those readers serve.
+ */
+export async function loadPublicCatalogMediaBlobsForPublicationInExecutor(
+  executor: DatabaseExecutor,
+): Promise<ReadonlyArray<CatalogPublicMediaBlob>> {
+  const result = await executor.query<CatalogPublicMediaBlobRow>(
+    [
+      "SELECT",
+      "media_blobs.sha256 AS sha256,",
+      "media_blobs.storage_key AS storage_key,",
+      "media_blobs.mime_type AS mime_type,",
+      "media_blobs.size_bytes AS size_bytes",
+      "FROM catalog.package_media_assets AS media_assets",
+      "INNER JOIN catalog.package_versions AS versions",
+      "ON versions.package_version_id = media_assets.package_version_id",
+      "INNER JOIN catalog.packages AS packages",
+      "ON packages.package_id = versions.package_id",
+      "INNER JOIN content.media_blobs AS media_blobs",
+      "ON media_blobs.media_blob_id = media_assets.media_blob_id",
+      "WHERE versions.status = 'published'",
+      "AND versions.delisted_at IS NULL",
+      "AND packages.status = 'published'",
+      "AND packages.delisted_at IS NULL",
+      "UNION",
+      "SELECT",
+      "media_blobs.sha256 AS sha256,",
+      "media_blobs.storage_key AS storage_key,",
+      "media_blobs.mime_type AS mime_type,",
+      "media_blobs.size_bytes AS size_bytes",
+      "FROM catalog.collections AS collections",
+      "INNER JOIN content.media_blobs AS media_blobs",
+      "ON media_blobs.media_blob_id = collections.cover_media_blob_id",
+      "WHERE collections.cover_media_blob_id IS NOT NULL",
+      "AND collections.status = 'published'",
+      "AND collections.delisted_at IS NULL",
+      "ORDER BY sha256 ASC",
+    ].join(" "),
+    [],
+  );
+
+  // The mime allowlist and size cap decide what the public catalog may serve at
+  // all, so a blob it rejects is never published to the CDN either.
+  return result.rows
+    .map(mapCatalogPublicMediaBlob)
+    .filter((blob: CatalogPublicMediaBlob) => isPublicCatalogMediaDeliverable({
+      mimeType: blob.mimeType,
+      sizeBytes: blob.sizeBytes,
+    }));
+}
+
+async function listPublishedCatalogMediaObjectKeys(
+  observationScope: BackendObservationScope,
+  bucketName: string,
+): Promise<Set<string>> {
+  const publishedObjectKeys = new Set<string>();
+  let continuationToken: string | undefined;
+
+  do {
+    const requestContinuationToken = continuationToken;
+    const response = await runCatalogDumpS3OperationWithRetries({
+      operation: "list_objects",
+      observationScope,
+      bucketName,
+      objectKey: catalogMediaObjectKeyPrefix,
+      run: async () => getCatalogDumpS3Client().send(new ListObjectsV2Command({
+        Bucket: bucketName,
+        Prefix: catalogMediaObjectKeyPrefix,
+        ContinuationToken: requestContinuationToken,
+      })),
+    });
+
+    for (const object of response.Contents ?? []) {
+      if (object.Key !== undefined) {
+        publishedObjectKeys.add(object.Key);
+      }
+    }
+
+    continuationToken = response.IsTruncated === true
+      ? response.NextContinuationToken
+      : undefined;
+  } while (continuationToken !== undefined);
+
+  return publishedObjectKeys;
+}
+
+async function copyCatalogMediaObject(params: Readonly<{
+  observationScope: BackendObservationScope;
+  dumpBucketName: string;
+  mediaAssetsBucketName: string;
+  objectKey: string;
+  blob: CatalogPublicMediaBlob;
+}>): Promise<void> {
+  try {
+    await runCatalogDumpS3OperationWithRetries({
+      operation: "copy_object",
+      observationScope: params.observationScope,
+      bucketName: params.dumpBucketName,
+      objectKey: params.objectKey,
+      run: async () => getCatalogDumpS3Client().send(new CopyObjectCommand({
+        Bucket: params.dumpBucketName,
+        Key: params.objectKey,
+        CopySource: createCatalogMediaCopySource(
+          params.mediaAssetsBucketName,
+          params.blob.storageKey,
+        ),
+        MetadataDirective: "REPLACE",
+        ContentType: params.blob.mimeType,
+        CacheControl: immutableCatalogDumpCacheControl,
+      })),
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to publish public catalog media to s3://${params.dumpBucketName}/${params.objectKey}: ${formatCatalogDumpS3ErrorSummary(error)}`,
+    );
+  }
+}
+
+async function deleteCatalogMediaObject(params: Readonly<{
+  observationScope: BackendObservationScope;
+  dumpBucketName: string;
+  objectKey: string;
+}>): Promise<void> {
+  try {
+    await runCatalogDumpS3OperationWithRetries({
+      operation: "delete_object",
+      observationScope: params.observationScope,
+      bucketName: params.dumpBucketName,
+      objectKey: params.objectKey,
+      run: async () => getCatalogDumpS3Client().send(new DeleteObjectCommand({
+        Bucket: params.dumpBucketName,
+        Key: params.objectKey,
+      })),
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to withdraw public catalog media from s3://${params.dumpBucketName}/${params.objectKey}: ${formatCatalogDumpS3ErrorSummary(error)}`,
+    );
+  }
+}
+
+/**
+ * Reconciles the `catalog/media/` prefix of the dump bucket against the blobs the
+ * public catalog currently exposes.
+ *
+ * Copies are server-side, so no blob bytes pass through this process. The pass is
+ * deliberately not incremental or paginated: at the current scale one full pass
+ * is far inside the dump function's timeout, and a full pass is what makes the
+ * result independent of which run last succeeded.
+ *
+ * The single desired set it refuses to act on is an empty one against a non-empty
+ * prefix: that would withdraw every published blob at once, and it reads as a
+ * failed catalog read far more readily than as a catalog with no media.
+ */
+export async function publishPublicCatalogMediaToCatalogDumpBucket(
+  observationScope: BackendObservationScope,
+): Promise<CatalogPublicMediaPublicationResult> {
+  const dumpBucketName = getCatalogDumpStorageConfig().bucketName;
+  const mediaAssetsBucketName = getMediaAssetsStorageConfig().bucketName;
+  const desiredBlobs = await unsafeRepeatableReadReadOnlyTransaction(async (executor) => (
+    loadPublicCatalogMediaBlobsForPublicationInExecutor(executor)
+  ));
+  const desiredObjectKeys = new Set<string>(
+    desiredBlobs.map((blob: CatalogPublicMediaBlob) => buildCatalogMediaObjectKey(blob.sha256)),
+  );
+  const publishedObjectKeys = await listPublishedCatalogMediaObjectKeys(
+    observationScope,
+    dumpBucketName,
+  );
+
+  // An empty desired set against a non-empty prefix is far more likely a read
+  // regression — a lost `backend_app` grant on the catalog tables, a predicate
+  // bug — than a catalog that genuinely exposes no media at all, and acting on
+  // it would withdraw every published blob in a single pass. Fail the run the
+  // same way a failed copy does instead of deleting.
+  if (desiredObjectKeys.size === 0 && publishedObjectKeys.size > 0) {
+    throw new Error(
+      `Refusing to withdraw every published public catalog media object from s3://${dumpBucketName}/${catalogMediaObjectKeyPrefix}: the public catalog resolved 0 desired blobs while ${publishedObjectKeys.size} objects are published.`,
+    );
+  }
+
+  let copiedObjectCount = 0;
+  for (const blob of desiredBlobs) {
+    const objectKey = buildCatalogMediaObjectKey(blob.sha256);
+    if (publishedObjectKeys.has(objectKey)) {
+      continue;
+    }
+
+    await copyCatalogMediaObject({
+      observationScope,
+      dumpBucketName,
+      mediaAssetsBucketName,
+      objectKey,
+      blob,
+    });
+    // Two rows can address one blob, so record the copy to keep the pass from
+    // writing the same object twice.
+    publishedObjectKeys.add(objectKey);
+    copiedObjectCount += 1;
+  }
+
+  let deletedObjectCount = 0;
+  for (const objectKey of publishedObjectKeys) {
+    if (desiredObjectKeys.has(objectKey)) {
+      continue;
+    }
+
+    await deleteCatalogMediaObject({ observationScope, dumpBucketName, objectKey });
+    deletedObjectCount += 1;
+  }
+
+  addBackendBreadcrumb({
+    action: "catalog_dump_media_published",
+    scope: observationScope,
+    details: {
+      bucketName: dumpBucketName,
+      desiredObjectCount: desiredObjectKeys.size,
+      copiedObjectCount,
+      deletedObjectCount,
+    },
+  });
+
+  return {
+    bucketName: dumpBucketName,
+    desiredObjectCount: desiredObjectKeys.size,
+    copiedObjectCount,
+    deletedObjectCount,
+  };
+}

--- a/apps/backend/src/observability/sentry/events/index.ts
+++ b/apps/backend/src/observability/sentry/events/index.ts
@@ -96,6 +96,7 @@ export type {
   CatalogDeckInstalledAnalyticsSkippedDetails,
   CatalogDumpFailureDetails,
   CatalogDumpGeneratedDetails,
+  CatalogDumpMediaPublishedDetails,
   CatalogDumpRefreshFailureDetails,
   CatalogDumpS3RetryDetails,
   CatalogSnapshotPointerErrorDetails,

--- a/apps/backend/src/observability/sentry/events/operations.ts
+++ b/apps/backend/src/observability/sentry/events/operations.ts
@@ -108,6 +108,19 @@ export type CatalogDumpGeneratedDetails = Readonly<{
   triggerRoute: string | null;
 }>;
 
+/**
+ * One completed media reconcile of the `catalog/media/` prefix of the dump
+ * bucket. `desiredObjectCount` is what the public catalog currently exposes;
+ * the copy and delete counts are the work that pass had to do, so a steady
+ * state reports zero for both.
+ */
+export type CatalogDumpMediaPublishedDetails = Readonly<{
+  bucketName: string;
+  desiredObjectCount: number;
+  copiedObjectCount: number;
+  deletedObjectCount: number;
+}>;
+
 export type CatalogDumpFailureDetails = Readonly<{
   bucketName: string | null;
   triggerRoute: string | null;
@@ -395,8 +408,16 @@ export type GlobalMetricsS3RetryDetails = Readonly<{
 }>;
 
 export type CatalogDumpS3RetryDetails = Readonly<{
-  /** The retry helper is shared by the artifact write and the pointer read. */
-  operation: "get_object" | "put_object";
+  /**
+   * The retry helper is shared by the artifact write, the pointer read, and the
+   * media reconcile that publishes catalog blobs to the same bucket.
+   */
+  operation:
+    | "get_object"
+    | "put_object"
+    | "list_objects"
+    | "copy_object"
+    | "delete_object";
   attempt: number;
   maxAttempts: number;
   bucketName: string;
@@ -567,6 +588,7 @@ export type OperationsBreadcrumbEvent =
   | EventByAction<"mcp_request", McpRequestDetails>
   | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
   | EventByAction<"catalog_dump_generated", CatalogDumpGeneratedDetails>
+  | EventByAction<"catalog_dump_media_published", CatalogDumpMediaPublishedDetails>
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>

--- a/infra/aws/lib/catalog-dump.ts
+++ b/infra/aws/lib/catalog-dump.ts
@@ -18,6 +18,7 @@ export interface CatalogDumpProps {
   lambdaSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
   backendDbSecret: cdk.aws_secretsmanager.Secret;
+  mediaAssetsBucket: s3.IBucket;
   baseDomain: string;
   sentryDsnSecretArn: string | undefined;
   sentryEnvironment: string | undefined;
@@ -41,6 +42,20 @@ const catalogDumpObjectKeyPrefix = "catalog";
  * through the builder's write prefix.
  */
 export const catalogDumpPointerObjectKey = `${catalogDumpObjectKeyPrefix}/pointer.json`;
+
+/**
+ * Prefix of the dump bucket the builder publishes public catalog media blobs to.
+ * Must stay in sync with `catalogMediaObjectKeyPrefix` in
+ * `apps/backend/src/catalog/distribution/public/mediaPublication.ts`.
+ */
+const catalogDumpMediaObjectKeyPrefix = `${catalogDumpObjectKeyPrefix}/media/`;
+
+/**
+ * Prefix of the private media assets bucket those blobs are copied from. Must
+ * stay in sync with `buildMediaBlobStorageKey` in
+ * `apps/backend/src/mediaAssets/storageKeys.ts`.
+ */
+const mediaAssetsBlobObjectKeyPrefix = "media/blobs/sha256/";
 
 const lambdaBundling: lambdaNodejs.BundlingOptions = {
   minify: true,
@@ -148,6 +163,7 @@ export function catalogDump(scope: Construct, props: CatalogDumpProps): CatalogD
       PUBLIC_APP_BASE_URL: parsePublicOrigin(`https://app.${props.baseDomain}`, "appBaseUrl"),
       CATALOG_DUMP_S3_BUCKET_NAME: bucket.bucketName,
       CATALOG_DUMP_CDN_BASE_URL: cdnBaseUrl,
+      MEDIA_ASSETS_S3_BUCKET_NAME: props.mediaAssetsBucket.bucketName,
     },
   });
 
@@ -156,6 +172,31 @@ export function catalogDump(scope: Construct, props: CatalogDumpProps): CatalogD
   dumpFunction.addToRolePolicy(new iam.PolicyStatement({
     actions: ["s3:PutObject"],
     resources: [bucket.arnForObjects(`${catalogDumpObjectKeyPrefix}/*`)],
+  }));
+
+  // The builder reconciles public catalog media blobs onto the CDN, so it reads
+  // the private blobs and owns the media prefix it publishes them to. Reads are
+  // scoped to the blob prefix because the reconcile only ever copies a
+  // content-addressed blob, and writes are stated on the media prefix of their
+  // own so the reconcile keeps its permissions if the artifact grant above is
+  // ever narrowed.
+  dumpFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:GetObject"],
+    resources: [props.mediaAssetsBucket.arnForObjects(`${mediaAssetsBlobObjectKeyPrefix}*`)],
+  }));
+  dumpFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:PutObject", "s3:DeleteObject"],
+    resources: [bucket.arnForObjects(`${catalogDumpMediaObjectKeyPrefix}*`)],
+  }));
+  dumpFunction.addToRolePolicy(new iam.PolicyStatement({
+    sid: "ListCatalogDumpMediaObjects",
+    actions: ["s3:ListBucket"],
+    resources: [bucket.bucketArn],
+    conditions: {
+      StringLike: {
+        "s3:prefix": [`${catalogDumpMediaObjectKeyPrefix}*`],
+      },
+    },
   }));
 
   return {

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -283,6 +283,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       lambdaSg: net.lambdaSg,
       db: dbResult.db,
       backendDbSecret: dbResult.backendDbSecret,
+      mediaAssetsBucket: mediaAssetsResult.bucket,
       baseDomain,
       ...sentryContext,
     });


### PR DESCRIPTION
### Why not presigned URLs

Workspace media already transfers directly to and from S3 with presigned URLs, and that path is untouched here. The public catalog could never use it: the snapshot is written with `Cache-Control: public, max-age=31536000, immutable` and embeds an absolute `downloadUrl` per media asset, while `downloadUrlExpiresSeconds` is one hour. An hour-long URL cannot live inside an artifact cached for a year.

So the snapshot needed a *stable* URL, and it got one pointing at the backend `/download` route, which proxies the bytes — one Lambda invocation and one Postgres connection per asset. A client pulling a whole deck issues those in parallel, which is what drove `DatabaseConnections` from 3 to 110 on 29 August.

### What this does

Reconciles published catalog media into the existing dump bucket under `catalog/media/{sha256}`, mirroring the content-addressed immutable model the snapshot already uses for itself. One idempotent pass covers publishing, backfilling the 369 already-published assets, and withdrawing delisted blobs. Copies are server-side `CopyObject`, so no blob bytes pass through the Lambda.

Content addressing dedupes identical blobs across package versions and keeps the key underivable from public catalog data.

**Nothing reads the prefix yet.** A later PR points the snapshot and the API at these keys and retires the byte proxy, at which point the 4.5 MB proxy cap goes away with it.

### Failure behavior

The reconcile fails the whole run rather than letting a snapshot be written over a partial result. It also refuses to withdraw every published object when the catalog resolves zero desired blobs while objects exist — that shape means a grant regression or a predicate bug, not an empty catalog. Both checks run before the snapshot write.

Note for operators: because that refusal is deliberate, a *legitimately* empty media set would halt dump refreshes until the `catalog/media/` prefix is purged by hand. Not reachable at 69 packages / 369 assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)