### PR TITLE
Answer a malformed token with a rejection instead of a 500

### DIFF
--- a/apps/backend/src/agent/apiKeys.ts
+++ b/apps/backend/src/agent/apiKeys.ts
@@ -104,11 +104,13 @@ function hashSecret(secret: string): string {
 }
 
 function isEqualHash(expectedHash: string, actualHash: string): boolean {
-  if (expectedHash.length !== actualHash.length) {
+  const expectedBytes = Buffer.from(expectedHash);
+  const actualBytes = Buffer.from(actualHash);
+  if (expectedBytes.length !== actualBytes.length) {
     return false;
   }
 
-  return timingSafeEqual(Buffer.from(expectedHash), Buffer.from(actualHash));
+  return timingSafeEqual(expectedBytes, actualBytes);
 }
 
 /**

--- a/apps/backend/src/auth/requestSecurity.ts
+++ b/apps/backend/src/auth/requestSecurity.ts
@@ -76,11 +76,15 @@ function createSessionCsrfToken(sessionToken: string, csrfSecret: string): strin
 }
 
 function isMatchingToken(expectedToken: string, actualToken: string): boolean {
-  if (expectedToken.length !== actualToken.length) {
+  // `actualToken` is the client-supplied header, and `String.length` counts UTF-16 code units while
+  // `timingSafeEqual` compares bytes, so the guard has to measure the buffers it hands over.
+  const expectedBytes = Buffer.from(expectedToken);
+  const actualBytes = Buffer.from(actualToken);
+  if (expectedBytes.length !== actualBytes.length) {
     return false;
   }
 
-  return timingSafeEqual(Buffer.from(expectedToken), Buffer.from(actualToken));
+  return timingSafeEqual(expectedBytes, actualBytes);
 }
 
 function getBackendCsrfSecretArn(): string {

--- a/apps/backend/src/chat/live/auth.ts
+++ b/apps/backend/src/chat/live/auth.ts
@@ -111,11 +111,13 @@ function decodePayload(encodedPayload: string): ChatLiveAuthPayload {
 }
 
 function isMatchingSignature(expected: string, actual: string): boolean {
-  if (expected.length !== actual.length) {
+  const expectedBytes = Buffer.from(expected);
+  const actualBytes = Buffer.from(actual);
+  if (expectedBytes.length !== actualBytes.length) {
     return false;
   }
 
-  return timingSafeEqual(Buffer.from(expected), Buffer.from(actual));
+  return timingSafeEqual(expectedBytes, actualBytes);
 }
 
 export async function createChatLiveStreamEnvelope(


### PR DESCRIPTION
Three helpers in `apps/backend` guarded `timingSafeEqual` with a `String.length` check. `String.length` counts UTF-16 code units while `timingSafeEqual` compares UTF-8 bytes, so two strings of equal code-unit length can produce buffers of different byte length and the call throws `RangeError` instead of returning `false`.

| Helper | Reachable from | Was | Now |
|---|---|---|---|
| `isMatchingToken` (`auth/requestSecurity.ts`) | the client-supplied `X-CSRF-Token` header | `500` + Sentry event | `403 SESSION_CSRF_TOKEN_INVALID` |
| `isMatchingSignature` (`chat/live/auth.ts`) | the client `Authorization` header | `500` + Sentry event | `401 CHAT_LIVE_AUTH_INVALID` |
| `isEqualHash` (`agent/apiKeys.ts`) | two sha256 hex digests, ASCII in practice | never threw | unchanged in effect |

The first two are unauthenticated paths, so a single malformed header value produced an unhandled error and a Sentry capture where the branch had always meant to answer a plain rejection.

The short-circuit on a length mismatch stays: a length mismatch is already public information, and a constant-time length comparison would be new machinery for no gain. Status codes, error codes and messages are otherwise untouched.

The identical defect was fixed earlier in `apps/auth`. A sweep of every `timingSafeEqual` call in the repository confirms no site is left gated on `String.length`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)