### PR TITLE
Select a bottom tab on a route boundary, not a bare prefix

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
@@ -132,10 +132,10 @@ fun currentTopLevelDestination(navController: NavHostController): TopLevelDestin
 
     return when {
         route == null -> ReviewDestination
-        route.startsWith(CardsDestination.route) -> CardsDestination
-        route.startsWith(AiDestination.route) -> AiDestination
-        route.startsWith(ProgressDestination.route) -> ProgressDestination
-        route.startsWith(SettingsDestination.route) -> SettingsDestination
+        route.isWithinTopLevelDestination(destination = CardsDestination) -> CardsDestination
+        route.isWithinTopLevelDestination(destination = AiDestination) -> AiDestination
+        route.isWithinTopLevelDestination(destination = ProgressDestination) -> ProgressDestination
+        route.isWithinTopLevelDestination(destination = SettingsDestination) -> SettingsDestination
         else -> ReviewDestination
     }
 }
@@ -155,4 +155,19 @@ fun currentVisibleAppScreen(navController: NavHostController): VisibleAppScreen 
         route == SettingsWorkspaceDeleteCurrentDestination.route -> VisibleAppScreen.SETTINGS_WORKSPACE_OVERVIEW
         else -> VisibleAppScreen.OTHER
     }
+}
+
+/**
+ * A tab owns the route when the route is the tab's own route or continues past it at a separator of
+ * the app's route grammar: `/` opens a nested path segment or a path argument
+ * (`settings/access/detail/{capability}`), `?` opens the optional query arguments
+ * (`settings/account/sign-in?origin={origin}`). No tab route declares an argument today, so only
+ * `/` occurs here; `?` keeps the check correct if one ever gains one.
+ */
+private fun String.isWithinTopLevelDestination(destination: TopLevelDestination): Boolean {
+    if (!startsWith(prefix = destination.route)) {
+        return false
+    }
+    val boundary = getOrNull(index = destination.route.length) ?: return true
+    return boundary == '/' || boundary == '?'
 }


### PR DESCRIPTION
`currentTopLevelDestination` decided the selected tab with `route.startsWith(tabRoute)` and no boundary, so a future route named `ai-something` would claim the `ai` tab. Correctness rested on branch order rather than on the match, and the failure would have been silent — a wrong tab highlight and a wrong foreground-sync polling key.

A route now selects a tab only on an exact match or up to a route boundary, derived from the tab's own route constant rather than declared anywhere new.

**The boundary set is `/` and `?`**, which is what this app's route grammar produces: path arguments open with `/`, the single query argument opens with `?`. An `&` can only follow a query pair, so it never sits directly after a tab route, and the module has no deep links. Accepting `?` matters: a first version of this change took `/` alone, which would have made a tab route carrying a query argument stop matching its own screen — a case the unbounded prefix had survived, so the patch briefly owned a narrow regression.

**Behaviour is unchanged for every route the app can produce.** Verified by enumerating routes from the destination objects and every `composable`/`navigation` registration, then running all of them through three predicates — the original, the `/`-only interim, and this one. A reviewer derived the inventory independently and reached the same result, and additionally established from the pinned navigation library's source that a nested graph's own route can never appear as the current destination.

Queued separately: two helpers in `FlashcardsApp.kt` carry the same unbounded-prefix shape, and their fix genuinely needs both boundary characters, because the sign-in email step's route is the one that uses `?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)