### PR TITLE
Re-check the reporting pool after its await, and correct two comments

### DIFF
--- a/apps/backend/src/admin/reportingDb.ts
+++ b/apps/backend/src/admin/reportingDb.ts
@@ -48,6 +48,16 @@ async function getReportingPool(): Promise<pg.Pool> {
   }
 
   const connectionString = await getReportingDatabaseUrl();
+  // Re-checked after the await, as apps/backend/src/database/core.ts, apps/auth/src/db.ts and
+  // apps/backend/src/productAnalytics/writer.ts do. No reporting caller is known to issue
+  // concurrent queries today - every one of them runs a single transaction at a time - but without
+  // the second check any future concurrent first touch on a cold container would build one pool per
+  // caller, and only the last would stay reachable to end(); the rest would hold their connections
+  // for the life of the container with no reference left to close them.
+  if (reportingPool !== undefined) {
+    return reportingPool;
+  }
+
   const ssl = process.env.REPORTING_DB_SECRET_ARN !== undefined && process.env.REPORTING_DB_SECRET_ARN !== "";
   // Keep the pool below the reporting_readonly role connection limit.
   reportingPool = new pg.Pool({ connectionString, ssl, max: reportingPoolMaxConnections });

--- a/apps/backend/src/routes/catalog/public.ts
+++ b/apps/backend/src/routes/catalog/public.ts
@@ -198,10 +198,15 @@ function createCatalogPublicScope(
 /**
  * The CDN base URL on its own, deliberately not `getCatalogDumpStorageConfig()`.
  *
- * That accessor also requires `CATALOG_DUMP_S3_BUCKET_NAME`, which no route here
- * reads: only the dump run writes to the bucket. Resolving the whole config
- * would let a missing bucket name take down package browse and media delivery
- * over a variable they never use, while `GET /catalog` keeps failing that same
+ * That accessor also requires `CATALOG_DUMP_S3_BUCKET_NAME`, which the media and
+ * browse routes never read. `GET /catalog` does read it: its
+ * `loadCatalogDumpPointerFromS3` in
+ * apps/backend/src/catalog/distribution/public/dumpStorage.ts calls
+ * `getCatalogDumpStorageConfig()` to resolve the bucket the pointer object is
+ * fetched from, so the variable stays required on `BackendHandler` in
+ * infra/aws/lib/gateways/api-gateway.ts. Resolving the whole config here would
+ * let a missing bucket name take down package browse and media delivery over a
+ * variable they never use, while `GET /catalog` keeps failing that same
  * configuration as its own typed 503.
  */
 function resolveCatalogMediaCdnBaseUrl(): string {
@@ -420,11 +425,29 @@ export function createCatalogPublicRoutes(options: CatalogPublicRoutesOptions): 
   });
 
   /**
-   * Compatibility route for the URL every previously published snapshot embeds,
-   * and the only public catalog media path that still opens a Postgres
-   * connection. It redirects instead of proxying bytes, keeps the
-   * published-and-not-delisted lookup on every request, and is never cached:
-   * a package version that republishes its media changes which object this key
+   * Redirect to the published CDN object for one catalog package media asset.
+   *
+   * Every snapshot published before the CDN embeds this URL for each of its
+   * media assets, and the current builder still names it:
+   * `mapCatalogPublicSnapshotMediaAssets` in
+   * apps/backend/src/catalog/distribution/public/snapshot.ts hands out a CDN URL
+   * only for a deliverable asset whose digest names an object key, and falls
+   * back to this route otherwise - a fallback that file documents as unreachable
+   * today, not as removed. It is also the machine-API template
+   * apps/backend/src/agent/discovery.ts publishes, so it serves current clients
+   * rather than only archived URLs.
+   *
+   * It redirects instead of proxying bytes, but it keeps the
+   * published-and-not-delisted lookup on every request, so it still costs one
+   * Postgres connection - as do the three sibling media routes above
+   * (`media-assets/:packageMediaKey/download-url`,
+   * `collections/:collectionId/cover/download-url` and
+   * `collections/:collectionId/cover/download`), which reach their loaders
+   * through `unsafeRepeatableReadReadOnlyTransaction`. What moved off Postgres
+   * is the URL a snapshot hands out for a deliverable asset, not this route.
+   *
+   * The redirect is never cached for the same reason the lookup stays: a
+   * package version that republishes its media changes which object this key
    * resolves to, and a delist has to stop resolving at once.
    */
   app.get("/catalog/package-versions/:packageVersionId/media-assets/:packageMediaKey/download", async (context) => {


### PR DESCRIPTION
Follow-up to the connection-budget and CDN-media wave. Three corrections that reviewers raised there and that were deliberately deferred rather than folded into items whose scope did not cover them.

### The last unguarded pool initializer

`getReportingPool` returned early on a set pool, awaited the database URL, then assigned without re-checking, so concurrent first-touch callers on a cold container could each build a `max: 4` pool and leave all but the last unreachable — leaking their connections with nothing left to call `end()` on.

The same defect was repaired in `apps/auth/src/db.ts` during the connection-budget change, where it *was* reachable: `decideOtpRateLimit` issues eight concurrent queries through `Promise.all` on the ordinary OTP path.

**Here it is not reachable.** Every consumer of `withReportingReadOnlyTransaction` — `admin/query.ts`, `globalMetrics/reporting.ts`, the guest reaper, and the active-days backfill — runs sequentially inside one transaction, and there is no `Promise.all` in any of them. The check is applied anyway so all four pool initializers share one shape, and the next one written is copied from a correct example.

### Two comments that said the opposite of the code

- One claimed no route in `routes/catalog/public.ts` reads `CATALOG_DUMP_S3_BUCKET_NAME`. `GET /catalog` does, through `loadCatalogDumpPointerFromS3` → `getCatalogDumpStorageConfig()`, which resolves the bucket the pointer object is fetched from. Believing the claim would invite dropping that variable from `BackendHandler` and turning `GET /catalog` into a permanent 503.
- The other called the media download route "the only public catalog media path that still opens a Postgres connection". Three sibling routes do the same, and the claim about what the snapshot hands out was absolute where the snapshot builder is conditional.

No behaviour changes beyond the two-line re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)