### PR TITLE
Record the card flip and the prompt outcomes on iOS

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
@@ -7,13 +7,22 @@ import Foundation
  * declares and there is deliberately no `track(name:properties:)` anywhere. A typo or an undeclared
  * property does not compile instead of becoming a silent server-side rejection.
  *
- * That strictness covers event names and properties, and no longer covers every enum value here:
- * `AnalyticsSurface` still declares `onboarding`, which the catalog dropped, so an event carrying
- * it as its `screen` compiles and is rejected `invalid_event`. No call site uses that value, and
- * until the enum drops it a value in this file is not on its own proof that the server accepts it.
+ * Every enum value below is a value the current catalog declares, so a value here is again proof
+ * the server accepts it. The one that was not — `AnalyticsSurface.onboarding`, dropped by the
+ * catalog — is gone; while it existed an event carrying it as its `screen` compiled and was
+ * rejected `invalid_event`.
  *
- * `guest_upgrade_completed` and `catalog_deck_installed` are server-derived and are absent here on
- * purpose: a client batch that carries one is rejected `server_only_event`.
+ * The ten server-derived events are absent here on purpose, because a client batch that carries one
+ * is rejected `server_only_event`: `guest_upgrade_completed`, `review_answered`, `card_created`,
+ * `card_updated`, `deck_created`, `deck_updated`, `friend_invitation_created`, `friendship_created`,
+ * `ai_message_sent` and `catalog_deck_installed`.
+ *
+ * `signin_code_requested` and `signin_succeeded` are client-emittable and absent for a different
+ * reason: nothing reports the two middle funnel steps yet. The catalog declares them ahead of a
+ * producer, and there is no emit site for either anywhere in the repository — not on the auth
+ * origin the catalog names as the intended web producer, and not in the web client's own mirror.
+ * Adopting them here is its own change rather than a gap in this mirror, and iOS is not behind web
+ * on them.
  *
  * `onboarding_step_completed`, `review_session_started` and `review_session_ended` were removed
  * from the catalog outright, so the server no longer declares them and rejects them as unknown
@@ -23,7 +32,30 @@ enum AnalyticsEvent: Sendable, Equatable {
     case appOpened(launchType: AnalyticsLaunchType)
     case screenViewed(screen: AnalyticsSurface)
     case signInFailed(reason: AnalyticsSignInFailureReason)
+    /// The card flip: the answer side being shown, once per card presentation. It never reaches the
+    /// backend on its own, so only a client can report it, and it is the denominator the
+    /// server-derived `review_answered` is read against.
+    case reviewCardRevealed
     case reviewAnswerFailed(reason: AnalyticsReviewAnswerFailureReason)
+    /**
+     * One of our own in-app prompts was answered.
+     *
+     * This is not the same fact as `permissionPromptAnswered` and the two must never be merged: this
+     * one is ours to decide when to show, while that one is an OS dialog whose outcome the app only
+     * observes, and a person can accept ours and still deny the system's. The prompt being *shown*
+     * is a third fact, recorded as `screen_viewed` on the prompt's own surface, so the conversion
+     * between showing and answering is a query rather than something a client has to compute.
+     */
+    case promptAnswered(prompt: AnalyticsPrompt, outcome: AnalyticsPromptOutcome)
+    /**
+     * An OS permission dialog was answered.
+     *
+     * The surface is carried by the event's own `screen` and never duplicated into a property: an OS
+     * dialog can be answered after the app was backgrounded and resumed somewhere else, so the
+     * surface that asked for the permission is not necessarily where the person is when the answer
+     * arrives, and only the latter is what `screen` means here.
+     */
+    case permissionPromptAnswered(permission: AnalyticsPermission, outcome: AnalyticsPermissionOutcome)
     case cardCreateStarted(entryPoint: AnalyticsCardCreateEntryPoint)
     /// Emit only through `Analytics.reportSyncFailure(reason:)`. Sync is retried on a timer, so a
     /// direct `track` measures poll cadence instead of failure incidence.
@@ -36,17 +68,41 @@ enum AnalyticsEvent: Sendable, Equatable {
  * Platform-independent surfaces from the backend catalog. Native screens are mapped onto these and a
  * native screen name is never sent, because cross-client funnel comparison is the only reason the
  * surface list is shared at all.
+ *
+ * Existing spellings are never renamed: they are already in production data and a rename silently
+ * splits a series in two. The catalog surfaces missing here name screens this app does not have —
+ * the public catalog import steps, the friend-invitation landing page and the platform-links share
+ * page are web routes — so this client sends no `screen` where it has no screen, rather than the
+ * nearest wrong one.
  */
 enum AnalyticsSurface: String, Sendable, Equatable, CaseIterable {
     case review
     case catalog
     case deckDetail = "deck_detail"
-    case onboarding
     case cardEditor = "card_editor"
     case cards
     case progress
     case settings
     case ai
+    // Workspace content management. These are pushed under Settings here only as a routing accident:
+    // they act on the person's own decks, cards and tags, the same object family `cards`,
+    // `cardEditor` and `deckDetail` already name.
+    case decks
+    case deckEditor = "deck_editor"
+    case tags
+    // Authentication. `signin` is the whole sign-in sheet whatever it splits into — the email step,
+    // the code step and the workspace choice are one screen in the catalog. `credentialRecovery` is
+    // the gate that replaces the app root when stored credentials can no longer be used.
+    case signin
+    case credentialRecovery = "credential_recovery"
+    // Our own in-app prompts, each a screen a person has to answer before anything else continues.
+    // `AnalyticsPrompt` repeats these two spellings verbatim, so an answer joins to the
+    // `screen_viewed` that recorded its showing by equality; the two must stay identical.
+    case notificationsPrePrompt = "notifications_pre_prompt"
+    case signInAfterReviewPrompt = "signin_after_review_prompt"
+    // The friend-invitation creation screen. Its counterpart, the landing page the invited person
+    // opens, is a web route with no iOS screen.
+    case friendInvite = "friend_invite"
 }
 
 /**
@@ -61,9 +117,64 @@ enum AnalyticsNetworkState: String, Sendable, Equatable {
     case unknown
 }
 
+/**
+ * Deliberately only the two values a client can know.
+ *
+ * The catalog declares a third, `unknown`, and it is server-only in practice rather than in the
+ * schema: it exists for the days migration `0121` reconstructed from stored activity long after the
+ * fact, which cannot know whether a launch was cold or warm, while a live client always can. Ingest
+ * accepts `unknown` from a client, so this union is the only thing preventing one from being sent.
+ * Do not widen it when mirroring the catalog.
+ */
 enum AnalyticsLaunchType: String, Sendable, Equatable {
     case cold
     case warm
+}
+
+/**
+ * The in-app prompts, spelled exactly as their own surfaces in `AnalyticsSurface` so an answer joins
+ * to the `screen_viewed` that recorded its showing without a mapping.
+ */
+enum AnalyticsPrompt: String, Sendable, Equatable {
+    case signInAfterReviewPrompt = "signin_after_review_prompt"
+    case notificationsPrePrompt = "notifications_pre_prompt"
+}
+
+/**
+ * How one of our own prompts was answered.
+ *
+ * Both iOS prompts are UIKit-backed alerts, which cannot be closed without pressing a button, so
+ * every answer here comes from a button and each prompt produces only the outcomes its buttons mean:
+ * the after-review sign-in prompt reports `accepted` or `snoozed` — its "Later" really does snooze
+ * for a week — and the notifications pre-prompt reports `accepted` or `dismissed`. A programmatic
+ * teardown, such as a cloud identity reset closing a prompt nobody answered, reports nothing.
+ */
+enum AnalyticsPromptOutcome: String, Sendable, Equatable {
+    case accepted
+    case dismissed
+    case snoozed
+}
+
+enum AnalyticsPermission: String, Sendable, Equatable {
+    case notifications
+    case photoLibrary = "photo_library"
+    case camera
+    case microphone
+}
+
+/**
+ * How the OS permission dialog was answered. `dismissed` is the answer that is not one: the person
+ * closed the dialog leaving the permission undetermined.
+ *
+ * Only the photo-library request can report it, because only `PHPhotoLibrary` answers with a status
+ * that can still be `notDetermined`. The camera, microphone and notification requests answer with a
+ * bool, so an undecided close is indistinguishable from a denial there and is reported as `denied`.
+ * A zero `dismissed` count for those three is structural rather than a signal.
+ */
+enum AnalyticsPermissionOutcome: String, Sendable, Equatable {
+    case granted
+    case denied
+    case dismissed
 }
 
 enum AnalyticsSignInFailureReason: String, Sendable, Equatable {
@@ -147,8 +258,14 @@ extension AnalyticsEvent {
             return "screen_viewed"
         case .signInFailed:
             return "signin_failed"
+        case .reviewCardRevealed:
+            return "review_card_revealed"
         case .reviewAnswerFailed:
             return "review_answer_failed"
+        case .promptAnswered:
+            return "prompt_answered"
+        case .permissionPromptAnswered:
+            return "permission_prompt_answered"
         case .cardCreateStarted:
             return "card_create_started"
         case .syncFailed:
@@ -162,13 +279,20 @@ extension AnalyticsEvent {
 
     /**
      * `screen` is a top-level event field on the wire, never a property: a surface placed inside
-     * `properties` is rejected `unknown_property`. Only `screen_viewed` carries one of its own; every
-     * other event takes the surface the caller was on, if any.
+     * `properties` is rejected `unknown_property`. Only `screen_viewed` and `review_card_revealed`
+     * carry one of their own; every other event takes the surface the caller was on, if any.
      */
     var declaredScreen: AnalyticsSurface? {
         switch self {
         case .screenViewed(let screen):
             return screen
+        // The catalog requires a surface on the flip, and the flip has no home other than the review
+        // screen. Declaring it here rather than leaving it to the call site is what keeps a caller
+        // that forgets `screen:` from producing an event the server rejects `missing_screen`, which
+        // is the reason a required screen that is absent draws; `invalid_event` is what an
+        // unrecognised surface value draws instead.
+        case .reviewCardRevealed:
+            return .review
         default:
             return nil
         }
@@ -187,8 +311,20 @@ extension AnalyticsEvent {
             return [:]
         case .signInFailed(let reason):
             return ["reason": .string(reason.rawValue)]
+        case .reviewCardRevealed:
+            return [:]
         case .reviewAnswerFailed(let reason):
             return ["reason": .string(reason.rawValue)]
+        case .promptAnswered(let prompt, let outcome):
+            return [
+                "prompt": .string(prompt.rawValue),
+                "outcome": .string(outcome.rawValue)
+            ]
+        case .permissionPromptAnswered(let permission, let outcome):
+            return [
+                "permission": .string(permission.rawValue),
+                "outcome": .string(outcome.rawValue)
+            ]
         case .cardCreateStarted(let entryPoint):
             return ["entry_point": .string(entryPoint.rawValue)]
         case .syncFailed(let reason):

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsSurfaceTracking.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsSurfaceTracking.swift
@@ -46,19 +46,75 @@ extension Analytics {
      * `AppNavigationModel.selectTab` emit the destination's `screen_viewed` synchronously before the
      * selection moves, so it is already recorded when the view update that removes the outgoing
      * hierarchy runs `.onDisappear`.
+     *
+     * Two kinds of caller cannot lean on that, and neither is left to ordering. A sheet restores from
+     * the presentation's `onDismiss` and never from the content's `.onDisappear`, because SwiftUI
+     * destroys and rebuilds sheet content while the presentation stays on screen — a programmatic tab
+     * switch under the presenter is enough — so `.onDisappear` would hand the surface back under a
+     * sheet the person is still using, and the rebuilt content's `.onAppear` would then report a
+     * second view of a screen they never left. A push whose destination reports itself from its own
+     * `.onAppear` — the decks list opening a deck detail — decides from settled navigation state
+     * instead, so its restore is a no-op on a push whichever way SwiftUI orders the two callbacks.
+     *
+     * The entry half of a sheet's pair stays on the content's `.onAppear`, which is the only callback
+     * that proves the screen was actually shown, and there a rebuild is absorbed by the dedupe: it
+     * reports nothing while the tracker still holds the sheet's own surface. Only something that
+     * moves the tracker out from under a live sheet reopens that, and the one reachable mover is a
+     * notification tap — `handleAppNotificationTap` selects Review without closing anything. The
+     * in-app switches that run from inside these sheets, the AI hand-off in `ReviewView` and
+     * `CardsScreen`, clear the presentation in the same action, so their content is being removed
+     * rather than rebuilt. What that leaves is one extra `screen_viewed` for a sheet the person is
+     * genuinely still looking at, with the tracker ending up where it belongs, so the restore that
+     * follows is still right.
      */
     static func trackScreenViewedOnDismiss(
         of dismissedSurface: AnalyticsSurface,
         restoring restoredSurface: AnalyticsSurface
     ) {
+        self.trackScreenViewedOnDismiss(ofAnyOf: [dismissedSurface], restoring: restoredSurface)
+    }
+
+    /**
+     * The same restore for a screen that can be taken away while something it presented still owns
+     * the tracker: `restoredSurface` is emitted when any of `dismissedSurfaces` is the one being
+     * viewed, under the same guard.
+     *
+     * Only the credential-recovery gate needs it. The gate is torn down by its own success, which
+     * happens while the sign-in sheet it presented is still on screen and holding `signin`, and
+     * removing the gate destroys that sheet's presenter without an `onDismiss`, so the gate's own
+     * dismissal is the only thing left to name the screen the person lands on.
+     */
+    static func trackScreenViewedOnDismiss(
+        ofAnyOf dismissedSurfaces: Set<AnalyticsSurface>,
+        restoring restoredSurface: AnalyticsSurface
+    ) {
         guard self.surfaceTracker.restoreViewing(
-            from: dismissedSurface,
+            fromAnyOf: dismissedSurfaces,
             to: restoredSurface
         ) else {
             return
         }
 
         self.track(.screenViewed(screen: restoredSurface))
+    }
+
+    /**
+     * Emits `permission_prompt_answered` on the surface the person is on when the OS answers, which
+     * is what `screen` means on this event and is not necessarily the surface that asked.
+     *
+     * The system dialog suspends the app, and the person can background it, come back somewhere else
+     * and answer there, so the asking surface is not reliably where they are by the time the result
+     * arrives. Reading the tracker gives the surface last reported for real instead; when nothing has
+     * been reported yet the event carries no `screen`, which the catalog allows, rather than a guess.
+     */
+    static func trackPermissionPromptAnswered(
+        permission: AnalyticsPermission,
+        outcome: AnalyticsPermissionOutcome
+    ) {
+        self.track(
+            .permissionPromptAnswered(permission: permission, outcome: outcome),
+            screen: self.surfaceTracker.currentViewingSurface()
+        )
     }
 }
 
@@ -69,6 +125,17 @@ final class AnalyticsSurfaceTracker: @unchecked Sendable {
     init() {
         self.lock = NSLock()
         self.currentSurface = nil
+    }
+
+    /// The surface last reported as viewed, for the events that have to name where the person is now
+    /// rather than where the caller happens to sit in the view hierarchy.
+    func currentViewingSurface() -> AnalyticsSurface? {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        return self.currentSurface
     }
 
     func beginViewing(surface: AnalyticsSurface) -> Bool {
@@ -98,17 +165,20 @@ final class AnalyticsSurfaceTracker: @unchecked Sendable {
         return true
     }
 
-    /// Moves the current surface back to `restoredSurface`, but only while `dismissedSurface` is still
-    /// the one being viewed. A screen that something else has already superseded restores nothing.
+    /// Moves the current surface back to `restoredSurface`, but only while one of `dismissedSurfaces`
+    /// is still the one being viewed. A screen that something else has already superseded restores
+    /// nothing.
     func restoreViewing(
-        from dismissedSurface: AnalyticsSurface,
+        fromAnyOf dismissedSurfaces: Set<AnalyticsSurface>,
         to restoredSurface: AnalyticsSurface
     ) -> Bool {
         self.lock.lock()
         defer {
             self.lock.unlock()
         }
-        guard self.currentSurface == dismissedSurface, restoredSurface != dismissedSurface else {
+        guard let currentSurface = self.currentSurface,
+              dismissedSurfaces.contains(currentSurface),
+              restoredSurface != currentSurface else {
             return false
         }
 

--- a/apps/ios/Flashcards/Flashcards/App/CloudCredentialRecoveryGateView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/CloudCredentialRecoveryGateView.swift
@@ -92,6 +92,40 @@ struct CloudCredentialRecoveryGateView: View {
             .navigationTitle(self.presentation.title)
             .navigationBarTitleDisplayMode(.inline)
         }
+        .onAppear {
+            // The gate replaces the whole app root, so it is a screen of its own rather than
+            // something over a tab, and while it is up the tab root does not exist to report one.
+            Analytics.trackScreenViewed(.credentialRecovery)
+        }
+        .onDisappear {
+            // Clearing the gate swaps the tab root back in with the visible tab unchanged, which the
+            // tab root reports as a launch-time view and therefore stays silent about. This is the
+            // only place the screen the person lands on can be named.
+            //
+            // `signin` is accepted alongside the gate's own surface because the flow the gate exists
+            // for ends while its sign-in sheet is still on screen: `completeCloudLink` and
+            // `completeGuestLocalRecoveryCloudLink` clear the recovery state from under it, and
+            // removing the gate destroys that sheet's presenter without an `onDismiss`, so
+            // `endCloudSignInAttempt` never runs to hand the surface back. Restoring from `signin`
+            // too is what keeps that success path from leaving the tracker parked on the sign-in
+            // screen, where the next `permission_prompt_answered` would be stamped `signin` and the
+            // person's genuine next arrival on this tab would be swallowed by the dedupe.
+            //
+            // Accepted only for the gate's *own* sheet, which is what this view's own presentation
+            // state answers and no shared counter can. A gate that opened and closed over a sheet
+            // the tab root was already presenting leaves that binding true, so `RootTabView` installs
+            // a fresh `CloudSignInSheetModifier` that presents immediately and reports `signin` — and
+            // whether that lands before or after this callback is not ordered. Accepting `signin`
+            // unconditionally would lose that race by parking the tracker on the tab while the sheet
+            // is on screen, and `endCloudSignInAttempt` would then refuse its own restore. The gate
+            // never presented that sheet, so this flag is false for it either way round.
+            Analytics.trackScreenViewedOnDismiss(
+                ofAnyOf: self.isCloudSignInPresented
+                    ? [.credentialRecovery, .signin]
+                    : [.credentialRecovery],
+                restoring: analyticsSurface(tab: self.store.currentVisibleTab)
+            )
+        }
         .cloudSignInSheet(
             isPresented: self.$isCloudSignInPresented,
             presentationContext: .credentialRecoveryGate

--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -214,7 +214,17 @@ struct CardsScreen: View {
                 .accessibilityIdentifier(UITestIdentifier.cardsAddButton)
             }
         }
-        .sheet(item: self.$editorPresentation) { presentation in
+        .sheet(
+            item: self.$editorPresentation,
+            onDismiss: {
+                // From the presentation, never from the content, for the reason
+                // `Analytics.trackScreenViewedOnDismiss` gives. The editor only ever presents over
+                // the Cards tab, so the restore is already safe here; it is written conditionally
+                // anyway because it costs nothing and keeps the one rule for restoring a surface
+                // identical at every site.
+                Analytics.trackScreenViewedOnDismiss(of: .cardEditor, restoring: .cards)
+            }
+        ) { presentation in
             NavigationStack {
                 CardEditorScreen(
                     title: presentation.title,
@@ -243,12 +253,6 @@ struct CardsScreen: View {
             .interactiveDismissDisabled()
             .onAppear {
                 Analytics.trackScreenViewed(.cardEditor)
-            }
-            .onDisappear {
-                // The editor only ever presents over the Cards tab, so the restore is already safe
-                // here; it is written conditionally anyway because it costs nothing and keeps the one
-                // rule for restoring a surface identical at both sites.
-                Analytics.trackScreenViewedOnDismiss(of: .cardEditor, restoring: .cards)
             }
         }
         .sheet(isPresented: $isFilterSheetPresented) {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/Identity/FlashcardsStore+CloudIdentity.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/Identity/FlashcardsStore+CloudIdentity.swift
@@ -21,6 +21,7 @@ extension FlashcardsStore {
         // would name the wrong user on an append-only table. The discarded count is reported
         // through observability, not as an analytics_events_dropped reason.
         Analytics.reset()
+        self.restoreSurfaceForPromptsClosedByCloudIdentityReset()
         let database = try requireLocalDatabase(database: self.database)
         let previousStrictReminderNotificationScope = storedStrictReminderNotificationScope(userDefaults: self.userDefaults)
 
@@ -75,6 +76,35 @@ extension FlashcardsStore {
         self.clearPendingGuestUpgradeStateAndUnblockMutations()
         try self.reload()
         self.clearCloudCredentialRecoveryState()
+    }
+
+    /**
+     * Hands the surface back for whichever of our two in-app prompts this reset is about to close.
+     *
+     * The reset closes them by writing their presentation state directly, which reports no
+     * `prompt_answered` — nobody answered one — but also bypasses SwiftUI's binding write-back, so
+     * neither prompt's own restore runs, and `Analytics.reset` rotates the identity without touching
+     * the surface tracker. Left undone the tracker keeps naming a prompt that is gone: the next
+     * `permission_prompt_answered` would carry it, and the person's genuine next arrival on the tab
+     * underneath would be swallowed by the dedupe.
+     *
+     * Placed after `Analytics.reset` on purpose. The person is on that tab now, under the identity
+     * this reset just started, and that is the only identity the report can honestly carry.
+     */
+    private func restoreSurfaceForPromptsClosedByCloudIdentityReset() {
+        let landingSurface = analyticsSurface(tab: self.currentVisibleTab)
+        if self.isReviewNotificationPrePromptPresented {
+            Analytics.trackScreenViewedOnDismiss(
+                of: .notificationsPrePrompt,
+                restoring: landingSurface
+            )
+        }
+        if self.isGuestSignInAfterReviewPromptPresented {
+            Analytics.trackScreenViewedOnDismiss(
+                of: .signInAfterReviewPrompt,
+                restoring: landingSurface
+            )
+        }
     }
 
     private func removeStrictReminderNotificationsForCloudIdentityReset(

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -91,10 +91,7 @@ struct ProgressScreen: View {
             isPresented: self.$isCloudSignInPresented,
             presentationContext: .standard(originSurface: .progress)
         )
-        .sheet(isPresented: self.$isFriendInvitePresented) {
-            ProgressFriendInviteSheet()
-                .environment(self.store)
-        }
+        .friendInviteSheet(isPresented: self.$isFriendInvitePresented, store: self.store)
         .sheet(item: self.$selectedLeaderboardProfile) { selectedProfile in
             ProgressLeaderboardProfileSheet(selectedProfile: selectedProfile)
                 .environment(self.store)

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressFriendInviteSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressFriendInviteSheet.swift
@@ -203,6 +203,7 @@ struct ProgressFriendInviteSheet: View {
             }
             .onAppear {
                 self.isDisplayNameFocused = true
+                Analytics.trackScreenViewed(.friendInvite)
             }
             .onSubmit {
                 guard self.canCreateInvite else {
@@ -278,6 +279,31 @@ private func isInlineFriendInvitationError(error: Error) -> Bool {
     }
 
     return false
+}
+
+extension View {
+    /**
+     * The friend-invitation sheet with its surface reporting owned by the presentation.
+     *
+     * Progress and Settings both present it, and both go through here so the restore is written
+     * once. It belongs to the presentation and not to the sheet's content for the reason
+     * `Analytics.trackScreenViewedOnDismiss` gives, and the surface it hands back is the tab the
+     * person is actually on rather than a fixed one.
+     */
+    func friendInviteSheet(isPresented: Binding<Bool>, store: FlashcardsStore) -> some View {
+        self.sheet(
+            isPresented: isPresented,
+            onDismiss: {
+                Analytics.trackScreenViewedOnDismiss(
+                    of: .friendInvite,
+                    restoring: analyticsSurface(tab: store.currentVisibleTab)
+                )
+            }
+        ) {
+            ProgressFriendInviteSheet()
+                .environment(store)
+        }
+    }
 }
 
 #Preview {

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -217,6 +217,11 @@ extension FlashcardsStore {
         }
     }
 
+    /**
+     * The pre-prompt closed. `markDismissed` is what separates the two ways in: only "Not now" passes
+     * `true`, and it is the person declining. SwiftUI's own binding write-back passes `false` and
+     * runs behind whichever button was pressed, so reporting on it would double-count every answer.
+     */
     func dismissReviewNotificationPrePrompt(markDismissed: Bool) {
         self.isReviewNotificationPrePromptPresented = false
         if markDismissed {
@@ -227,6 +232,11 @@ extension FlashcardsStore {
                     hasDismissedPrePrompt: true
                 )
             )
+            Analytics.track(
+                .promptAnswered(prompt: .notificationsPrePrompt, outcome: .dismissed),
+                screen: .notificationsPrePrompt
+            )
+            self.restoreSurfaceAfterNotificationPrePrompt()
         }
     }
 
@@ -239,9 +249,27 @@ extension FlashcardsStore {
                 hasDismissedPrePrompt: self.notificationPermissionPromptState.hasDismissedPrePrompt
             )
         )
+        // Accepting our prompt and being granted the OS permission are separate facts, reported
+        // separately: the system dialog that follows can still be denied, and the gap between the two
+        // is the whole reason this app asks first.
+        Analytics.track(
+            .promptAnswered(prompt: .notificationsPrePrompt, outcome: .accepted),
+            screen: .notificationsPrePrompt
+        )
+        self.restoreSurfaceAfterNotificationPrePrompt()
         Task { @MainActor in
             _ = await self.requestReviewNotificationPermissionFromSettings(now: Date())
         }
+    }
+
+    /// The tab the person is on, not `.review`: the presentation decision is awaited and validates
+    /// the review context rather than the visible tab, so the tab can have changed inside that
+    /// window. The system dialog that may follow is not one of ours and is no surface at all.
+    private func restoreSurfaceAfterNotificationPrePrompt() {
+        Analytics.trackScreenViewedOnDismiss(
+            of: .notificationsPrePrompt,
+            restoring: analyticsSurface(tab: self.currentVisibleTab)
+        )
     }
 
     /// Requests the top-level system notification permission and then reconciles
@@ -257,7 +285,21 @@ extension FlashcardsStore {
             return .blocked
         }
 
-        let isAllowed = (try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+        // The one branch that actually presents the OS dialog: the two returns above answer from a
+        // decision already stored, without anything being shown, and reporting those would count
+        // dialogs nobody saw. A throw is not an answer either, so only a returned decision reports.
+        // iOS gives no way to close this dialog undecided, which is why `dismissed` never appears
+        // here. Among the access permissions only the photo-library request can report it; camera and
+        // microphone answer with a bool exactly as this one does.
+        let authorizationDecision = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+        if let authorizationDecision {
+            Analytics.trackPermissionPromptAnswered(
+                permission: .notifications,
+                outcome: authorizationDecision ? .granted : .denied
+            )
+        }
+
+        let isAllowed = authorizationDecision ?? false
         self.updateNotificationPermissionPromptState(
             state: NotificationPermissionPromptState(
                 hasShownPrePrompt: true,
@@ -416,6 +458,17 @@ extension FlashcardsStore {
                 hasDismissedPrePrompt: false
             )
         )
+        // The showing, which `prompt_answered` is the other half of. Without it the answers have no
+        // denominator and no acceptance rate can be computed.
+        //
+        // Reported from the state that presents the alert rather than from the alert, which SwiftUI
+        // gives no appearance callback for. The alert is attached to `ReviewView`, and the decision
+        // that reaches here is awaited and validates the review context rather than the visible tab,
+        // so a person who leaves Review inside that await window can have this row written just
+        // before the alert becomes visible to them. It is not guarded on the visible tab, because
+        // the prompt does present when they come back and a guard would drop the only denominator
+        // its answers have.
+        Analytics.trackScreenViewed(.notificationsPrePrompt)
 
         return true
     }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -202,7 +202,20 @@ struct ReviewView: View {
                 )
             }
         }
-        .sheet(isPresented: self.$isEditorPresented) {
+        .sheet(
+            isPresented: self.$isEditorPresented,
+            onDismiss: {
+                // The same pair the Cards tab's editor reports, because it is the same screen: the
+                // pencil here opens `CardEditorScreen` too, and leaving it out would leave
+                // `card_editor` half-populated, counting only the editor views that happen on the
+                // Cards tab. This sheet is the edit path alone — the create button on Review calls
+                // `navigation.openCardCreation()`, which opens the Cards tab's own editor and is
+                // reported there. From the presentation, never from the content, for the reason
+                // `Analytics.trackScreenViewedOnDismiss` gives; the hand-off to the AI tab reports
+                // `ai` before it closes the editor, so this restore is then refused.
+                Analytics.trackScreenViewedOnDismiss(of: .cardEditor, restoring: .review)
+            }
+        ) {
             NavigationStack {
                 CardEditorScreen(
                     title: String(localized: "Edit card", table: reviewCardsStringsTableName),
@@ -248,6 +261,9 @@ struct ReviewView: View {
             }
             .technicalErrorSheet(store: self.store)
             .interactiveDismissDisabled()
+            .onAppear {
+                Analytics.trackScreenViewed(.cardEditor)
+            }
         }
         .alert(
             String(localized: "Review wasn't saved", table: reviewCardsStringsTableName),
@@ -701,9 +717,26 @@ struct ReviewView: View {
         }
     }
 
+    /**
+     * The flip, and the only place the answer side is shown.
+     *
+     * `review_card_revealed` is emitted from the tap itself rather than from a state observer,
+     * because an observer fires for view updates the person did not cause. The guard is
+     * `isAnswerVisible`, which is per *presentation* and not per card: `.onChange(of:
+     * currentCard?.cardId)` clears it whenever the presented card changes, and answering a card puts
+     * it in the pending set so the presented card changes immediately — so a card that later returns
+     * to the head of the queue is a new presentation and reports its flip again. A "last card
+     * reported" guard would go silent on exactly that card. Within one presentation the guard also
+     * absorbs a double tap landing before SwiftUI swaps the bottom bar for the rating buttons.
+     */
     private var showAnswerButton: some View {
         Button {
+            guard isAnswerVisible == false else {
+                return
+            }
+
             isAnswerVisible = true
+            Analytics.track(.reviewCardRevealed)
         } label: {
             Label(String(localized: "Show answer", table: reviewCardsStringsTableName), systemImage: "eye")
                 .frame(maxWidth: .infinity)

--- a/apps/ios/Flashcards/Flashcards/Settings/AccessPermissionSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/AccessPermissionSupport.swift
@@ -233,8 +233,65 @@ func accessPermissionGuidance(kind: AccessPermissionKind, status: AccessPermissi
     }
 }
 
+/**
+ * Requests one OS permission and reports what the person answered.
+ *
+ * Every caller in the app already asks only when the permission is undetermined, and this checks it
+ * again because that is what makes the event honest: an already-decided permission resolves from the
+ * stored answer without a dialog being shown, and reporting one then would count dialogs nobody saw.
+ * The check is also what keeps that true for a future caller that forgets the gate.
+ */
 @MainActor
 func requestAccessPermission(kind: AccessPermissionKind) async -> AccessPermissionStatus {
+    let wasUndecided = accessPermissionStatus(kind: kind) == .askEveryTime
+    let status = await performAccessPermissionRequest(kind: kind)
+    if wasUndecided, let outcome = analyticsPermissionPromptOutcome(status: status) {
+        Analytics.trackPermissionPromptAnswered(
+            permission: analyticsPermission(kind: kind),
+            outcome: outcome
+        )
+    }
+
+    return status
+}
+
+func analyticsPermission(kind: AccessPermissionKind) -> AnalyticsPermission {
+    switch kind {
+    case .photos:
+        return .photoLibrary
+    case .camera:
+        return .camera
+    case .microphone:
+        return .microphone
+    }
+}
+
+/**
+ * Maps a post-request status onto the catalog's three outcomes, or to nothing when no dialog can
+ * have produced it.
+ *
+ * `limited` is a grant: the person allowed the app a chosen set of photos, which is an answer of yes
+ * with a scope attached, and the catalog has no narrower value for it. `askEveryTime` means the
+ * request came back with the permission still undetermined, which is the person closing the dialog
+ * without deciding — reachable from the photos branch of `performAccessPermissionRequest` alone,
+ * because the camera and microphone requests answer with a bool and map an undecided close onto
+ * `blocked`. `unavailable` is the device having no such hardware, so nothing was ever asked.
+ */
+func analyticsPermissionPromptOutcome(status: AccessPermissionStatus) -> AnalyticsPermissionOutcome? {
+    switch status {
+    case .allowed, .limited:
+        return .granted
+    case .blocked:
+        return .denied
+    case .askEveryTime:
+        return .dismissed
+    case .unavailable:
+        return nil
+    }
+}
+
+@MainActor
+private func performAccessPermissionRequest(kind: AccessPermissionKind) async -> AccessPermissionStatus {
     switch kind {
     case .photos:
         let status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
@@ -159,6 +159,10 @@ extension FlashcardsStore {
         self.isCloudSignInAttemptOpen = true
         self.cloudSignInOriginSurface = originSurface
         self.wasCredentialRecoveryGateActiveAtSignInStart = self.isCloudCredentialRecoveryGateActive
+        // The sign-in screen's own `screen_viewed`, reported per presentation for the same reason the
+        // attempt is opened here: the sheet's content is destroyed and rebuilt while the presentation
+        // stays on screen, so reporting from its `onAppear` would record a view per rebuild.
+        Analytics.trackScreenViewed(.signin)
     }
 
     /**
@@ -180,6 +184,19 @@ extension FlashcardsStore {
      * person walked away from is theirs to abandon and is worth a `signin_failed(cancelled)`, while
      * an attempt whose surface the recovery gate took away is not. That is why the gate's activation
      * is latched when the attempt begins and a mismatch here reports nothing.
+     *
+     * The surface handed back is `cloudSignInReturnSurface`, which is where the person is now — a
+     * different question from where the sheet was opened from, and deliberately not answered by
+     * `cloudSignInOriginSurface`, which is `signin_failed`'s entry point and nothing else. The guest
+     * after-review prompt is the case that separates the two: it is owned by the review flow
+     * whichever tab it floats over, so its entry point stays Review while the person is handed back
+     * to the tab they are actually looking at. The restore is conditional on the tracker still
+     * holding `signin`, so a sign-in that ended by moving the person somewhere that reported itself
+     * first — a workspace landing them on a tab — leaves that report standing.
+     *
+     * The credential-recovery gate clearing on its own success is not such a case, and does not
+     * reach here at all: removing the gate destroys this sheet's presenter without an `onDismiss`.
+     * The gate's own `.onDisappear` is what names the screen the person lands on there.
      */
     func endCloudSignInAttempt() {
         if self.isCloudSignInAttemptOpen,
@@ -187,6 +204,10 @@ extension FlashcardsStore {
             self.trackCloudSignInFailed(reason: .cancelled)
         }
 
+        Analytics.trackScreenViewedOnDismiss(
+            of: .signin,
+            restoring: self.cloudSignInReturnSurface
+        )
         self.cancelCloudSignInPostAuthTasks()
         self.cloudSignInAttempt = CloudSignInAttemptState()
         self.isCloudSignInAttemptOpen = false
@@ -267,6 +288,15 @@ extension FlashcardsStore {
         self.cloudCredentialRecoveryState != nil
     }
 
+    /// Where closing the sign-in sheet leaves the person, read live rather than latched at the start
+    /// of the attempt: the recovery gate while it is still up, and otherwise the visible tab, which
+    /// is what the sheet was covering.
+    private var cloudSignInReturnSurface: AnalyticsSurface {
+        self.isCloudCredentialRecoveryGateActive
+            ? .credentialRecovery
+            : analyticsSurface(tab: self.currentVisibleTab)
+    }
+
     private func trackCloudSignInFailed(reason: AnalyticsSignInFailureReason) {
         self.isCloudSignInAttemptOpen = false
         Analytics.track(.signInFailed(reason: reason), screen: self.cloudSignInOriginSurface)
@@ -281,13 +311,21 @@ enum CloudPostAuthRetryAction: Hashable {
 }
 
 /**
- * Where a sign-in sheet was opened from, and with it the `screen` its `signin_failed` carries.
+ * Where a sign-in sheet was opened from, and with it the `screen` its `signin_failed` carries. It is
+ * the entry-point reading and only that: the surface the sheet hands back when it closes is a
+ * separate question, answered live by `cloudSignInReturnSurface`.
  *
- * The credential-recovery gate carries no surface on purpose: it replaces the app's root because a
- * stored credential stopped working, so the person was on no product surface and naming one would be
- * a lie. Every other presenter names the surface that owns the control the person tapped, out of the
- * shared server-owned catalog, so a prompt owned by the review flow stays Review whichever tab it
- * floats over.
+ * The credential-recovery gate used to carry no surface, because the catalog had no value for a
+ * screen that replaces the app's root when a stored credential stops working, and naming any product
+ * surface for it would have been a lie. The catalog now names it, so the gate is `credentialRecovery`
+ * and this is no longer an entry point that can only be reported as no screen at all. Every other
+ * presenter names the surface that owns the control the person tapped, so a prompt owned by the
+ * review flow stays Review whichever tab it floats over — which is exactly why this value must never
+ * be reused as the surface the person returns to.
+ *
+ * `originSurface` stays optional because `signin_failed` takes it directly: the catalog leaves that
+ * event's surface open so a sign-in the client genuinely cannot attribute reports none rather than
+ * the nearest wrong one.
  */
 enum CloudSignInPresentationContext: Hashable {
     case standard(originSurface: AnalyticsSurface)
@@ -298,7 +336,7 @@ enum CloudSignInPresentationContext: Hashable {
         case .standard(let originSurface):
             return originSurface
         case .credentialRecoveryGate:
-            return nil
+            return .credentialRecovery
         }
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
@@ -24,12 +24,24 @@ extension FlashcardsStore {
             now: now
         )
         self.isGuestSignInAfterReviewPromptPresented = true
+        // The showing and the answer are two facts, and this is the showing. Recording only the
+        // answer — which is what the retired `onboarding_step_completed` did — leaves no denominator,
+        // so no acceptance rate can ever be computed from it.
+        Analytics.trackScreenViewed(.signInAfterReviewPrompt)
     }
 
     func requestGuestSignInAfterReviewPromptReconciliation() {
         self.guestSignInAfterReviewPromptReconciliationToken = self.guestSignInAfterReviewPromptReconciliationToken &+ 1
     }
 
+    /**
+     * The prompt closed without either button having decided anything.
+     *
+     * It reports no answer on purpose. The alert is UIKit-backed and cannot be closed by the person
+     * without pressing a button, so this runs either as SwiftUI's own binding write-back behind the
+     * button that already reported its outcome — reporting here too would double-count every answer —
+     * or for a programmatic close nobody answered.
+     */
     func dismissGuestSignInAfterReviewPrompt() {
         self.isGuestSignInAfterReviewPromptPresented = false
     }
@@ -42,6 +54,13 @@ extension FlashcardsStore {
             )
         )
         self.isGuestSignInAfterReviewPromptPresented = false
+        // No surface is restored here: accepting opens the sign-in sheet, which reports `signin` as
+        // it begins its attempt. Closing that sheet is what hands the tab underneath back, and it
+        // reads the visible tab rather than this prompt's entry point, which stays Review.
+        Analytics.track(
+            .promptAnswered(prompt: .signInAfterReviewPrompt, outcome: .accepted),
+            screen: .signInAfterReviewPrompt
+        )
     }
 
     func snoozeGuestSignInAfterReviewPrompt(reviewedCount: Int, now: Date) {
@@ -53,6 +72,16 @@ extension FlashcardsStore {
             )
         )
         self.isGuestSignInAfterReviewPromptPresented = false
+        // "Later" is `snoozed` rather than `dismissed`: it holds the prompt back for a week and a
+        // further ten reviews, which is a different answer from walking away from it.
+        Analytics.track(
+            .promptAnswered(prompt: .signInAfterReviewPrompt, outcome: .snoozed),
+            screen: .signInAfterReviewPrompt
+        )
+        Analytics.trackScreenViewedOnDismiss(
+            of: .signInAfterReviewPrompt,
+            restoring: analyticsSurface(tab: self.currentVisibleTab)
+        )
     }
 
     func clearGuestSignInAfterReviewPromptState() {

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -348,10 +348,7 @@ struct SettingsView: View {
             isPresented: self.$isCloudSignInPresented,
             presentationContext: .standard(originSurface: .settings)
         )
-        .sheet(isPresented: self.$isFriendInvitePresented) {
-            ProgressFriendInviteSheet()
-                .environment(self.store)
-        }
+        .friendInviteSheet(isPresented: self.$isFriendInvitePresented, store: self.store)
     }
 
     private var friendInviteButton: some View {

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DecksScreen: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
+    @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
     @Environment(\.dismissSearch) private var dismissSearch
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -84,6 +85,26 @@ struct DecksScreen: View {
         .task(id: store.localReadVersion) {
             await self.reloadDecksSnapshot()
         }
+        .onAppear {
+            Analytics.trackScreenViewed(.decks)
+        }
+        .onDisappear {
+            // This also fires when a deck detail is pushed on top, and naming Settings then would
+            // record a view the person never had and hide their next real one behind the dedupe. The
+            // tracker guard cannot settle that one, because it would depend on
+            // `DeckDetailScreen.onAppear` winning a race SwiftUI does not order — and every deck open
+            // would take that race. The settings path answers it from state instead: the push is
+            // destination-based and leaves `workspaceDecks` on the path, a tab switch away leaves it
+            // there too, and only the pop back to Settings has removed it. This screen is reachable
+            // no other way, so the path is the whole question. `DeckDetailScreen.onDisappear` reads
+            // the same value for the opposite decision — the list still on the path is what it lands
+            // on — so the two must stay separate rather than be merged into one guard.
+            guard self.navigation.settingsPath.contains(.workspaceDecks) == false else {
+                return
+            }
+
+            Analytics.trackScreenViewedOnDismiss(of: .decks, restoring: .settings)
+        }
         .navigationDestination(item: self.$createdDeckDestination) { destination in
             DeckDetailScreen(destination: destination)
         }
@@ -96,7 +117,16 @@ struct DecksScreen: View {
                 }
             }
         }
-        .sheet(isPresented: $isEditorPresented) {
+        .sheet(
+            isPresented: $isEditorPresented,
+            onDismiss: {
+                // From the presentation, never from the content, for the reason
+                // `Analytics.trackScreenViewedOnDismiss` gives. Saving pushes the new deck's detail
+                // screen, which reports itself; this restore is then refused because the tracker no
+                // longer holds the editor.
+                Analytics.trackScreenViewedOnDismiss(of: .deckEditor, restoring: .decks)
+            }
+        ) {
             NavigationStack {
                 DeckEditorView(
                     title: aiSettingsLocalized("settings.workspace.decks.newDeck", "New deck"),
@@ -112,6 +142,9 @@ struct DecksScreen: View {
                 )
             }
             .technicalErrorSheetHost(store: self.store)
+            .onAppear {
+                Analytics.trackScreenViewed(.deckEditor)
+            }
         }
     }
 
@@ -438,11 +471,22 @@ private struct DeckDetailScreen: View {
             Analytics.trackScreenViewed(.deckDetail)
         }
         .onDisappear {
-            // Popping back lands on the decks list, which is inside Settings and emits nothing of its
-            // own. Conditional, because this also fires for a tab switch away from an open deck
-            // detail, and naming Settings then would both record a view the user never had and hide
-            // their next real one behind the dedupe.
-            Analytics.trackScreenViewedOnDismiss(of: .deckDetail, restoring: .settings)
+            // Popping back usually lands on the decks list, which now has a surface of its own, but
+            // not always: the long-press menu on the standard back button pops several levels at
+            // once, and jumping straight to Settings takes the list away with the detail. Naming the
+            // list then would record a view the person never had and park the tracker on it, so the
+            // Settings arrival is never reported and their genuine next arrival on the list is
+            // swallowed by the dedupe. The settings path is the same settled state the list's own
+            // guard reads, and it still holds `workspaceDecks` for as long as the list is in the
+            // stack; only a pop that removed the list has cleared it. The list uses that to return
+            // early on the push, this uses it to land on Settings — the same value, opposite
+            // decisions, so the two guards must not be merged. Conditional, because this also fires
+            // for a tab switch away from an open deck detail, where `selectTab` has already reported
+            // the destination and the tracker guard refuses.
+            Analytics.trackScreenViewedOnDismiss(
+                of: .deckDetail,
+                restoring: self.navigation.settingsPath.contains(.workspaceDecks) ? .decks : .settings
+            )
         }
         .toolbar {
             if detailState?.allowsEditing == true {
@@ -453,7 +497,12 @@ private struct DeckDetailScreen: View {
                 }
             }
         }
-        .sheet(isPresented: $isEditorPresented) {
+        .sheet(
+            isPresented: $isEditorPresented,
+            onDismiss: {
+                Analytics.trackScreenViewedOnDismiss(of: .deckEditor, restoring: .deckDetail)
+            }
+        ) {
             NavigationStack {
                 DeckEditorView(
                     title: aiSettingsLocalized("settings.workspace.decks.editDeck", "Edit deck"),
@@ -469,6 +518,9 @@ private struct DeckDetailScreen: View {
                 )
             }
             .technicalErrorSheetHost(store: self.store)
+            .onAppear {
+                Analytics.trackScreenViewed(.deckEditor)
+            }
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Tags/TagsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Tags/TagsScreen.swift
@@ -109,6 +109,13 @@ struct TagsScreen: View {
         .task(id: store.localReadVersion) {
             await self.reloadTagsSummary()
         }
+        .onAppear {
+            Analytics.trackScreenViewed(.tags)
+        }
+        .onDisappear {
+            // Conditional, because this also fires for a tab switch away from an open tags list.
+            Analytics.trackScreenViewedOnDismiss(of: .tags, restoring: .settings)
+        }
     }
 
     @MainActor


### PR DESCRIPTION
The card flip, both in-app prompt answers, and the outcome of every system permission dialog the app raises. None of these three events existed on any client before this wave.

## The two prompt facts stay separate on purpose

`prompt_answered` is our own prompt; `permission_prompt_answered` is the OS dialog the app only observes, and it carries **no** surface property because that dialog can be answered after the app was backgrounded and resumed somewhere else — so its `screen` is read where the person actually is when the answer arrives.

Each prompt also reports a `screen_viewed` where it is shown. That is the half the removed `onboarding_step_completed` never had: it recorded an outcome without ever recording that a prompt appeared, so no rate could be computed. Now the showing and the answer are two facts and the conversion is a query.

Outcomes the platform cannot produce are documented rather than mirrored: the sign-in prompt can never report `dismissed` and the pre-prompt can never report `snoozed` (both are UIKit alerts with no non-button exit), and only the photo-library request can report `dismissed` — camera, microphone and notifications answer with a bool, so a zero count for them is structural.

## `review_card_revealed` means the flip

Emitted from the reveal action rather than an effect — an effect sees the reveal state of the render it was created in and would have fired for the *next* card at presentation. Its guard means "this presentation", so a card returned to the head of the queue by `again` is a new presentation and reports again.

## Restores now name where the person actually lands

Under a tracker that collapses an immediate repeat, a wrong restore is doubly bad: it writes a false row *and* swallows the person's genuine next arrival on that screen. Three cases fixed:

- **The sign-in sheet's entry surface and return surface are now separate values.** The after-review prompt's entry point is deliberately `review` even when the person is on another tab, so reusing it as the landing surface reported a screen they never returned to. `signin_failed` keeps the entry-point reading.
- **The credential-recovery gate reports its own landing screen**, which it could not do while its restore accepted only one source surface — the recovery state is cleared while its sign-in sheet is still up.
- **Sheet restores moved to the presentation's `onDismiss`**, so a SwiftUI rebuild cannot restore while the sheet is still on screen. That also fixes the pre-existing Cards editor, where the old placement made the duplicate unconditional.

The deck list and deck detail read the same navigation predicate for opposite decisions, so the restore is correct whichever order SwiftUI runs the two callbacks in.

## `launch_type` stays cold and warm

The catalog's third value is written by the `0121` backfill for reconstructed days. Ingest accepts it, so this union is the only thing keeping a client from sending it.

**Not shipped by this PR:** iOS PR checks do not compile Swift by design, and these events reach real devices only through a TestFlight/App Store release, which is triggered by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)