### PR TITLE
Make the AWS helper scripts run on macOS bash 3.2

### DIFF
--- a/scripts/android/run-android-firebase-test-lab.sh
+++ b/scripts/android/run-android-firebase-test-lab.sh
@@ -309,7 +309,8 @@ gcloud_args+=(
   "${RESULTS_DIR}"
 )
 
-for test_target in "${TEST_TARGETS[@]}"; do
+# bash 3.2 treats expanding an empty array under set -u as an unbound variable.
+for test_target in "${TEST_TARGETS[@]+"${TEST_TARGETS[@]}"}"; do
   gcloud_args+=(
     --test-targets
     "${test_target}"

--- a/scripts/checks/check-demo-cognito-users.sh
+++ b/scripts/checks/check-demo-cognito-users.sh
@@ -14,6 +14,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# bash 3.2 treats expanding an empty array under set -u as an unbound variable.
 AWS_REGION_ARGS=()
 if [[ -n "$REGION" ]]; then
   AWS_REGION_ARGS=(--region "$REGION")
@@ -22,7 +23,7 @@ fi
 get_stack_output() {
   local output_key="$1"
 
-  aws "${AWS_REGION_ARGS[@]}" cloudformation describe-stacks \
+  aws "${AWS_REGION_ARGS[@]+"${AWS_REGION_ARGS[@]}"}" cloudformation describe-stacks \
     --stack-name "$STACK_NAME" \
     --query "Stacks[0].Outputs[?OutputKey=='${output_key}'].OutputValue" \
     --output text
@@ -35,7 +36,7 @@ if [[ -z "$AUTH_FUNCTION_NAME" || "$AUTH_FUNCTION_NAME" == "None" ]]; then
   exit 1
 fi
 
-LAMBDA_CONFIG_JSON="$(aws "${AWS_REGION_ARGS[@]}" lambda get-function-configuration \
+LAMBDA_CONFIG_JSON="$(aws "${AWS_REGION_ARGS[@]+"${AWS_REGION_ARGS[@]}"}" lambda get-function-configuration \
   --function-name "$AUTH_FUNCTION_NAME" \
   --query '{demoEmails: Environment.Variables.DEMO_EMAIL_DOSTIP, demoPassword: Environment.Variables.DEMO_PASSWORD_DOSTIP, demoPasswordSecretArn: Environment.Variables.DEMO_PASSWORD_SECRET_ARN, userPoolId: Environment.Variables.COGNITO_USER_POOL_ID, cognitoRegion: Environment.Variables.COGNITO_REGION}' \
   --output json)"

--- a/scripts/setup/get-analytics-db-access.sh
+++ b/scripts/setup/get-analytics-db-access.sh
@@ -15,6 +15,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# bash 3.2 treats expanding an empty array under set -u as an unbound variable.
 AWS_REGION_ARGS=()
 if [[ -n "$REGION" ]]; then
   AWS_REGION_ARGS=(--region "$REGION")
@@ -23,7 +24,7 @@ fi
 get_stack_output() {
   local output_key="$1"
 
-  aws "${AWS_REGION_ARGS[@]}" cloudformation describe-stacks \
+  aws "${AWS_REGION_ARGS[@]+"${AWS_REGION_ARGS[@]}"}" cloudformation describe-stacks \
     --stack-name "$STACK_NAME" \
     --query "Stacks[0].Outputs[?OutputKey=='${output_key}'].OutputValue" \
     --output text
@@ -60,7 +61,7 @@ if [[ -z "$SECRET_ARN" || "$SECRET_ARN" == "None" ]]; then
   exit 1
 fi
 
-SECRET_JSON="$(aws "${AWS_REGION_ARGS[@]}" secretsmanager get-secret-value \
+SECRET_JSON="$(aws "${AWS_REGION_ARGS[@]+"${AWS_REGION_ARGS[@]}"}" secretsmanager get-secret-value \
   --secret-id "$SECRET_ARN" \
   --query 'SecretString' \
   --output text)"


### PR DESCRIPTION
Under `set -euo pipefail`, bash 3.2 treats expansion of an empty array as an unbound variable. That is the `/bin/bash` that `#!/usr/bin/env bash` resolves to on macOS, so the operator shortcut documented in `docs/analytics-db-access.md` died on its first AWS call:

```
get-analytics-db-access.sh: line 26: AWS_REGION_ARGS[@]: unbound variable
```

Passing `--region` populated the array and hid the bug, which is why CI never saw it: the one workflow that runs `check-demo-cognito-users.sh` always passes `--region` explicitly.

Three expansions are reachable while empty and now use the alternate-value idiom: both `AWS_REGION_ARGS` sites in `get-analytics-db-access.sh`, both in `check-demo-cognito-users.sh`, and `TEST_TARGETS` in `run-android-firebase-test-lab.sh`, which is only appended by an optional flag. Expansions that are provably non-empty or guarded by a count check are left alone, as are `${arr[@]:offset}` slices, which do not trip `set -u` on 3.2.

`get-analytics-db-access.sh` is now fully bash 3.2 clean. Two other scripts still use the bash 4 builtins `readarray`/`mapfile`, so they remain unusable on stock macOS bash for a separate reason; that is a different portability invariant and is left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)