### PR TITLE
Document how the web sign-in funnel is measured

### DIFF
--- a/docs/analytics-db-access.md
+++ b/docs/analytics-db-access.md
@@ -324,3 +324,22 @@ Sync diagnostics intentionally do not expose the superseded `sync.changes` paylo
 Product analytics writes on the guest upgrade path are best effort: they run after the upgrade transaction already committed. On the merge path they are never retried, because that path revokes the guest session, so a client retry returns an idempotent replay and never reaches the producer again. `auth.guest_upgrade_history` is the reconstruction source for either loss on that path. `source_guest_user_id` and `target_user_id` rebuild a missing `analytics.identity_links` row, which is what makes that guest's pre-upgrade history resolve to the account instead of the guest id in `analytics.product_events_resolved`; those columns together with `source_guest_session_id`, `target_workspace_id`, and `merged_at` rebuild a missing `guest_upgrade_completed` row in `analytics.product_events`, whose `event_id` is derived from the guest session id by `apps/backend/src/productAnalytics/serverEvents.ts`. All of these columns are already granted to `reporting_readonly`.
 
 A bound completion — the ordinary first-time guest-to-account conversion, where the Cognito subject is already bound to the guest user — writes no `auth.guest_upgrade_history` row at all, so there is nothing to query and nothing to reconstruct from. It also writes no identity link, because the guest user id is already the account id. It does not revoke the guest session either, so a repeated `POST /guest-auth/upgrade/complete` reaches the producer again, and the derived `event_id` conflicting in the writer is what keeps that conversion counted once.
+
+The auth origin writes product analytics rows of its own: the web sign-in funnel, produced by
+`apps/auth` into the same `analytics.product_events` feed and its resolved view. Read how in the
+`Login funnel analytics` section of `docs/auth-service.md`, not from the rows. Each caveat below is
+owned by the source it names, else by a comment in `apps/auth/src/server/analytics/catalog.ts`:
+
+- The pair (`screen_viewed`, `screen = 'signin'`) has a second `platform = 'web'` producer: the web
+  app reports it for the workspace-choice step, downstream of `signin_succeeded`, inflating a
+  login-page denominator (`resolveSessionGateSurface` in `apps/web/src/App.tsx`). Auth-origin rows
+  are the ones with a null `app_version`, true only because `postAnalyticsEvents` in `client.ts`
+  sends no `x-client-version`. `device_locale`, `timezone` and `network_state` are null too: a
+  `platform = 'web'` breakdown grouped by one buckets the funnel, and only a filter or join drops it.
+- Auth-origin rows resolve to the visitor's guest user id, not the account, whenever the sign-in's
+  best-effort identity link did not land, and nothing reconstructs it. A first-ever sign-in usually
+  loses it, and so does a sign-in that ran slow (`analyticsReportBudgetMs` in `signInFunnel.ts`).
+- `signin_failed` carries no `screen`; a funnel filtered on `screen = 'signin'` reads it as zero.
+- Web session counts include auth-origin sessions; a visitor whose posts run slow adds one per event.
+- A conversion computed from `signin_succeeded` is a lower bound rather than a rate.
+- `signin_failed` with `reason = 'server_error'` is a floor rather than the whole.

--- a/docs/auth-service.md
+++ b/docs/auth-service.md
@@ -4,9 +4,9 @@ Email + OTP authentication via AWS Cognito (passwordless).
 
 - `AUTH_MODE`: `none` (local dev, no auth) or `cognito` (verify JWT from `Authorization: Bearer`)
 - Guest sessions (`POST /v1/guest-auth/session`) are bound to `ios`, `android`, or `web`. A `web`
-  guest session is an analytics credential only: the browser requests one lazily on a signed-out
-  visitor's first real interaction and sends it as `Authorization: Guest <token>` to
-  `POST /v1/analytics/events` alone.
+  guest session is an analytics credential only, sent as `Authorization: Guest <token>` to
+  `POST /v1/analytics/events` alone. It is requested by the browser, lazily on a signed-out
+  visitor's first real interaction, and by this service itself (`Login funnel analytics` below).
   - The route's own ingest contract lives in the source:
     `apps/backend/src/routes/productAnalytics.ts` owns its HTTP surface, accepted transports,
     and the `accepted`/`rejected` envelope; `apps/backend/src/productAnalytics/validation.ts`
@@ -96,3 +96,39 @@ Email + OTP authentication via AWS Cognito (passwordless).
   - `apps/backend/src/auth/ensureUser.ts`: auto-provisions `user_settings` and `workspace` on first request
   - `infra/aws/lib/auth.ts`: CDK Cognito User Pool construct
   - `db/migrations/0002_user_settings.sql`: `user_settings` table
+
+## Login funnel analytics
+
+`apps/auth` measures the web sign-in funnel itself, server-side, from its own route handlers. The
+login page runs no analytics script and posts no event; all it contributes is the `?screen=signin`
+query on the sign-in `fetch` calls it already makes (`apps/auth/src/templates/login.ts`). The events
+go to the public client ingest route `POST /v1/analytics/events` as a `web` guest client, never to
+the `analytics` schema directly: the `auth_app` role has no grants there and must not be given any.
+
+- The steps, and the branch that observes each:
+  - `screen_viewed` with `screen = signin`: `POST /api/refresh-session`
+    (`apps/auth/src/routes/browser/refreshSession.ts`) on an absent `refresh` cookie — a first visit,
+    a sign-out and an expired cookie alike — and on a rejected refresh token. A non-terminal refresh
+    failure is rethrown as a `500` and reports nothing, so this page-view denominator is a floor.
+  - `signin_code_requested`: a `POST /api/send-code` that accepted the request
+    (`apps/auth/src/routes/browser/sendCode.ts`).
+  - `signin_succeeded` and `signin_failed` with a `reason`: `verifyCode.ts` beside it, plus the
+    demo-account and refusal branches of `sendCode.ts`.
+  - Abandonment is the absence of the next step for an actor, not an event.
+  - Every step is gated on that marker and on the visitor cookie; lose either and the funnel counts
+    zero in silence. The cookie is minted outside the producer, by `GET /login`
+    (`apps/auth/src/routes/browser/loginPage.ts`); what a cache in front of that page costs is stated
+    there, and what an edited attribute costs beside `visitorCookieOptions` in `visitorSession.ts`.
+  - The producer — catalog mirror, cookie module, transport, report budgets, and the marker check
+    that keeps non-funnel callers of these shared routes out — is `apps/auth/src/server/analytics/`.
+- Identity: its own `anonymous_id` and `web` guest session, both in the `__Host-analytics_visitor`
+  cookie (`apps/auth/src/server/analytics/visitorSession.ts`). Nothing is shared with the app origin.
+- The join: at sign-in success, and only there, this service links the visitor's guest identity to
+  the account with `POST /v1/guest-auth/identity/link`, best effort inside the whole request's
+  budget, which the success event shares and a first-ever sign-in usually overruns. Nothing recovers
+  a link that did not land (`analyticsReportBudgetMs`, `reportSignInSucceeded` in `signInFunnel.ts`).
+- The accepted limitation: an unjoined visitor never stitches to the app-side guest identity, so an
+  end-to-end "opened the app -> registered" path needs a cross-origin identifier this design refuses.
+- The cost: one `web` guest session per visitor identity, not one per login-page load.
+- Deliberately not measured: the OAuth consent page at `GET /authorize`, and `app_version`.
+- Querying these rows: the caveats an analyst needs are in `docs/analytics-db-access.md`.


### PR DESCRIPTION
The auth origin measures its own login funnel and joins the visitor to the account server-side. This records it in the two places a reader actually goes: `docs/auth-service.md` for the contract, and `docs/analytics-db-access.md` for the analyst about to write a query.

Both sections point at the code rather than restating it. What they carry is the part an analyst cannot get from the rows:

| Caveat | Why it matters |
|---|---|
| `signin_failed` carries no `screen` | a funnel filtered on `screen = 'signin'` reads its failure arm as **zero** |
| The pair (`screen_viewed`, `screen='signin'`) has a second `platform='web'` producer | the web app's workspace-choice step sits **downstream** of `signin_succeeded` and inflates the denominator |
| The identity link is best effort inside the request budget | a first-ever sign-in usually overruns it, and nothing reconstructs a link that did not land — those rows keep resolving to the guest user id |
| The page-view denominator is a floor | a non-terminal refresh failure is rethrown and reports nothing |
| Every step is gated on the screen marker **and** the visitor cookie | losing either counts zero in silence; the cookie is minted only by `GET /login` |

Six review rounds; every one found a false statement, and each fix was verified against the code rather than against the previous sentence. The last two rounds were subtractive — the section is shorter than its first draft while carrying more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)