### PR TITLE
Tell an already-used sign-in code apart from an expired one

### DIFF
--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsEvent.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/analytics/AnalyticsEvent.kt
@@ -13,10 +13,8 @@ package com.flashcardsopensourceapp.core.observability.analytics
  * including values no Android screen reaches yet, because it is the contract rather than an
  * inventory of what happens to be wired today.
  *
- * The narrower enums are not complete mirrors, and each omission is deliberate and documented at
- * the enum: `AnalyticsLaunchType` withholds a value a live client must never send, and
- * `AnalyticsSignInFailureReason` omits one this client cannot yet tell apart. A value being absent
- * here is therefore not on its own evidence that the server rejects it.
+ * A narrower enum is allowed, and every omission is deliberate and documented at the enum itself.
+ * A value being absent here is therefore not on its own evidence that the server rejects it.
  *
  * Ten events are server-derived — `guest_upgrade_completed`, `review_answered`, `card_created`,
  * `card_updated`, `deck_created`, `deck_updated`, `friend_invitation_created`,
@@ -28,10 +26,9 @@ package com.flashcardsopensourceapp.core.observability.analytics
  * event names.
  *
  * Two client events the catalog declares are absent because this client does not observe them yet
- * rather than because it may not send them: `signin_code_requested` and `signin_succeeded`. No
- * client emits either one today — `apps/backend/src/productAnalytics/catalog.ts` is their only
- * other mention in the repository — so whoever wires the Android sign-in funnel has no existing
- * producer to mirror and should read that catalog entry for the shape.
+ * rather than because it may not send them: `signin_code_requested` and `signin_succeeded`.
+ * Whoever wires the Android sign-in funnel adds each one here and at its emit site together, and
+ * reads the catalog entry for the shape.
  */
 
 /** Named because the delivery path has to recognise a batch that carries nothing else. */
@@ -171,15 +168,14 @@ enum class AnalyticsPermissionOutcome(val wireValue: String) {
 }
 
 /**
- * Missing the catalog's `code_already_used` on purpose for now: this client folds the auth service's
- * `OTP_CHALLENGE_CONSUMED` into [EXPIRED_CODE], and reporting a value the mapping does not actually
- * separate would be a false distinction. Splitting the two is a change to that mapping, not to this
- * list, and it breaks the continuity of the existing `expired_code` series, so it belongs to
- * whoever decides that trade rather than to a mirroring pass.
+ * [CODE_ALREADY_USED] is reported only by app versions whose mapping separates the auth service's
+ * `OTP_CHALLENGE_CONSUMED` from an expired session. One that folds them reports [EXPIRED_CODE] for
+ * both, so an `expired_code` series is not like-for-like across that boundary.
  */
 enum class AnalyticsSignInFailureReason(val wireValue: String) {
     INVALID_CODE(wireValue = "invalid_code"),
     EXPIRED_CODE(wireValue = "expired_code"),
+    CODE_ALREADY_USED(wireValue = "code_already_used"),
     RATE_LIMITED(wireValue = "rate_limited"),
     OFFLINE(wireValue = "offline"),
     SERVER_ERROR(wireValue = "server_error"),

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -1053,8 +1053,9 @@ private fun analyticsCloudSignInFailureReason(error: CloudRemoteException): Anal
     }
 
     return when (error.errorCode?.trim()?.uppercase()) {
-        "OTP_CODE_INVALID", "OTP_VERIFY_FAILED", "INVALID_EMAIL" -> AnalyticsSignInFailureReason.INVALID_CODE
-        "OTP_SESSION_EXPIRED", "OTP_CHALLENGE_CONSUMED" -> AnalyticsSignInFailureReason.EXPIRED_CODE
+        "OTP_CODE_INVALID", "INVALID_EMAIL" -> AnalyticsSignInFailureReason.INVALID_CODE
+        "OTP_SESSION_EXPIRED" -> AnalyticsSignInFailureReason.EXPIRED_CODE
+        "OTP_CHALLENGE_CONSUMED" -> AnalyticsSignInFailureReason.CODE_ALREADY_USED
         "OTP_TOO_MANY_ATTEMPTS", "RATE_LIMITED" -> AnalyticsSignInFailureReason.RATE_LIMITED
         else -> AnalyticsSignInFailureReason.SERVER_ERROR
     }

--- a/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/AnalyticsEvent.swift
@@ -18,11 +18,10 @@ import Foundation
  * `ai_message_sent` and `catalog_deck_installed`.
  *
  * `signin_code_requested` and `signin_succeeded` are client-emittable and absent for a different
- * reason: nothing reports the two middle funnel steps yet. The catalog declares them ahead of a
- * producer, and there is no emit site for either anywhere in the repository — not on the auth
- * origin the catalog names as the intended web producer, and not in the web client's own mirror.
- * Adopting them here is its own change rather than a gap in this mirror, and iOS is not behind web
- * on them.
+ * reason: this app reports neither of the two middle funnel steps. Adopting one is its own change —
+ * a case here plus an emit site in the iOS sign-in flow — rather than a gap in this mirror. Which
+ * other producers already report them is not this file's to track; the catalog entry is where their
+ * shape is defined.
  *
  * `onboarding_step_completed`, `review_session_started` and `review_session_ended` were removed
  * from the catalog outright, so the server no longer declares them and rejects them as unknown
@@ -177,9 +176,15 @@ enum AnalyticsPermissionOutcome: String, Sendable, Equatable {
     case dismissed
 }
 
+/**
+ * `codeAlreadyUsed` is reported only by app versions whose mapping separates the auth service's
+ * `OTP_CHALLENGE_CONSUMED` from an expired session. One that folds them reports `expiredCode` for
+ * both, so an `expired_code` series is not like-for-like across that boundary.
+ */
 enum AnalyticsSignInFailureReason: String, Sendable, Equatable {
     case invalidCode = "invalid_code"
     case expiredCode = "expired_code"
+    case codeAlreadyUsed = "code_already_used"
     case rateLimited = "rate_limited"
     case offline
     case serverError = "server_error"

--- a/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+Analytics.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+Analytics.swift
@@ -126,8 +126,10 @@ func analyticsSignInFailureReason(error: Error) -> AnalyticsSignInFailureReason 
     switch details.code {
     case "OTP_CODE_INVALID", "INVALID_EMAIL":
         return .invalidCode
-    case "OTP_SESSION_EXPIRED", "OTP_CHALLENGE_CONSUMED":
+    case "OTP_SESSION_EXPIRED":
         return .expiredCode
+    case "OTP_CHALLENGE_CONSUMED":
+        return .codeAlreadyUsed
     case "OTP_TOO_MANY_ATTEMPTS":
         return .rateLimited
     default:


### PR DESCRIPTION
Both mobile clients folded the auth service's `OTP_CHALLENGE_CONSUMED` into `expired_code`, so the catalog's `code_already_used` could only ever be produced by the auth origin. Both now report it.

Android also reported `OTP_VERIFY_FAILED` as `invalid_code`. `apps/auth` declares `signInFailureReasonByVerifyFailureCode` as a **total** map and classifies that code as `server_error` — which iOS already agreed with by falling through. Android was recording a failure our own server calls a server error as though the person had typed a wrong code.

| Verify-failure code | `apps/auth` | iOS | Android |
|---|---|---|---|
| `OTP_CODE_INVALID` | `invalid_code` | ✓ | ✓ |
| `OTP_SESSION_EXPIRED` | `expired_code` | ✓ | ✓ |
| `OTP_CHALLENGE_CONSUMED` | `code_already_used` | now ✓ | now ✓ |
| `OTP_VERIFY_FAILED` | `server_error` | ✓ | now ✓ |

Splitting the reasons breaks the continuity of each client's `expired_code` series at its release boundary. That is recorded at each enum, phrased as what a mapping that folds them reports rather than as a claim about which versions shipped — so it stays true whether or not a released build ever emitted the folded value.

Two mirror header comments asserted that nothing in the repository emits `signin_code_requested` or `signin_succeeded`. The auth origin has emitted both since `59798729a`.

The user-facing error message paths are deliberately untouched: this changes the analytics reason only.

Known and queued separately: `SERVICE_UNAVAILABLE` on verify-code and `PASSWORD_SIGN_IN_FAILED` on send-code still disagree with the auth service's classification. The same wire code means different things on send and verify, so the fix needs route context threaded through both clients' mapping functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)