### PR TITLE
Let a hovered review button hand the shortcuts back the keyboard

### DIFF
--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -9,6 +9,7 @@ import type { ReviewLoadingSnapshot } from "../../shared/loadingSnapshots";
 import { formatTagSummary } from "../../shared/featureFormatting";
 import { ReviewCardSide, ReviewCardSpeechButton, ReviewEditIcon } from "./card/ReviewCardSide";
 import { reviewRatingShortcutKeys } from "../input/reviewShortcutKeys";
+import type { ReviewShortcutPointerEnterHandler } from "../input/useReviewKeyboardShortcuts";
 import type { ReviewButtonOption } from "./reviewRatingOptions";
 import type { ReviewSpeechSide } from "../speech/reviewSpeech";
 import {
@@ -42,6 +43,7 @@ export type ReviewPaneProps = Readonly<{
   onEditCard: (card: Card) => void;
   onRevealAnswer: () => void;
   onReview: (card: Card, rating: ReviewRating) => Promise<void>;
+  onShortcutButtonPointerEnter: ReviewShortcutPointerEnterHandler;
   onSwitchToAllCards: () => void;
   onToggleSpeech: (side: ReviewSpeechSide, sourceText: string) => void;
   reviewButtonErrorMessage: string;
@@ -77,6 +79,7 @@ type ReviewActiveCardPaneProps = Readonly<{
   onEditCard: (card: Card) => void;
   onRevealAnswer: () => void;
   onReview: (card: Card, rating: ReviewRating) => Promise<void>;
+  onShortcutButtonPointerEnter: ReviewShortcutPointerEnterHandler;
   onToggleSpeech: (side: ReviewSpeechSide, sourceText: string) => void;
   reviewButtonErrorMessage: string;
   reviewButtonOptions: ReadonlyArray<ReviewButtonOption>;
@@ -89,6 +92,7 @@ type ReviewActiveCardPaneProps = Readonly<{
 type ReviewRatingButtonColumnProps = Readonly<{
   isSubmitting: boolean;
   onReview: (rating: ReviewRating) => void;
+  onShortcutButtonPointerEnter: ReviewShortcutPointerEnterHandler;
   options: ReadonlyArray<ReviewButtonOption>;
 }>;
 
@@ -268,7 +272,7 @@ function ReviewEmptyPane(props: ReviewEmptyPaneProps): ReactElement {
 }
 
 function ReviewRatingButtonColumn(props: ReviewRatingButtonColumnProps): ReactElement {
-  const { isSubmitting, onReview, options } = props;
+  const { isSubmitting, onReview, onShortcutButtonPointerEnter, options } = props;
 
   return (
     <div className="rating-bar-column">
@@ -280,6 +284,7 @@ function ReviewRatingButtonColumn(props: ReviewRatingButtonColumnProps): ReactEl
           aria-keyshortcuts={reviewRatingShortcutKeys[option.rating]}
           disabled={isSubmitting}
           onClick={() => onReview(option.rating)}
+          onPointerEnter={onShortcutButtonPointerEnter}
           data-testid={`review-rate-${option.testId}`}
         >
           <span className="rating-btn-title">{option.title}</span>
@@ -301,6 +306,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     onEditCard,
     onRevealAnswer,
     onReview,
+    onShortcutButtonPointerEnter,
     onToggleSpeech,
     reviewButtonErrorMessage,
     reviewButtonOptions,
@@ -424,6 +430,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
                 onReview={(rating) => {
                   void onReview(selectedCard, rating);
                 }}
+                onShortcutButtonPointerEnter={onShortcutButtonPointerEnter}
                 options={leftReviewButtonOptions}
               />
               <ReviewRatingButtonColumn
@@ -431,6 +438,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
                 onReview={(rating) => {
                   void onReview(selectedCard, rating);
                 }}
+                onShortcutButtonPointerEnter={onShortcutButtonPointerEnter}
                 options={rightReviewButtonOptions}
               />
             </div>
@@ -441,6 +449,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
             className="primary-btn review-reveal-btn"
             aria-keyshortcuts={REVIEW_REVEAL_SHORTCUT_ARIA_KEY}
             onClick={onRevealAnswer}
+            onPointerEnter={onShortcutButtonPointerEnter}
             data-testid="review-reveal-answer"
           >
             {t("reviewScreen.actions.revealAnswer")}
@@ -466,6 +475,7 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
     onEditCard,
     onRevealAnswer,
     onReview,
+    onShortcutButtonPointerEnter,
     onSwitchToAllCards,
     onToggleSpeech,
     reviewButtonErrorMessage,
@@ -517,6 +527,7 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
           onEditCard={onEditCard}
           onRevealAnswer={onRevealAnswer}
           onReview={onReview}
+          onShortcutButtonPointerEnter={onShortcutButtonPointerEnter}
           onToggleSpeech={onToggleSpeech}
           reviewButtonErrorMessage={reviewButtonErrorMessage}
           reviewButtonOptions={reviewButtonOptions}

--- a/apps/web/src/screens/review/input/useReviewKeyboardShortcuts.ts
+++ b/apps/web/src/screens/review/input/useReviewKeyboardShortcuts.ts
@@ -1,6 +1,8 @@
-import { useEffect, useEffectEvent } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef, type PointerEvent as ReactPointerEvent } from "react";
 import type { Card } from "../../../types";
 import { reviewRevealShortcutKey, reviewShortcutRatingsByKey } from "./reviewShortcutKeys";
+
+export type ReviewShortcutPointerEnterHandler = (event: ReactPointerEvent<HTMLButtonElement>) => void;
 
 type UseReviewKeyboardShortcutsParams = Readonly<{
   handleReview: (card: Card, rating: 0 | 1 | 2 | 3) => Promise<void>;
@@ -16,7 +18,11 @@ type UseReviewKeyboardShortcutsParams = Readonly<{
   setIsAnswerVisible: (value: boolean) => void;
 }>;
 
-function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+type UseReviewKeyboardShortcutsResult = Readonly<{
+  handleShortcutButtonPointerEnter: ReviewShortcutPointerEnterHandler;
+}>;
+
+function isEditableKeyboardTarget(target: EventTarget | null): target is HTMLElement {
   if (!(target instanceof HTMLElement)) {
     return false;
   }
@@ -30,7 +36,7 @@ function isEditableKeyboardTarget(target: EventTarget | null): boolean {
     || target instanceof HTMLSelectElement;
 }
 
-export function useReviewKeyboardShortcuts(params: UseReviewKeyboardShortcutsParams): void {
+export function useReviewKeyboardShortcuts(params: UseReviewKeyboardShortcutsParams): UseReviewKeyboardShortcutsResult {
   const {
     handleReview,
     isAnswerVisible,
@@ -44,16 +50,18 @@ export function useReviewKeyboardShortcuts(params: UseReviewKeyboardShortcutsPar
     selectedCard,
     setIsAnswerVisible,
   } = params;
+  const isImeCompositionActiveRef = useRef<boolean>(false);
+  const areShortcutsSuppressed = isSubmitting
+    || isEditorPresented
+    || isFeedbackDialogOpen
+    || isHardReminderVisible
+    || isMobileAppPromotionDialogOpen
+    || isReviewFilterMenuOpen;
 
   const handleDocumentKeyDown = useEffectEvent((event: KeyboardEvent) => {
     if (
       selectedCard === null
-      || isSubmitting
-      || isEditorPresented
-      || isFeedbackDialogOpen
-      || isHardReminderVisible
-      || isMobileAppPromotionDialogOpen
-      || isReviewFilterMenuOpen
+      || areShortcutsSuppressed
       || isEditableKeyboardTarget(event.target)
     ) {
       return;
@@ -88,4 +96,44 @@ export function useReviewKeyboardShortcuts(params: UseReviewKeyboardShortcutsPar
     document.addEventListener("keydown", handleDocumentKeyDown);
     return () => document.removeEventListener("keydown", handleDocumentKeyDown);
   }, [handleDocumentKeyDown]);
+
+  useEffect(() => {
+    function handleCompositionStart(): void {
+      isImeCompositionActiveRef.current = true;
+    }
+
+    function handleCompositionEnd(): void {
+      isImeCompositionActiveRef.current = false;
+    }
+
+    document.addEventListener("compositionstart", handleCompositionStart);
+    document.addEventListener("compositionend", handleCompositionEnd);
+    return () => {
+      document.removeEventListener("compositionstart", handleCompositionStart);
+      document.removeEventListener("compositionend", handleCompositionEnd);
+    };
+  }, []);
+
+  // Mouse hover over a review action button releases text-field focus so the document-level
+  // shortcuts start working. Focus is only released, never moved onto the hovered button,
+  // because a focused rating button would be natively activated by Space or Enter.
+  const handleShortcutButtonPointerEnter = useCallback(function handleShortcutButtonPointerEnter(event: ReactPointerEvent<HTMLButtonElement>): void {
+    if (
+      event.pointerType !== "mouse"
+      || isImeCompositionActiveRef.current
+      || selectedCard === null
+      || areShortcutsSuppressed
+    ) {
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    if (!isEditableKeyboardTarget(activeElement)) {
+      return;
+    }
+
+    activeElement.blur();
+  }, [areShortcutsSuppressed, selectedCard]);
+
+  return { handleShortcutButtonPointerEnter };
 }

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -420,7 +420,7 @@ export function useReviewScreenController(
     };
   }, [stopSpeech]);
 
-  useReviewKeyboardShortcuts({
+  const { handleShortcutButtonPointerEnter } = useReviewKeyboardShortcuts({
     handleReview: async (card, rating) => {
       await handleReview(card, rating);
     },
@@ -567,6 +567,7 @@ export function useReviewScreenController(
       onEditCard: handleOpenEditor,
       onRevealAnswer: handleRevealAnswer,
       onReview: handleReview,
+      onShortcutButtonPointerEnter: handleShortcutButtonPointerEnter,
       onSwitchToAllCards: handleSwitchToAllCards,
       onToggleSpeech: toggleSpeech,
       reviewButtonErrorMessage,


### PR DESCRIPTION
Follow-up to the hotkey hint tooltip. With the AI chat sidebar open, focus normally sits in its composer, so pressing `Space` or `1`-`4` for the review screen typed into the textarea instead of rating the card — the hint promised something that did not work.

Hovering one of the five review action buttons with a **mouse** now blurs the focused text field. That alone is enough: the document-level shortcut handler only bails on editable targets, so once focus falls back to the body the keys work.

Deliberately narrow:

- Focus is **released, never moved**. A focused rating button would be natively activated by `Space`/`Enter` and would rate the card behind the handler's back.
- Nothing happens when the active element is not editable — focus you are holding elsewhere is left alone until you hover these buttons again.
- Mouse only (`pointerType === "mouse"`); touch and pen unaffected.
- Skipped during an IME composition, so ja/zh/hi input is never committed or dropped mid-word.
- Suppressed by the same flags that already suppress the shortcuts (editor, dialogs, filter menu, submitting).
- Focus is never restored, and only the four rating buttons plus the interactive reveal button are wired — the loading placeholder and every other screen are untouched.

No visual change, no CSS. Web only. No new tests per repository policy; existing suites and the e2e flow do not depend on hover or focus over these buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)