### PR TITLE
Stop a link in flight writing to an account the person left

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -54,6 +54,13 @@ extension FlashcardsStore {
             }
             await self.blockGuestUpgradeLocalOutboxMutationsBeforeDrain()
             do {
+                // The wait above is a bare `withCheckedContinuation` with no cancellation handler,
+                // so a body parked in it never observes the cancel and resumes on its own schedule.
+                // Re-read it here. Inside the `do` and before the drain on purpose: the drain's own
+                // catch sets `syncStatus` and `globalErrorMessage` without short-circuiting on
+                // cancellation, and someone who just erased their data must not be shown an error
+                // about it. The catch below only unblocks mutations and rethrows.
+                try Task.checkCancellation()
                 // Guest upgrade completion only merges already-synced cloud state.
                 // Drain normal guest sync first so no pending guest outbox is carried
                 // into the linked workspace.
@@ -62,6 +69,9 @@ extension FlashcardsStore {
                     configuration: configuration,
                     trigger: trigger
                 )
+                // The drain suspends, so re-read the cancel before writing this identity's
+                // credentials and the pending-upgrade record that follows them.
+                try Task.checkCancellation()
                 try self.cloudRuntime.saveCredentials(credentials: linkContext.credentials)
                 let inFlightState = pendingGuestUpgradeInFlightState(
                     linkContext: linkContext,
@@ -208,6 +218,11 @@ extension FlashcardsStore {
         return try self.matchingInFlightPendingGuestUpgradeState(apiBaseUrl: apiBaseUrl) != nil
     }
 
+    /// Call it only from a workspace completion body that reaches it with nothing suspended since
+    /// the task head. The credential write below has no cancellation read of its own and relies on
+    /// the head check in `CloudSessionRuntime.runWorkspaceCompletion`; a caller that arrives here
+    /// through an await would restore the abandoned account's credentials after an erase cleared
+    /// them, and has to read the cancel itself first.
     func finalizeCompletedPendingGuestUpgradeForRecoveredLinkIfNeeded(
         linkContext: CloudWorkspaceLinkContext,
         trigger: CloudSyncTrigger
@@ -447,12 +462,20 @@ extension FlashcardsStore {
         state: PendingGuestUpgradeCompletedState,
         trigger: CloudSyncTrigger
     ) async throws {
+        // Reached from three completion bodies, each through an await, and the credential load below
+        // both marks recovery state and refreshes credentials for this identity, so one check here
+        // covers all three callers. Throwing from inside two of those callers' `do` still runs their
+        // `applyCloudAccountPreferences` defer, which is safe on its own terms: it is keyed on the
+        // current account identity and returns early once the reset has changed that key.
+        try Task.checkCancellation()
         let credentials = try await self.loadPendingGuestUpgradeCredentials(
             commonState: state.common,
             detectedAt: trigger.now
         )
         let linkedSession = cloudLinkedSession(state: state, credentials: credentials)
 
+        // The credential load suspends too, so re-read the cancel before the link is finished.
+        try Task.checkCancellation()
         try await self.finishCompletedGuestCloudLink(
             linkedSession: linkedSession,
             workspace: state.workspace,
@@ -510,6 +533,10 @@ extension FlashcardsStore {
                 state: inFlightState,
                 workspace: workspace
             )
+            // The backend completion above suspends. Persisting the checkpoint after an erase would
+            // leave a pending-upgrade record naming the abandoned account behind a reset that has
+            // already cleared it, so the write re-reads cancellation rather than trusting the await.
+            try Task.checkCancellation()
             try self.savePendingGuestUpgradeState(state: .completed(completionState))
             return completionState
         }
@@ -670,6 +697,11 @@ extension FlashcardsStore {
             // Backend completion already merged drained guest cloud state.
             // Do not migrate any local guest outbox; switch locally and hydrate
             // the linked workspace from remote instead.
+            //
+            // Nothing suspends between the head of the link transition task and this migration, so
+            // the head check in `CloudSessionRuntime.runCloudLinkTransition` is the only cancellation
+            // read it gets. Anything awaited above it needs its own read, or an erase lands here and
+            // this deletes the workspace it just created.
             try context.database.switchGuestUpgradeToLinkedWorkspaceFromRemote(
                 localWorkspaceId: context.workspaceId,
                 linkedSession: linkedSession,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -140,6 +140,11 @@ final class CloudSessionRuntime {
             idToken: refreshedToken.idToken,
             idTokenExpiresAt: refreshedToken.idTokenExpiresAt
         )
+        // The network refresh above is a suspension an identity abandonment can land in, and this
+        // line writes credentials. Resuming past a cancel would put the abandoned account's
+        // credentials back into the Keychain that the reset around `cancelForAccountDeletion` has
+        // just cleared, so the write has to re-read cancellation rather than trust the await.
+        try Task.checkCancellation()
         try self.credentialStore.saveCredentials(credentials: updatedCredentials)
 
         if let activeCloudSession = self.state.activeCloudSession {
@@ -268,7 +273,11 @@ final class CloudSessionRuntime {
         let linkTransition = CloudLinkTransitionState(
             id: UUID().uuidString.lowercased(),
             task: Task { @MainActor in
-                try await operation()
+                // The same head window `runWorkspaceCompletion` guards below, and it matters more
+                // here: a body of this task can reach a workspace write with nothing suspending in
+                // front of it, and for such a write this read is the only one it gets.
+                try Task.checkCancellation()
+                return try await operation()
             }
         )
         self.state.activeCloudLinkTask = linkTransition
@@ -296,7 +305,12 @@ final class CloudSessionRuntime {
         let workspaceCompletion = CloudWorkspaceCompletionState(
             id: UUID().uuidString.lowercased(),
             task: Task { @MainActor in
-                try await operation()
+                // Cancellation has two windows here, and only one of them is an await. This is the
+                // other one: a cancel that lands between creating this task and its first scheduled
+                // run leaves the body starting from the top with `Task.isCancelled` already true and
+                // no suspension left to rethrow at. The bodies re-check it after their own awaits.
+                try Task.checkCancellation()
+                return try await operation()
             }
         )
         self.state.activeWorkspaceCompletionTask = workspaceCompletion
@@ -823,7 +837,35 @@ final class CloudSessionRuntime {
         self.state.activeGuestCloudSessionCreation = nil
     }
 
+    /**
+     * Every caller abandons the identity the cancelled work is authenticated as, so a workspace
+     * completion in flight must stop here rather than finish its credential and workspace writes
+     * against an account the person has just left.
+     *
+     * The workspace completion and the cloud link transition it wraps are separate unstructured
+     * tasks, so cancelling the outer one does not reach the inner one and both need their own line.
+     *
+     * Cancelling is only half of it. Callers reset local state synchronously right after this, so a
+     * body whose await has already resumed is queued to run immediately with cancellation set, and
+     * one parked in a continuation that takes no cancellation handler never observes the cancel at
+     * all. The obligation that makes this call effective therefore lives in the bodies, not here:
+     * every identity side effect in them must have a `Task.checkCancellation()` ahead of it with no
+     * suspension in between, the task head counting as the first such read. A write moved behind a
+     * new await needs its own read, and a write that relies on its callers reaching it with nothing
+     * suspended in between has to say so where it is written.
+     *
+     * Where such a read may go is bounded too. The workspace completion and the link transition
+     * are cancelled nowhere else, so only inside those two does a cancel mean an abandoned identity
+     * and nothing else. A read in code the other slots also reach, as `refreshCloudCredentials`
+     * above is, needs its own justification: it is allowed only where a cancel arriving from
+     * `cancelForWorkspaceSwitch` abandons that same work anyway, so throwing there costs nothing.
+     * The same bound ends a body at the reset it performs on itself: past that the cancel is its
+     * own and benign, so the read belongs before the reset, or behind the early return that
+     * follows it.
+     */
     func cancelForAccountDeletion() {
+        self.state.activeWorkspaceCompletionTask?.task.cancel()
+        self.state.activeWorkspaceCompletionTask = nil
         self.state.activeCloudLinkTask?.task.cancel()
         self.state.activeCloudLinkTask = nil
         self.cancelAndClearActiveCloudSyncTask(stage: "clear_active_sync_task_account_deletion")

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/Identity/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/Identity/FlashcardsStore+CloudLink.swift
@@ -346,6 +346,13 @@ extension FlashcardsStore {
                 }
             }
 
+            // Everything below writes for `linkContext`'s identity, and the awaits above can have
+            // resumed already when an erase or an account deletion cancels this task: the resumed
+            // job runs straight after the synchronous reset, with cancellation set and nothing
+            // reading it. `validateCloudCredentialRecoveryUserBeforeIdentitySideEffects` sits before
+            // those awaits and cannot re-gate them, so the cancel has to be re-read right here.
+            // This one check also covers `finishCloudLink` below, which nothing suspends before.
+            try Task.checkCancellation()
             try self.cloudRuntime.saveCredentials(credentials: linkContext.credentials)
             let configuration = try self.currentCloudServiceConfiguration()
             let linkedSession = CloudLinkedSession(
@@ -463,6 +470,10 @@ extension FlashcardsStore {
                 )
                 linkedWorkspace = workspaceCreation.workspace
                 credentials = workspaceCreation.credentials
+                // The workspace creation above suspends, so this checkpoint can be reached after an
+                // erase has already cleared the recovery state it belongs to. Persisting it then
+                // would strand a checkpoint pointing at the abandoned account's new workspace.
+                try Task.checkCancellation()
                 try self.saveGuestLocalRecoveryWorkspaceCheckpoint(
                     linkContext: linkContext,
                     recoveryState: recoveryState,
@@ -470,6 +481,10 @@ extension FlashcardsStore {
                 )
             }
 
+            // Every branch above reaches here through an await, so re-read the cancel before the
+            // link is finished for this identity. Placed outside the `do` on purpose: a throw here
+            // must not run the `defer` that applies the abandoned account's preferences.
+            try Task.checkCancellation()
             do {
                 defer {
                     self.applyCloudAccountPreferences(
@@ -504,6 +519,9 @@ extension FlashcardsStore {
         configuration: CloudServiceConfiguration,
         forceRefresh: Bool
     ) async throws -> StoredCloudCredentials {
+        // Two of the call sites are authorization retries that run after an awaited failure, so the
+        // credential write below can be reached with the identity already abandoned.
+        try Task.checkCancellation()
         let storedCredentials = try self.cloudRuntime.loadCredentials()
         if let storedCredentials {
             if storedCredentials.refreshToken != linkContextCredentials.refreshToken {
@@ -755,6 +773,9 @@ extension FlashcardsStore {
             && self.cloudSettings?.linkedUserId == linkedSession.userId {
             let database = try requireLocalDatabase(database: self.database)
             if self.workspace?.workspaceId == linkedSession.workspaceId {
+                // Nothing suspends between the head of the link transition task and this write, so
+                // the head check in `CloudSessionRuntime.runCloudLinkTransition` is the only
+                // cancellation read it gets; an await introduced above it needs its own.
                 try database.updateCloudSettings(
                     cloudState: .linked,
                     linkedUserId: linkedSession.userId,
@@ -789,6 +810,12 @@ extension FlashcardsStore {
                 migrationKind: migrationKind,
                 remoteWorkspaceIsEmpty: remoteWorkspaceIsEmpty
             )
+            // `context` was captured before the await above, so after an erase `context.workspaceId`
+            // names the workspace that no longer exists and the migration's
+            // `deleteOtherWorkspaces(exceptWorkspaceId:)` would delete the one the erase just
+            // created, leaving the install `linked` to the abandoned account with its credentials
+            // already cleared. The task head cannot cover a write this far past a suspension.
+            try Task.checkCancellation()
             try context.database.migrateLocalWorkspaceToLinkedWorkspace(
                 localWorkspaceId: context.workspaceId,
                 linkedSession: linkedSession,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudCredentialRecovery.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudCredentialRecovery.swift
@@ -53,12 +53,14 @@ extension FlashcardsStore {
      *
      * That is narrower than "nothing writes across the reset", and the difference matters if you are
      * working here. Those comparisons gate the write-back only; they sit after the awaited work and
-     * do not gate its identity side effects. `FlashcardsStore.completeCloudLink` runs its body
-     * through `CloudSessionRuntime.runWorkspaceCompletion`, which awaits an unstructured `Task`, so
-     * cancelling `postAuthSyncTask` cancels the wait and not that task: a `completeCloudLink`
-     * already in flight when this runs still finishes its credential and workspace writes, and this
-     * call does not stop it. That overlap is a known gap left open on purpose — closing it is a
-     * larger change than this one.
+     * do not gate its identity side effects. What stops a `FlashcardsStore.completeCloudLink`
+     * already in flight is the `cancelForAccountDeletion` inside the reset below, which cancels both
+     * the unstructured task `CloudSessionRuntime.runWorkspaceCompletion` holds and the separate one
+     * the link transition nested inside it holds. Ending the attempt cannot do that on its own:
+     * cancelling `postAuthSyncTask` cancels the wait, not those tasks.
+     *
+     * The cancel alone would not be enough either, and reading it is the cancelled bodies'
+     * obligation rather than this reset's. `CloudSessionRuntime.cancelForAccountDeletion` states it.
      */
     func eraseLocalDataForCredentialRecovery() throws {
         guard self.cloudCredentialRecoveryState != nil else {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudRestore.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudRestore.swift
@@ -67,6 +67,17 @@ extension FlashcardsStore {
 
         self.cloudRuntime.cancelForWorkspaceSwitch()
         await self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: linkedSession.workspaceId)
+        // The wait above suspends, and the write below relinks this install: it recreates the
+        // workspace shell and stores `linked` against this user. Landing after an erase would point
+        // the freshly reset install back at the abandoned account whose credentials are already
+        // gone, leaving it in `linkedCredentialsMissing` recovery.
+        //
+        // Reading the cancel here is unambiguous only because of who can reach it. The line above
+        // leaves the link transition task alone, so an ordinary workspace switch never sets this.
+        // And the silent-restore caller cannot arrive with a cancel pending: it returns before this
+        // function when its own different-user reset self-cancels, and after any other reset it
+        // cannot get past `storedLinkedSession`, which needs the `linked` state that reset clears.
+        try Task.checkCancellation()
         try database.switchActiveWorkspace(workspace: workspaceSummary, linkedSession: linkedSession)
         self.cloudRuntime.setActiveCloudSession(linkedSession: linkedSession)
         try self.reload()


### PR DESCRIPTION
`runWorkspaceCompletion` and `runCloudLinkTransition` run their bodies in unstructured tasks, and callers only `await` the task's `.value` — which propagates no cancellation. So erasing local data from the credential-recovery gate, or deleting the account, cancelled the *wait* and never the *work*.

A link already in flight then went on to save the abandoned account's credentials into the Keychain the reset had just cleared, migrate the freshly reset local workspace into that account, and run a full sync against it. The install ended up linked to the account the person had just left.

**Cancelling is not enough on its own.** A cancel reaches a body only while it is parked at a suspension. A body that has already *resumed* has its continuation queued on the main actor, and the identity resets are synchronous — so the queued job runs immediately after the reset returns, with the cancellation flag set and nothing reading it. Both tasks are now cancelled on identity abandonment, and every identity side effect inside them reads the cancel before it writes.

Four such writes existed, found across four review rounds, each one level further out than the last: the parked body, the resumed body, a second unstructured task, and a fourth call site. The last round stopped hunting instances and enumerated the category instead — every persisted identity write reachable in the two tasks — which is what established there is no fifth.

**Where a read may sit is bounded**, and that bound is now recorded next to `cancelForAccountDeletion`. Of the six task slots it cancels, four are also cancelled by an ordinary workspace switch, so only the other two can treat a cancel as identity abandonment. A body's own self-cancelling reset ends the region where a read is legal. Getting that wrong turns a correct fix into a regression on a path that works today.

Every new throw is a `CancellationError` reaching a catch that short-circuits on it, so nothing surfaces to someone who has just erased their data. Compiled locally before merge (`xcodebuild build`, exit 0, zero errors), since PR checks do not build Swift.

**Known and left open:** the server-side workspace a cancelled `.createNew` may already have created stays the abandoned account's *selected* workspace, so another device holding stored credentials can restore into it and see an empty workspace. Nothing local points at it and the original workspace is intact. The structural fix — making these tasks propagate cancellation instead of requiring a manual read before every write — is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)