### PR TITLE
Hold the Lambda fleet to a Postgres connection budget

### DIFF
--- a/apps/auth/src/db.ts
+++ b/apps/auth/src/db.ts
@@ -9,6 +9,68 @@ import {
 import { logWarning } from "./server/logger.js";
 
 let pool: pg.Pool | undefined;
+// AuthHandler's share of the fleet-wide Postgres connection budget is stated per container, so the
+// pool has to be bounded here for its reservedConcurrentExecutions to bound anything.
+// Infrastructure owns the number: infra/aws/lib/gateways/api-gateway.ts checks the whole budget at
+// synth time and infra/aws/lib/gateways/auth-gateway.ts sets DB_POOL_MAX_CONNECTIONS from the same
+// constant, so the check governs what this container actually opens.
+const authPoolMaxConnectionsEnvName = "DB_POOL_MAX_CONNECTIONS";
+// Used for local runs. Same value and same floor reasoning as the backend pool in
+// apps/backend/src/database/core.ts.
+const defaultAuthPoolMaxConnections = 3;
+// The pg default is 0, which waits for a free connection forever.
+const authPoolConnectionTimeoutMs = 5_000;
+// The exact messages pg raises when authPoolConnectionTimeoutMs expires: the first from pg-pool
+// while queueing for a free slot, the other two from the client's own connect handshake. None
+// carries a code or a SQLSTATE, so isTransientDatabaseError in ./server/databaseErrors.js matches
+// nothing and the request would answer 500 instead of the 503 this class of failure deserves.
+const authPoolConnectionTimeoutMessages: ReadonlySet<string> = new Set([
+  "timeout exceeded when trying to connect",
+  "timeout expired",
+  "Connection terminated due to connection timeout",
+]);
+
+/**
+ * Carries a pg connection timeout as ETIMEDOUT, which isTransientDatabaseError already recognizes,
+ * so the auth error handler answers 503 with a Retry-After instead of a generic 500.
+ */
+class AuthPoolConnectionTimeoutError extends Error {
+  readonly code = "ETIMEDOUT";
+
+  constructor(cause: Error) {
+    super(`PostgreSQL pool connection timed out. cause=${cause.message}`, { cause });
+    this.name = "AuthPoolConnectionTimeoutError";
+  }
+}
+
+function resolveAuthPoolMaxConnections(): number {
+  const configuredValue = process.env[authPoolMaxConnectionsEnvName];
+  if (configuredValue === undefined || configuredValue === "") {
+    return defaultAuthPoolMaxConnections;
+  }
+
+  const parsedValue = Number(configuredValue);
+  if (!Number.isSafeInteger(parsedValue) || parsedValue < defaultAuthPoolMaxConnections) {
+    throw new Error(
+      `${authPoolMaxConnectionsEnvName} must be an integer of at least `
+        + `${defaultAuthPoolMaxConnections}. value=${configuredValue}`,
+    );
+  }
+
+  return parsedValue;
+}
+
+/**
+ * Normalizes the errors the pool raises while it is still trying to hand out a connection. Once a
+ * client is checked out these messages can no longer occur, so only checkout sites need this.
+ */
+function toAuthPoolBoundaryError(error: unknown): unknown {
+  if (error instanceof Error && authPoolConnectionTimeoutMessages.has(error.message)) {
+    return new AuthPoolConnectionTimeoutError(error);
+  }
+
+  return error;
+}
 
 type SqlValue = string | number | boolean | Date | null | ReadonlyArray<string>;
 
@@ -34,8 +96,21 @@ async function getPool(): Promise<pg.Pool> {
   }
 
   const connectionString = await getDatabaseUrl();
+  // Re-checked after the await, as apps/backend/src/database/core.ts does. decideOtpRateLimit runs
+  // eight queries through Promise.all, so on a cold container eight callers reach this point
+  // together; without the second check each would build its own pool and only the last would be
+  // reachable to close, leaving the container holding several times the budgeted connections.
+  if (pool !== undefined) {
+    return pool;
+  }
+
   const ssl = process.env.DB_SECRET_ARN ? true : false;
-  pool = new pg.Pool({ connectionString, ssl });
+  pool = new pg.Pool({
+    connectionString,
+    ssl,
+    max: resolveAuthPoolMaxConnections(),
+    connectionTimeoutMillis: authPoolConnectionTimeoutMs,
+  });
   pool.on("error", (error: Error) => {
     logWarning({
       domain: "auth",
@@ -69,7 +144,23 @@ export async function query<Row extends pg.QueryResultRow>(
   text: string,
   params: ReadonlyArray<SqlValue>,
 ): Promise<pg.QueryResult<Row>> {
-  return (await getPool()).query<Row>(text, params as Array<unknown>);
+  const activePool = await getPool();
+  try {
+    // The pool checks a connection out before it runs the statement, so a checkout or handshake
+    // timeout surfaces here too.
+    return await activePool.query<Row>(text, params as Array<unknown>);
+  } catch (error) {
+    throw toAuthPoolBoundaryError(error);
+  }
+}
+
+async function connectAuthClient(): Promise<pg.PoolClient> {
+  const activePool = await getPool();
+  try {
+    return await activePool.connect();
+  } catch (error) {
+    throw toAuthPoolBoundaryError(error);
+  }
 }
 
 export async function applyUserDatabaseScopeInExecutor(
@@ -89,7 +180,7 @@ export async function applyWorkspaceDatabaseScopeInExecutor(
 export async function transaction<Result>(
   callback: (executor: DatabaseExecutor) => Promise<Result>,
 ): Promise<Result> {
-  const client = await (await getPool()).connect();
+  const client = await connectAuthClient();
   const executor: DatabaseExecutor = {
     query<Row extends pg.QueryResultRow>(
       text: string,

--- a/apps/backend/src/database/core.ts
+++ b/apps/backend/src/database/core.ts
@@ -9,6 +9,7 @@ import {
   logDatabasePoolError,
   toDatabaseBoundaryError,
   toDatabaseCommitBoundaryError,
+  toDatabasePoolBoundaryError,
 } from "./transient";
 import {
   captureBackendRuntimeWarning,
@@ -24,7 +25,40 @@ import {
 } from "./deadline";
 
 let pool: pg.Pool | undefined;
+// Per-container share of the fleet-wide Postgres connection budget. Infrastructure owns the number:
+// infra/aws/lib/gateways/api-gateway.ts multiplies it by each DB-backed Lambda's
+// reservedConcurrentExecutions and refuses to synthesize a stack that exceeds the instance's usable
+// connections, so it sets DB_POOL_MAX_CONNECTIONS on every budgeted function to make the check
+// govern what containers actually open.
+const databasePoolMaxConnectionsEnvName = "DB_POOL_MAX_CONNECTIONS";
+// Used for local runs and for the unbudgeted scheduled-job containers, which bundle this code but
+// receive no reservation and are treated as headroom rather than as budget. 3 is a floor, not a
+// tuning choice: a handler that holds a transaction client from pool.connect() and then issues a
+// pooled query needs at least two connections in the same container, so 1 or 2 can self-deadlock.
+const defaultMainPoolMaxConnections = 3;
+// The pg default is 0, which waits for a free connection forever. Match the session advisory lock
+// pool instead, so a saturated database fails fast rather than holding the request until the Lambda
+// timeout. The errors this raises carry no code and no SQLSTATE, so every checkout goes through
+// toDatabasePoolBoundaryError to reach the caller as a retryable 503 instead of a generic 500.
+const mainPoolConnectionTimeoutMs = 5_000;
 const databaseDeadlineStorage = new AsyncLocalStorage<number>();
+
+function resolveMainPoolMaxConnections(): number {
+  const configuredValue = process.env[databasePoolMaxConnectionsEnvName];
+  if (configuredValue === undefined || configuredValue === "") {
+    return defaultMainPoolMaxConnections;
+  }
+
+  const parsedValue = Number(configuredValue);
+  if (!Number.isSafeInteger(parsedValue) || parsedValue < defaultMainPoolMaxConnections) {
+    throw new Error(
+      `${databasePoolMaxConnectionsEnvName} must be an integer of at least `
+        + `${defaultMainPoolMaxConnections}. value=${configuredValue}`,
+    );
+  }
+
+  return parsedValue;
+}
 
 export type SqlValue = string | number | boolean | Date | null | ReadonlyArray<string> | ReadonlyArray<number>;
 
@@ -46,7 +80,12 @@ export type DatabaseExecutor = Readonly<{
 
 function createDatabasePool(connectionString: string): pg.Pool {
   const ssl = process.env.DB_SECRET_ARN ? true : false;
-  const databasePool = new pg.Pool({ connectionString, ssl });
+  const databasePool = new pg.Pool({
+    connectionString,
+    ssl,
+    max: resolveMainPoolMaxConnections(),
+    connectionTimeoutMillis: mainPoolConnectionTimeoutMs,
+  });
   databasePool.on("error", (error: Error): void => {
     logDatabasePoolError("main", error);
   });
@@ -117,7 +156,9 @@ async function executeQuery<Row extends pg.QueryResultRow>(
   try {
     return await executor.query<Row>(text, params as Array<unknown>);
   } catch (error) {
-    throw toDatabaseBoundaryError(error);
+    // A pool executor checks a connection out before it runs the statement, so a checkout or
+    // handshake timeout surfaces here too.
+    throw toDatabasePoolBoundaryError(error);
   }
 }
 
@@ -302,7 +343,7 @@ async function unsafeTransactionWithBeginStatement<Result>(
   try {
     client = await (await getPool()).connect();
   } catch (error) {
-    throw toDatabaseBoundaryError(error);
+    throw toDatabasePoolBoundaryError(error);
   }
 
   const executor: DatabaseExecutor = {

--- a/apps/backend/src/database/deadline.ts
+++ b/apps/backend/src/database/deadline.ts
@@ -6,6 +6,7 @@ import {
   toDatabaseBoundaryError,
   toDatabaseCommitBoundaryError,
   toDatabaseCommitOutcomeUnknownError,
+  toDatabasePoolBoundaryError,
   type DatabaseBoundaryErrorFields,
 } from "./transient";
 
@@ -177,7 +178,7 @@ async function connectUntilDeadline(pool: pg.Pool, deadlineAtMs: number): Promis
   try {
     connectPromise = pool.connect();
   } catch (error) {
-    throw toDatabaseBoundaryError(error);
+    throw toDatabasePoolBoundaryError(error);
   }
 
   return new Promise<pg.PoolClient>((resolve, reject) => {
@@ -209,7 +210,7 @@ async function connectUntilDeadline(pool: pg.Pool, deadlineAtMs: number): Promis
         if (settled) return;
         clearTimeout(timer);
         settled = true;
-        reject(toDatabaseBoundaryError(error));
+        reject(toDatabasePoolBoundaryError(error));
       },
     ).catch((error: unknown) => {
       logDatabasePoolError("deadline-late-checkout-release", error);

--- a/apps/backend/src/database/transient.ts
+++ b/apps/backend/src/database/transient.ts
@@ -35,6 +35,15 @@ const transientDatabaseMessageFragments: ReadonlyArray<string> = [
   "connection terminated unexpectedly",
 ];
 
+// The exact, unabbreviated messages pg raises when connectionTimeoutMillis expires: the first from
+// pg-pool while queueing for a free slot, the other two from the client's own connect handshake.
+// Matched whole rather than as fragments, so only these three failures are reclassified.
+const databasePoolConnectionTimeoutMessages: ReadonlySet<string> = new Set([
+  "timeout exceeded when trying to connect",
+  "timeout expired",
+  "Connection terminated due to connection timeout",
+]);
+
 const transientDatabaseRetryMaxAttempts = 3;
 const transientDatabaseRetryBaseDelayMs = 100;
 const transientDatabaseRetryCapDelayMs = 750;
@@ -166,6 +175,20 @@ function tryLogDatabaseTransientRetry(
   }
 }
 
+/**
+ * Carries a pg connection timeout as ETIMEDOUT, which isTransientDatabaseError already recognizes,
+ * so the failure reaches the caller as a retryable 503 instead of an unclassified 500. Mirrors
+ * SessionAdvisoryLockConnectionTimeoutError in sessionAdvisoryLock.ts.
+ */
+export class DatabasePoolConnectionTimeoutError extends Error {
+  readonly code = "ETIMEDOUT";
+
+  constructor(cause: Error) {
+    super(`PostgreSQL pool connection timed out. cause=${cause.message}`, { cause });
+    this.name = "DatabasePoolConnectionTimeoutError";
+  }
+}
+
 export class TransientDatabaseHttpError extends HttpError implements DatabaseBoundaryErrorFields {
   readonly sqlState: string | null;
   readonly errorCode: string | null;
@@ -239,6 +262,28 @@ export function toDatabaseBoundaryError(error: unknown): unknown {
   }
 
   return new TransientDatabaseHttpError(error);
+}
+
+/**
+ * Normalizes the errors a bounded pg pool raises while it is still trying to hand out a connection,
+ * then classifies them like any other database failure.
+ *
+ * pg answers a failed acquisition with a bare Error: no `code` and no SQLSTATE, so
+ * isTransientDatabaseError matches nothing and the caller would see a generic 500 for what is
+ * plainly a retryable capacity or reachability problem. The message is the only thing that names it.
+ * Normalizing here rather than widening transientDatabaseMessageFragments keeps the classifier
+ * untouched for the session advisory lock pool, which treats a checkout timeout as its own distinct
+ * capacity condition (sessionAdvisoryLock.ts) rather than as a transient database error.
+ *
+ * Use this wherever a pool checkout or a connection handshake can fail. Once a client is checked
+ * out, these messages can no longer occur, so plain toDatabaseBoundaryError is enough there.
+ */
+export function toDatabasePoolBoundaryError(error: unknown): unknown {
+  if (error instanceof Error && databasePoolConnectionTimeoutMessages.has(error.message)) {
+    return toDatabaseBoundaryError(new DatabasePoolConnectionTimeoutError(error));
+  }
+
+  return toDatabaseBoundaryError(error);
 }
 
 export function toDatabaseCommitOutcomeUnknownError(error: unknown): HttpError {

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -88,6 +88,9 @@ interface BackendFunctionProps {
   memorySize: number;
   architecture: lambda.Architecture;
   bundling: lambdaNodejs.BundlingOptions;
+  // Required, not defaulted: each caller states its own share of the Postgres connection budget
+  // recorded below at databasePoolMaxConnectionsPerContainer rather than silently inheriting one.
+  reservedConcurrentExecutions: number;
 }
 
 interface DirectImageIngestionFunctionProps {
@@ -117,6 +120,135 @@ const productAnalyticsIngestThrottlingRateLimit = 20;
 const productAnalyticsIngestThrottlingBurstLimit = 40;
 export const directImageIngestionMaximumOnDemandInitSeconds = 10;
 export const directImageIngestionLambdaTimeoutSeconds = 15;
+
+// Postgres connection budget for the DB-backed Lambda fleet.
+//
+//   sum(reservedConcurrentExecutions) * databasePoolMaxConnectionsPerContainer
+//     <= usableDatabaseConnections
+//
+// Every budgeted function states its share below, so a burst on any one route cannot take the
+// database out from under the others. Without both factors the bound does not exist: an unreserved
+// function scales to the account limit, and an unbounded pool multiplies each container by the pg
+// default of 10. Both factors are therefore machine-enforced from here: the checks under the
+// constants bound the summed reservations from above and the pool max from below at synth time, and
+// every budgeted function receives databasePoolMaxConnectionsPerContainer as
+// DB_POOL_MAX_CONNECTIONS, which apps/backend/src/database/core.ts and apps/auth/src/db.ts read when
+// they build their pools. Do not hardcode a pool max in either application; a value set there alone
+// would leave these checks passing while the guarantee silently broke.
+//
+// Hard guarantee. db.t4g.micro derives max_connections = LEAST({DBInstanceClassMemory/9531392},
+// 5000) ~= 112, about 3 of which are held for superusers, leaving ~109 usable. The reservations
+// below total 33 containers, so the worst case is 33 x 3 = 99 <= 109. That holds on the current
+// instance and does not depend on an instance-class upgrade landing first. The check under the
+// constants enforces it at synth time.
+//
+// Expected steady state. A warm container holds close to one connection, not the pool ceiling. This
+// is measured, not assumed: during the 2026-08-29 06:40 UTC burst BackendHandler
+// ConcurrentExecutions peaked at 110 in the same minute DatabaseConnections peaked at 110, a ratio
+// of about 1.1. So the expected draw here is 33 x ~1.1 ~= 36 connections, comfortably below the 62
+// this instance already carries. databasePoolMaxConnectionsPerContainer is a per-container safety
+// ceiling, not the expected per-container draw.
+//
+// Do not raise the total past 36 containers while the instance is db.t4g.micro: 36 x 3 = 108 is the
+// last allocation the synth check accepts, and it leaves nothing for the carve-outs below. Treat 33
+// as the practical ceiling until the instance grows.
+//
+// Do not lower databasePoolMaxConnectionsPerContainer below
+// minimumDatabasePoolMaxConnectionsPerContainer either. It is a floor, not a lever for fitting more
+// containers under that ceiling: a handler that holds a transaction client from pool.connect() and
+// then issues a pooled query needs at least two connections in the same container, so 1 or 2 can
+// self-deadlock. Both application pools already refuse to start below the floor
+// (defaultMainPoolMaxConnections in apps/backend/src/database/core.ts and
+// defaultAuthPoolMaxConnections in apps/auth/src/db.ts), so lowering it here would not buy container
+// headroom, it would throw on the first pool build in every DB-backed Lambda. The synth check
+// enforces that direction too, so the stack cannot deploy a value the fleet cannot run.
+//
+// Carve-outs. Two real draws on this database sit outside the factor above and are covered by
+// headroom rather than by budget, so 99 is this budget's ceiling and not the whole fleet's:
+//
+//   Secondary pools. A backend container may additionally open the session advisory lock pool
+//   (max: 2), the product analytics writer pool (max: 4), and the reporting pool (max: 4). Each is
+//   separately bounded where it is created.
+//
+//   Unreserved scheduled jobs. WebGuestReaperHandler, CommunityLeaderboardSnapshotHandler,
+//   StreakLeaderboardSnapshotHandler, ProgressActiveDaysBackfillHandler,
+//   MultipartCompletionReconciliationHandler and GeneratedMediaPromotionHandler bundle the same
+//   backend code and receive DB_SECRET_ARN, so they open this same main pool with no reservation of
+//   their own. They stay out of the budget deliberately: each is cron-driven and effectively
+//   serialized at roughly one container, a small and predictable draw rather than a burst source.
+//   (CatalogDumpHandler already pins reservedConcurrentExecutions to 1. GlobalMetricsSnapshotHandler
+//   and its freshness checker draw on the reporting pool only, and DbMigrationHandler connects with
+//   its own owner credentials, so neither touches this pool.)
+//
+// The honest worst case is therefore 99 from the budget plus those carve-outs, not 99 flat. Against
+// the current ~109 that is tight and the remaining headroom is deliberately thin: do not read
+// 109 - 99 = 10 as room to grow the allocation toward 36 containers. The db.t4g.small upgrade takes
+// effect at the next sun:03:00-sun:03:30 UTC maintenance window and roughly doubles the derived
+// ceiling to ~225, about ~222 usable, where the full pessimistic figure fits comfortably. Raise
+// usableDatabaseConnections only once that window has passed and the new max_connections is
+// confirmed on the instance.
+//
+// Once a reservation saturates, Lambda throttles and the caller sees a gateway error. That bounded,
+// observable rejection is the intended trade against an unbounded database outage.
+//
+// Sizing comes from ConcurrentExecutions observed 2026-08-22 to 2026-08-29, not from dividing the
+// budget across handlers, so each reservation sits above that handler's observed weekly demand.
+export const databasePoolMaxConnectionsPerContainer = 3;
+// The floor described above. Deliberately not shared with the applications: neither runtime can
+// import this file, so each keeps its own copy where it builds its pool and this one exists to stop
+// an unrunnable value from being synthesized in the first place.
+const minimumDatabasePoolMaxConnectionsPerContainer = 3;
+export const usableDatabaseConnections = 109;
+// Read by apps/backend/src/database/core.ts and apps/auth/src/db.ts when they build their pools.
+// Set it on every function that opens one of those pools and carries a reservation above.
+export const databasePoolMaxConnectionsEnvName = "DB_POOL_MAX_CONNECTIONS";
+export const databasePoolMaxConnectionsEnvValue = String(databasePoolMaxConnectionsPerContainer);
+// Observed p50/p95/max 1/4/110, where the 110 max was the catalog media fan-out that the CDN work
+// removes. 2x p95.
+export const backendHandlerReservedConcurrency = 8;
+// Observed 1/3/19. 2x p95.
+export const authHandlerReservedConcurrency = 6;
+// Observed 1/1/9. 4x p95.
+export const mcpHandlerReservedConcurrency = 4;
+// Observed 1/4/8, sized above the weekly max. SSE holds a container for the whole stream, up to
+// 222 s, so concurrency here is set by session duration rather than by requests per second; sizing
+// it like a short request handler would throttle live AI chat at its ordinary p95.
+const chatLiveHandlerReservedConcurrency = 10;
+// Observed 1/1/2, sized above the weekly max. A run holds a container up to 720 s, under the shared
+// 15-minute timeout, so the same duration-driven reasoning applies.
+const chatRunWorkerHandlerReservedConcurrency = 3;
+// Observed 1/1/2. At the weekly max.
+const directImageIngestionHandlerReservedConcurrency = 2;
+
+const budgetedDatabaseConnections = [
+  backendHandlerReservedConcurrency,
+  authHandlerReservedConcurrency,
+  mcpHandlerReservedConcurrency,
+  chatLiveHandlerReservedConcurrency,
+  chatRunWorkerHandlerReservedConcurrency,
+  directImageIngestionHandlerReservedConcurrency,
+].reduce((total, reserved) => total + reserved, 0) * databasePoolMaxConnectionsPerContainer;
+
+if (databasePoolMaxConnectionsPerContainer < minimumDatabasePoolMaxConnectionsPerContainer) {
+  throw new Error(
+    "Per-container Postgres pool max is below the floor both application pools enforce, so every "
+      + "DB-backed Lambda would throw on its first pool build. Keep it at or above the floor; if "
+      + "the floor itself ever moves, change defaultMainPoolMaxConnections in "
+      + "apps/backend/src/database/core.ts and defaultAuthPoolMaxConnections in "
+      + "apps/auth/src/db.ts in the same change. "
+      + `configured=${databasePoolMaxConnectionsPerContainer}; `
+      + `floor=${minimumDatabasePoolMaxConnectionsPerContainer}`,
+  );
+}
+
+if (budgetedDatabaseConnections > usableDatabaseConnections) {
+  throw new Error(
+    "DB-backed Lambda concurrency exceeds the usable Postgres connection budget. "
+      + `budgeted=${budgetedDatabaseConnections}; `
+      + `usable=${usableDatabaseConnections}`,
+  );
+}
+
 const allowAllRobotsBody = "User-agent: *\nDisallow:\n";
 
 export type DirectImageIngestionApiRoutes = Readonly<{
@@ -622,6 +754,7 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
     architecture: props.architecture,
     timeout: cdk.Duration.minutes(15),
     memorySize: props.memorySize,
+    reservedConcurrentExecutions: props.reservedConcurrentExecutions,
     ...backendStructuredLoggingProps,
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -634,6 +767,7 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
       REPORTING_DB_SECRET_ARN: props.reportingDbSecret.secretArn,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "flashcards",
+      [databasePoolMaxConnectionsEnvName]: databasePoolMaxConnectionsEnvValue,
       AUTH_MODE: "cognito",
       COGNITO_USER_POOL_ID: props.userPoolId,
       COGNITO_CLIENT_ID: props.userPoolClientId,
@@ -742,6 +876,7 @@ function createDirectImageIngestionFunction(
     architecture: lambda.Architecture.ARM_64,
     timeout: cdk.Duration.seconds(directImageIngestionLambdaTimeoutSeconds),
     memorySize: 1024,
+    reservedConcurrentExecutions: directImageIngestionHandlerReservedConcurrency,
     ...backendStructuredLoggingProps,
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -756,6 +891,7 @@ function createDirectImageIngestionFunction(
       DB_SECRET_ARN: props.backendDbSecret.secretArn,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "flashcards",
+      [databasePoolMaxConnectionsEnvName]: databasePoolMaxConnectionsEnvValue,
       AUTH_MODE: "cognito",
       COGNITO_USER_POOL_ID: props.userPoolId,
       COGNITO_CLIENT_ID: props.userPoolClientId,
@@ -875,6 +1011,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     catalogDumpArtifactConfig: props.catalogDumpArtifact,
     memorySize: 2048,
     architecture: lambda.Architecture.ARM_64,
+    reservedConcurrentExecutions: backendHandlerReservedConcurrency,
     bundling: createLambdaBundling({
       nodeModules: ["sharp"],
       forceDockerBundling: true,
@@ -933,6 +1070,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     catalogDumpArtifactConfig: undefined,
     memorySize: 1024,
     architecture: lambda.Architecture.ARM_64,
+    reservedConcurrentExecutions: chatRunWorkerHandlerReservedConcurrency,
     bundling: createLambdaBundling({
       nodeModules: ["sharp"],
       forceDockerBundling: true,
@@ -975,6 +1113,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     catalogDumpArtifactConfig: undefined,
     memorySize: 256,
     architecture: lambda.Architecture.X86_64,
+    reservedConcurrentExecutions: chatLiveHandlerReservedConcurrency,
     bundling: createLambdaBundling({
       nodeModules: [],
       forceDockerBundling: false,

--- a/infra/aws/lib/gateways/auth-gateway.ts
+++ b/infra/aws/lib/gateways/auth-gateway.ts
@@ -7,6 +7,11 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 import { createSafeApiGatewayAccessLogFormat } from "./api-gateway-access-log";
+import {
+  authHandlerReservedConcurrency,
+  databasePoolMaxConnectionsEnvName,
+  databasePoolMaxConnectionsEnvValue,
+} from "./api-gateway";
 import { authNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
 
 export interface AuthGatewayProps {
@@ -154,6 +159,8 @@ export function authGateway(scope: Construct, props: AuthGatewayProps): AuthGate
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.seconds(30),
     memorySize: 256,
+    // Share of the Postgres connection budget documented in ./api-gateway.ts.
+    reservedConcurrentExecutions: authHandlerReservedConcurrency,
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     securityGroups: [props.lambdaSg],
@@ -164,6 +171,7 @@ export function authGateway(scope: Construct, props: AuthGatewayProps): AuthGate
       DB_SECRET_ARN: props.authDbSecret.secretArn,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "flashcards",
+      [databasePoolMaxConnectionsEnvName]: databasePoolMaxConnectionsEnvValue,
       COGNITO_USER_POOL_ID: props.userPoolId,
       COGNITO_CLIENT_ID: props.userPoolClientId,
       COGNITO_REGION: cdk.Stack.of(scope).region,

--- a/infra/aws/lib/gateways/mcp-gateway.ts
+++ b/infra/aws/lib/gateways/mcp-gateway.ts
@@ -14,6 +14,11 @@ import {
 } from "./api-gateway-access-log";
 import { backendNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
 import { backendStructuredLoggingProps } from "../backend-lambda-logging";
+import {
+  databasePoolMaxConnectionsEnvName,
+  databasePoolMaxConnectionsEnvValue,
+  mcpHandlerReservedConcurrency,
+} from "./api-gateway";
 
 export interface McpGatewayProps {
   vpc: ec2.Vpc;
@@ -194,6 +199,8 @@ export function mcpGateway(scope: Construct, props: McpGatewayProps): McpGateway
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.seconds(30),
     memorySize: 256,
+    // Share of the Postgres connection budget documented in ./api-gateway.ts.
+    reservedConcurrentExecutions: mcpHandlerReservedConcurrency,
     ...backendStructuredLoggingProps,
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -205,6 +212,7 @@ export function mcpGateway(scope: Construct, props: McpGatewayProps): McpGateway
       DB_SECRET_ARN: props.backendDbSecret.secretArn,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "flashcards",
+      [databasePoolMaxConnectionsEnvName]: databasePoolMaxConnectionsEnvValue,
       MCP_BASE_DOMAIN: props.baseDomain,
       // The MCP sql_query and sql_execute tools return the shared agent
       // envelope; pin `docs.discoveryUrl` to the public API host instead of


### PR DESCRIPTION
Nothing bounded how many connections the fleet could open. `createDatabasePool` declared no `max`, so pg allowed ten per container, and no API Lambda declared `reservedConcurrentExecutions`.

On 29 August a burst of parallel catalog media downloads drove `ConcurrentExecutions` to 110; `DatabaseConnections` followed it to 110 **in the same minute**, and every DB-backed request answered 503 until the burst passed. That 1:1 ratio is also the measurement this budget is sized from — a warm container holds about one connection, not `max`.

### The budget

| Function | observed p50 / p95 / max | reserved |
| --- | --- | --- |
| `BackendHandler` | 1 / 4 / 110 (the incident) | 8 |
| `ChatLiveHandler` | 1 / 4 / 8 | 10 |
| `ChatRunWorkerHandler` | 1 / 1 / 2 | 3 |
| `AuthHandler` | 1 / 3 / 19 | 6 |
| `McpHandler` | 1 / 1 / 9 | 4 |
| `DirectImageIngestionHandler` | 1 / 1 / 2 | 2 |

33 containers. Hard guarantee `33 × 3 = 99 ≤ 109` holds on the current instance, so this does not depend on the `db.t4g.small` resize landing first.

`ChatLive` and `ChatRunWorker` are why the table is not derived from request rate: they hold a container for a whole SSE stream (up to 222 s observed) or AI run (up to 720 s), so sizing them like short request handlers would throttle live AI chat at its ordinary p95.

`max: 3` is a floor, not a tuning choice — a handler holding a transaction client from `pool.connect()` and then issuing a pooled query needs two connections in one container, so 1 or 2 can self-deadlock. Both factors are enforced at synth time, bounded above by the summed reservations and below by the pool floor, so neither can drift into a configuration the runtime rejects.

### Two repairs the budget depends on

- **The new connect timeout created an unclassified error class.** pg raises `timeout exceeded when trying to connect` and `Connection terminated due to connection timeout` with no `code`, matching no transient fragment — so a saturated or cold-starting database would have answered a non-retryable 500 instead of the retryable 503 the timeout exists to produce. Normalized at every pool checkout site (including both in `deadline.ts`, the dominant request path) into an `ETIMEDOUT`-coded error, following the existing `sessionAdvisoryLock.ts` precedent rather than broadening the shared fragment list.
- **Auth's pool initializer only re-checked before its `await`.** `decideOtpRateLimit` issues eight concurrent queries via `Promise.all` on the ordinary OTP path, so on a cold container all eight built their own `pg.Pool` and seven were orphaned with no reference left to `end()` — defeating the very budget this PR sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)