### PR TITLE
Compare auth error codes the same way on both clients

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -1052,7 +1052,7 @@ private fun analyticsCloudSignInFailureReason(error: CloudRemoteException): Anal
         return AnalyticsSignInFailureReason.RATE_LIMITED
     }
 
-    return when (error.errorCode?.trim()?.uppercase()) {
+    return when (error.errorCode) {
         "OTP_CODE_INVALID", "INVALID_EMAIL" -> AnalyticsSignInFailureReason.INVALID_CODE
         "OTP_SESSION_EXPIRED" -> AnalyticsSignInFailureReason.EXPIRED_CODE
         "OTP_CHALLENGE_CONSUMED" -> AnalyticsSignInFailureReason.CODE_ALREADY_USED


### PR DESCRIPTION
The Android analytics mapping normalised the wire value before matching (`?.trim()?.uppercase()`) while iOS matched it raw, so a drift in case or whitespace would have made one client fall through to `server_error` while the other still classified — a one-sided divergence in a series that exists to be compared across platforms.

**Android is now raw too, and nothing changes today.** The normalisation was the identity function on everything `apps/auth` can send: every code is a literal member of the closed `AuthPublicErrorCode` union written verbatim into the body, and no path interpolates a Cognito message or any computed value into that field.

**Why strict rather than lenient.** This series has three producers and only two of them read the wire code — the auth origin maps its own internal union straight to the reason. So a rename collapses iOS and Android to `server_error` while web keeps classifying correctly: a split *inside one series*, which is a built-in control arm. Normalising on both would have absorbed the drift silently, and it could never have absorbed a rename, which is the only drift a closed union permits.

**One scope claim corrected by review, and worth stating precisely.** Within `CloudSignInViewModel.kt` this was the file's only normaliser, and iOS is uniformly raw across all five of its auth-code comparisons. It was **not** the last normaliser in the Android client: the transport gate `isExpectedCloudHttpFailure` still compares these same values normalised. That is where leniency actively hides drift rather than merely masking it — a drifted code stays in the expected set and emits a breadcrumb instead of the warning that would surface it. That gate also covers backend codes, so straightening it is a wider change than this one and is queued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)