### PR TITLE
Add SSM Session Manager as the analytical DB access path

### DIFF
--- a/docs/analytics-db-access.md
+++ b/docs/analytics-db-access.md
@@ -6,12 +6,13 @@ This document describes the supported analytical access paths for the persistent
 
 The supported read-only access paths are:
 
-- manual/operator analytics and Metabase-style SSH tunneling without making the production RDS instance itself publicly reachable
+- manual/operator analytics and Metabase-style tunneling without making the production RDS instance itself publicly reachable
 - controlled server-side admin analytics where the backend Lambda runs read-only admin reporting SQL inside the VPC
 
-The `reporting_readonly` role is part of the baseline schema in every environment. When analytical SSH access is enabled, the stack also creates:
+The `reporting_readonly` role is part of the baseline schema in every environment. When analytical access is enabled, the stack also creates:
 
-- a public EC2 bastion host dedicated to analytical SSH tunneling
+- an EC2 bastion host dedicated to analytical tunneling, reachable both through AWS Systems Manager Session Manager and through public SSH
+- an instance role with the AWS managed policy `AmazonSSMManagedInstanceCore`, which is what registers the bastion with Systems Manager
 - a private network path from that bastion host to the RDS instance on `5432`
 
 The current `reporting_readonly` password secret is also part of the baseline infrastructure in every environment, even when the SSH bastion is disabled. The deployed backend Lambda uses that same role for server-side admin analytics through a separate read-only pool and without SSH.
@@ -57,10 +58,11 @@ gh variable delete CDK_ANALYTICS_SSH_USERNAME --repo kirill-markin/flashcards-op
    - `AnalyticsSshHost`
    - `AnalyticsSshPort`
    - `AnalyticsSshUsername`
+   - `AnalyticsSsmInstanceId`
 
 Important current behavior: this disable flow removes the AWS-side bastion path only. It does not remove the baseline Postgres role `reporting_readonly`, its read grants, or the current reporting password secret/output used by server-side admin analytics.
 
-That means disabling analytics SSH access should be treated as removing the supported operator access path only. It should not be treated as a full schema-level removal of `reporting_readonly`.
+That means disabling analytics SSH access should be treated as removing the bastion and both of its operator access paths, SSH and SSM. It should not be treated as a full schema-level removal of `reporting_readonly`.
 
 ## What gets exposed
 
@@ -71,6 +73,7 @@ After deployment, CloudFormation always includes:
 
 When analytical access is enabled, CloudFormation also includes:
 
+- `AnalyticsSsmInstanceId`
 - `AnalyticsSshHost`
 - `AnalyticsSshPort`
 - `AnalyticsSshUsername`
@@ -83,7 +86,45 @@ The supported operator shortcut is:
 bash scripts/setup/get-analytics-db-access.sh --stack-name FlashcardsOpenSourceApp
 ```
 
-That helper reads the current stack outputs, resolves the current reporting secret by ARN, and prints a JSON bundle with the current SSH, database, and password values.
+That helper reads the current stack outputs, resolves the current reporting secret by ARN, and prints a JSON bundle with the current SSM, SSH, database, and password values.
+
+The SSM path is additive, so `ssmInstanceId` is empty on any stack that has not yet deployed it. The helper only notes that on stderr and still prints the SSH, database, and password values, which remain the working path in that window.
+
+## Preferred operator path: SSM port forwarding
+
+Session Manager port forwarding is the preferred supported operator path. It works from any network, needs no inbound port on the bastion, and needs no entry in `ANALYTICS_SSH_ALLOWED_CIDRS`, because the tunnel is established outbound by the SSM Agent on the bastion.
+
+Local prerequisite: the AWS CLI plus the `session-manager-plugin`, which the AWS CLI shells out to for `aws ssm start-session`.
+
+```bash
+brew install --cask session-manager-plugin
+```
+
+Operator IAM prerequisite: credentials allowed to `ssm:StartSession` on the bastion instance and on `arn:aws:ssm:<region>::document/AWS-StartPortForwardingSessionToRemoteHost`, plus `ssm:TerminateSession` and `ssm:ResumeSession` on their own `arn:aws:ssm:*:*:session/*` sessions, plus `ssm:DescribeInstanceInformation` for the registration check below. No SSH key and no source-IP allowlist entry are involved.
+
+Verify that the bastion is registered with Systems Manager before opening a tunnel:
+
+```bash
+aws ssm describe-instance-information \
+  --filters Key=InstanceIds,Values=<AnalyticsSsmInstanceId>
+```
+
+An empty result right after a deploy is normal rather than a broken deploy: the SSM Agent backs off while it has no credentials, so an already-running bastion that has just been given its instance role can take several minutes to appear. Retry before investigating further.
+
+Open the tunnel with the instance id from `AnalyticsSsmInstanceId`:
+
+```bash
+aws ssm start-session \
+  --target <AnalyticsSsmInstanceId> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<DbEndpoint>"],"portNumber":["5432"],"localPortNumber":["15432"]}'
+```
+
+The session forwards `127.0.0.1:15432` to `<DbEndpoint>:5432` through the bastion, so every local client step below is identical to the SSH path.
+
+The two paths are not equally narrow. The SSH path is restricted by sshd to a tunnel into `<DbEndpoint>:5432` with no interactive shell, while `AmazonSSMManagedInstanceCore` registers the bastion with Session Manager generally, so a principal holding `ssm:StartSession` on it also gets an interactive shell on the bastion and port forwarding to any host reachable from it. That is accepted here because the only principals holding `ssm:StartSession` in this account are already account administrators.
+
+The public SSH path described in the rest of this document is still deployed and still supported. It is kept until the SSM path is confirmed in production, and it stays the path used by tools such as Metabase that speak SSH rather than SSM.
 
 ## Bastion behavior
 
@@ -96,7 +137,7 @@ The bastion host is public only for SSH and is expected to be protected by:
 - `PermitOpen <DbEndpoint>:5432`
 - no interactive shell access for the analytics SSH user
 
-The bastion exists only to forward traffic into the private database network. The RDS instance remains private, and the analytics SSH user is tunnel-only rather than a general shell user.
+These properties describe the SSH path. Over SSH the bastion exists only to forward traffic into the private database network: the RDS instance remains private, and the analytics SSH user is tunnel-only rather than a general shell user. The SSM path is not constrained by sshd, as described above.
 
 ## Database role: `reporting_readonly`
 
@@ -121,7 +162,7 @@ The baseline schema migration also enforces the persistent runtime policy for th
 
 Privileged role attributes such as `NOSUPERUSER` and `NOREPLICATION` are currently outside the normal migration path on RDS/PostgreSQL 18 and are not managed here.
 
-Important current behavior: this role is intentionally persistent across later bastion disablement because it is part of the baseline schema. The disable flow only removes the operator SSH access path.
+Important current behavior: this role is intentionally persistent across later bastion disablement because it is part of the baseline schema. The disable flow removes the bastion and both of its operator access paths, SSH and SSM, while leaving this role, its grants, and the reporting secret in place.
 
 ## Granted schemas
 
@@ -196,6 +237,7 @@ Example output:
   "sshHost": "ec2-203-0-113-10.eu-central-1.compute.amazonaws.com",
   "sshPort": "22",
   "sshUsername": "analytics",
+  "ssmInstanceId": "i-0123456789abcdef0",
   "dbEndpoint": "flashcards-db.abcdefghijkl.eu-central-1.rds.amazonaws.com",
   "dbName": "flashcards",
   "dbUsername": "reporting_readonly",
@@ -213,7 +255,16 @@ aws secretsmanager get-secret-value \
   --output text
 ```
 
-3. Start a local tunnel:
+3. Start a local tunnel. Preferred, with SSM port forwarding as described above:
+
+```bash
+aws ssm start-session \
+  --target <ssmInstanceId> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<dbEndpoint>"],"portNumber":["5432"],"localPortNumber":["15432"]}'
+```
+
+Or over the still-supported SSH path:
 
 ```bash
 ssh -N \
@@ -262,7 +313,7 @@ The reporting password secret now uses a stable baseline Secrets Manager name, b
 
 ## Usage guidance
 
-Use `reporting_readonly` only for analytical queries and investigation. It must remain read-only for both operator SSH access and backend-owned admin analytics.
+Use `reporting_readonly` only for analytical queries and investigation. It must remain read-only for both operator bastion access and backend-owned admin analytics.
 
 Prefer querying stable business tables first:
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -114,14 +114,17 @@ This same write-once bootstrap behavior applies to `GLOBAL_METRICS_VISIBLE` -> `
 
 The `reporting_readonly` Postgres role is part of the baseline database schema in every environment. It is supported for two read-only paths:
 
-- manual/operator analytics through the optional analytical SSH bastion
+- manual/operator analytics through the optional analytical bastion
 - controlled server-side admin analytics from the backend Lambda inside the VPC
 
-When the analytical SSH bastion variables are configured together, the stack also creates the optional operator access path used to reach that role through SSH tunneling into the private database.
+When the analytical SSH bastion variables are configured together, the stack also creates the optional operator access path used to reach that role by tunneling into the private database. The bastion carries two access paths:
 
-That bastion is tunnel-only for the configured analytical SSH user: it allows SSH key authentication and TCP forwarding to the private Postgres endpoint, but it does not provide interactive shell access.
+- SSM Session Manager port forwarding, the preferred path, enabled by an instance role with the AWS managed policy `AmazonSSMManagedInstanceCore` and published as the `AnalyticsSsmInstanceId` output
+- public SSH tunneling, still deployed and still supported
 
-The `reporting_readonly` password secret is also part of the baseline infrastructure in every environment. When this optional feature is disabled, only the bastion host and SSH-specific outputs are removed; the underlying `reporting_readonly` database principal and its current password secret remain part of the baseline environment.
+The SSH path is tunnel-only for the configured analytical SSH user: it allows SSH key authentication and TCP forwarding to the private Postgres endpoint, but it does not provide interactive shell access. The SSM path is broader by design: registering the instance with Session Manager also gives a principal holding `ssm:StartSession` on it an interactive shell and forwarding to any host reachable from the bastion. That is accepted because the only such principals in this account are already account administrators.
+
+The `reporting_readonly` password secret is also part of the baseline infrastructure in every environment. When this optional feature is disabled, only the bastion host, its instance role, and the bastion-specific outputs (`AnalyticsSsh*` and `AnalyticsSsmInstanceId`) are removed; the underlying `reporting_readonly` database principal and its current password secret remain part of the baseline environment.
 
 The reporting password secret now uses a stable baseline Secrets Manager name, but the supported operator discovery path remains the helper script or the stack outputs so operators always resolve the current deployed secret ARN. The database schema owns the reporting_readonly login role, read-only grants, and non-privileged role settings, while the deployed migration runner uses the secret only to rotate the current password.
 

--- a/infra/aws/lib/analytics-access.ts
+++ b/infra/aws/lib/analytics-access.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
 export interface AnalyticsAccessProps {
@@ -14,6 +15,7 @@ export interface AnalyticsAccessProps {
 export interface AnalyticsAccessResult {
   dbAccessInstance: ec2.Instance;
   sshUsername: string;
+  ssmInstanceId: string;
 }
 
 function validateAnalyticsSshUsername(sshUsername: string): string {
@@ -28,8 +30,8 @@ function validateAnalyticsSshUsername(sshUsername: string): string {
 }
 
 /**
- * Provisions the public SSH bastion used for analytical access to the private
- * RDS instance without making the database itself publicly reachable.
+ * Provisions the bastion used for analytical access to the private RDS
+ * instance without making the database itself publicly reachable.
  */
 export function analyticsAccess(scope: Construct, props: AnalyticsAccessProps): AnalyticsAccessResult {
   const sshUsername = validateAnalyticsSshUsername(props.sshUsername);
@@ -49,8 +51,19 @@ export function analyticsAccess(scope: Construct, props: AnalyticsAccessProps): 
 
   props.dbSg.addIngressRule(dbAccessSg, ec2.Port.tcp(5432), "Analytical DB access host to Postgres");
 
+  // Registers the bastion with Systems Manager so operators can port-forward
+  // to the database with their AWS credentials instead of a public SSH port.
+  const dbAccessRole = new iam.Role(scope, "DbAccessRole", {
+    assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
+    description: "Instance role for the analytical bastion host",
+    managedPolicies: [
+      iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore"),
+    ],
+  });
+
   const dbAccessInstance = new ec2.Instance(scope, "DbAccessInstance", {
     vpc: props.vpc,
+    role: dbAccessRole,
     vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
     securityGroup: dbAccessSg,
     instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.NANO),
@@ -113,5 +126,6 @@ export function analyticsAccess(scope: Construct, props: AnalyticsAccessProps): 
   return {
     dbAccessInstance,
     sshUsername,
+    ssmInstanceId: dbAccessInstance.instanceId,
   };
 }

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -52,6 +52,7 @@ export interface OutputsProps {
   multipartCompletionReconciliationScheduleName: string;
   dbAccessInstance?: ec2.Instance;
   analyticsSshUsername?: string;
+  analyticsSsmInstanceId?: string;
 }
 
 export function outputs(scope: Construct, props: OutputsProps): void {
@@ -241,6 +242,13 @@ export function outputs(scope: Construct, props: OutputsProps): void {
     new cdk.CfnOutput(scope, "AnalyticsSshUsername", {
       value: props.analyticsSshUsername,
       description: "SSH username for the analytical bastion host",
+    });
+  }
+
+  if (props.analyticsSsmInstanceId !== undefined) {
+    new cdk.CfnOutput(scope, "AnalyticsSsmInstanceId", {
+      value: props.analyticsSsmInstanceId,
+      description: "EC2 instance id of the analytical bastion host for SSM Session Manager port forwarding",
     });
   }
 

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -508,6 +508,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       dbAccessInstance: analyticsAccessResult?.dbAccessInstance,
       reportingDbSecret: dbResult.reportingDbSecret,
       analyticsSshUsername: analyticsAccessResult?.sshUsername,
+      analyticsSsmInstanceId: analyticsAccessResult?.ssmInstanceId,
     });
   }
 }

--- a/scripts/setup/get-analytics-db-access.sh
+++ b/scripts/setup/get-analytics-db-access.sh
@@ -33,6 +33,7 @@ get_stack_output() {
 SSH_HOST="$(get_stack_output "AnalyticsSshHost")"
 SSH_PORT="$(get_stack_output "AnalyticsSshPort")"
 SSH_USERNAME="$(get_stack_output "AnalyticsSshUsername")"
+SSM_INSTANCE_ID="$(get_stack_output "AnalyticsSsmInstanceId")"
 DB_ENDPOINT="$(get_stack_output "DbEndpoint")"
 SECRET_ARN="$(get_stack_output "ReportingDbSecretArn")"
 
@@ -51,6 +52,17 @@ if [[ -z "$SSH_USERNAME" || "$SSH_USERNAME" == "None" ]]; then
   exit 1
 fi
 
+# The SSM path is additive and is not required for analytical access to work.
+# A stack deployed before it existed still serves the SSH path, so report an
+# empty instance id instead of failing the whole bundle.
+if [[ "$SSM_INSTANCE_ID" == "None" ]]; then
+  SSM_INSTANCE_ID=""
+fi
+
+if [[ -z "$SSM_INSTANCE_ID" ]]; then
+  echo "NOTE: AnalyticsSsmInstanceId output not found on ${STACK_NAME}; SSM port forwarding is unavailable there, use the SSH path." >&2
+fi
+
 if [[ -z "$DB_ENDPOINT" || "$DB_ENDPOINT" == "None" ]]; then
   echo "ERROR: DbEndpoint output not found. Deploy the stack first." >&2
   exit 1
@@ -66,17 +78,18 @@ SECRET_JSON="$(aws "${AWS_REGION_ARGS[@]+"${AWS_REGION_ARGS[@]}"}" secretsmanage
   --query 'SecretString' \
   --output text)"
 
-python3 - "$SSH_HOST" "$SSH_PORT" "$SSH_USERNAME" "$DB_ENDPOINT" "$DB_NAME" "$SECRET_ARN" "$SECRET_JSON" <<'PY'
+python3 - "$SSH_HOST" "$SSH_PORT" "$SSH_USERNAME" "$SSM_INSTANCE_ID" "$DB_ENDPOINT" "$DB_NAME" "$SECRET_ARN" "$SECRET_JSON" <<'PY'
 import json
 import sys
 
 ssh_host = sys.argv[1]
 ssh_port = sys.argv[2]
 ssh_username = sys.argv[3]
-db_endpoint = sys.argv[4]
-db_name = sys.argv[5]
-secret_arn = sys.argv[6]
-secret_json = sys.argv[7]
+ssm_instance_id = sys.argv[4]
+db_endpoint = sys.argv[5]
+db_name = sys.argv[6]
+secret_arn = sys.argv[7]
+secret_json = sys.argv[8]
 
 secret_value = json.loads(secret_json)
 username = secret_value.get("username")
@@ -92,6 +105,7 @@ print(json.dumps({
     "sshHost": ssh_host,
     "sshPort": ssh_port,
     "sshUsername": ssh_username,
+    "ssmInstanceId": ssm_instance_id,
     "dbEndpoint": db_endpoint,
     "dbName": db_name,
     "dbUsername": username,


### PR DESCRIPTION
The analytical bastion was reachable only over public SSH, gated by a source-IP allowlist. That allowlist is unworkable in practice: the operator's exit IP floats, and every change to it costs a full CI/CD deploy. Widening it is the wrong direction for a host that exposes `:22` to the internet.

Session Manager removes the problem instead of managing it. The bastion already runs Amazon Linux 2023, where the SSM Agent is preinstalled, and already sits in a public subnet with outbound access, so the only missing piece was an instance role. With `AmazonSSMManagedInstanceCore` attached, an operator port-forwards to the private RDS instance from any network using their AWS credentials, with no inbound port and no allowlist.

## Expand half only

This is the additive half of an expand-and-contract change. The public SSH path keeps working and stays documented, so the deploy cannot leave the database unreachable if the SSM path misbehaves; a follow-up removes the SSH surface once this one is proven in production. For the same reason the helper treats `AnalyticsSsmInstanceId` as optional and still emits a complete bundle against a stack deployed before this commit.

## Posture change, stated plainly

Session Manager is broader than the SSH path it will replace: an `ssm:StartSession` principal also gets an interactive shell and forwarding to any host the bastion can reach, where sshd granted `nologin` and `PermitOpen` to Postgres only. Every such principal in this account is already an administrator, so nothing is gained by them today. `infra/aws/README.md` previously claimed the bastion provides no interactive shell access; that claim is now scoped to the SSH path instead of left false.

## Deploy verification

`IamInstanceProfile` on `AWS::EC2::Instance` is a no-interruption update and the instance already carries a CDK-generated profile, so the bastion should keep its id and public DNS — which matters because `AnalyticsSshHost` is what the Metabase connection points at. Verified against the pre-deploy baseline after this merge, along with SSM registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)