### PR TITLE
State the guest-session cost in the unit the mint actually uses

### DIFF
--- a/apps/auth/src/server/analytics/client.ts
+++ b/apps/auth/src/server/analytics/client.ts
@@ -12,7 +12,7 @@
  * resent. That is the design of this producer, not an omission from it.
  *
  * What it costs: one `web` guest session, and the four rows the web guest reaper documents it
- * owning, per signed-out login-page load rather than per sign-in attempt. That is deliberate.
+ * owning, per reporting visitor identity, retired by `visitorSession.ts`. That is deliberate.
  * "Reached the login page and never entered an email" is the most valuable number this measurement
  * produces, and it cannot exist without an identity at step one. The bound is the existing 90-day
  * web guest reaper in `apps/backend/src/guestAuth/reaper/`, which deletes web guests that never


### PR DESCRIPTION
The comment priced the sign-in funnel measurement at one `web` guest session "per signed-out login-page load". `GET /login` makes no network call and mints no guest session at all; the mint happens on a marked funnel report, and only when the stored visitor carries no guest token — so repeated login-page loads under one cookie cost nothing extra.

The claim matters because the two sentences after it hand the reader the 90-day reaper and `WebGuestReaperSaturatedAlarm` as the bound on exactly this growth. Sizing either against the wrong unit misjudges it.

The replacement names the condition the mint is actually guarded on, and points at `visitorSession.ts` for the identity's lifetime rather than paraphrasing it. A reviewer confirmed all four ways an identity ends live in that file — the explicit clear, the 90-day cookie, a signature failure, and a payload-shape rejection — so the pointer is the whole answer. It enumerates none of them, so adding or removing a boundary cannot falsify it.

An earlier attempt at this sentence said "lasting until this browser changes hands", which was also wrong: the identity is retired at every sign-in and every logout regardless of any hand-over. That version lifted a phrase from the *rationale* for why those boundaries exist and turned it into a claim about when the identity ends.

Comment only. No behaviour, code path, or constant changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)