### PR TITLE
Commit the guest identity link with its revoke

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
@@ -876,8 +876,8 @@ class CloudGuestSessionCoordinatorTest {
             assertEquals(500, error.statusCode)
         }
 
-        // A 5xx can leave the link written and the session live, so the retry is mandatory and the
-        // token has to survive for it.
+        // A 5xx leaves this guest's tail unclaimed, because a success is what says the link landed,
+        // so the retry is mandatory and the token has to survive for it.
         val keptSession = environment.guestAiSessionStore.loadAnySession(
             configuration = makeOfficialCloudServiceConfiguration()
         )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -108,9 +108,9 @@ class CloudGuestSessionCoordinator(
      *
      * Every failure except `GUEST_IDENTITY_LINK_OTHER_ACCOUNT`,
      * `GUEST_IDENTITY_LINK_UPGRADE_REQUIRED` and `410 ACCOUNT_DELETED` keeps the guest token and
-     * rethrows, because a guest session left live can later be bound to a different account:
-     * dropping the token loses that guest's whole analytics tail, and skipping the retry can
-     * attribute it to somebody else. The next sign-in or app start retries.
+     * rethrows, because a success here is what says the link landed, and the upgrade flow above —
+     * another producer of the same link — is not this guest's path: dropping the token loses that
+     * tail permanently, and giving up leaves it unclaimed. The next sign-in or app start retries.
      *
      * The process-wide analytics opt-out lives in `:app` and is enforced by the only caller,
      * `AppGraph.requestAnalyticsGuestIdentityLink`, which never reaches this function while it is

--- a/apps/auth/src/server/analytics/client.ts
+++ b/apps/auth/src/server/analytics/client.ts
@@ -304,20 +304,18 @@ export type AuthAnalyticsIdentityLinkOutcome = "linked" | "account_required" | "
  * this producer can honour only some of that. `GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED` it can:
  * `ensureAccountIdentityRow` below is the documented remedy and the caller runs it once. The rest it
  * cannot, and the reason is the same for all of them — a Lambda invocation has nothing to retry
- * into. `429 ANALYTICS_WRITER_BUSY` is retryable after its served `Retry-After`, which is always one
- * second and is several times the whole report budget. A `5xx` is a *required* retry, because the
- * link commits on the analytics pool while the revoke commits with the request transaction, so a
- * failure between them can leave a live guest session with a link already written. Both are one
- * logged failure here. The other two `409`s ask for nothing: `GUEST_IDENTITY_LINK_UPGRADE_REQUIRED`
+ * into. A `5xx` is a retry the route still asks for, because a success is what says the link landed,
+ * and for a `web` guest no upgrade flow will ever write it instead; any delay served is several times
+ * the whole report budget. The other two `409`s ask for nothing: `GUEST_IDENTITY_LINK_UPGRADE_REQUIRED`
  * is terminal and unreachable for a `web` guest, which can own nothing the upgrade transfers, and
  * `GUEST_IDENTITY_LINK_OTHER_ACCOUNT` is terminal because the token is not this account's to link.
  *
- * What makes that safe rather than merely lossy is that the caller drops the visitor cookie on every
- * outcome. The danger the retry rule exists to prevent is a *different* account later binding the
- * live guest session; short of the one-request-wide race `reportSignInSucceeded` records in
- * `signInFunnel.ts`, no one can, because the only copy of that token goes with the cookie. What is
+ * What keeps that merely lossy is that the caller drops the visitor cookie on every outcome. A link
+ * that failed before its commit stored nothing, and the session it leaves live is one a *different*
+ * account could still be bound to; short of the one-request-wide race `reportSignInSucceeded` records
+ * in `signInFunnel.ts`, no one can, because the only copy of that token goes with the cookie. What is
  * left is a guest session nobody should hold, which the 90-day web guest reaper collects unless the
- * link already landed: a `server_derived` link is what tells that reaper the guest signed in.
+ * link already landed: a `server_derived` link tells that reaper the guest signed in.
  */
 export async function linkVisitorGuestToAccount(
   call: AuthAnalyticsCall,
@@ -344,7 +342,7 @@ export async function linkVisitorGuestToAccount(
       : "failed";
   } catch (error) {
     // A timeout here is not the same as a lost link. The request has usually already reached the
-    // backend, which commits the link on its own pool regardless of whether this caller is still
+    // backend, whose transaction commits or rolls back regardless of whether this caller is still
     // waiting; abandoning it stops the waiting, not the write.
     logAnalyticsFailure(call, "analytics_identity_link_error", null, toErrorMessage(error));
     return "failed";

--- a/apps/auth/src/server/analytics/signInFunnel.ts
+++ b/apps/auth/src/server/analytics/signInFunnel.ts
@@ -484,9 +484,8 @@ export async function reportSignInFailed(
  * A report still in flight from a login page open elsewhere writes the cookie back after the clear,
  * and what survives decides the cost. A revoked token blocks the re-mint —
  * `deliverAuthAnalyticsEvent` mints only for a null one — so every later report is one logged
- * ingest failure and no row. A token no link bound is the kept-token misattribution above. Worst is
- * one a `5xx` left live and linked: its first link claims the next account's own sign-in, silently.
- * Only a tombstone cookie closes even that, and a `5xx` under this race does not earn one.
+ * ingest failure and no row. A token no link bound is the kept-token misattribution above, and only
+ * a tombstone cookie would close it, which a `5xx` under this race does not earn.
  */
 export async function reportSignInSucceeded(c: Context<AuthAppEnv>, idToken: string): Promise<void> {
   try {

--- a/apps/backend/src/guestAuth/identityLink/index.ts
+++ b/apps/backend/src/guestAuth/identityLink/index.ts
@@ -6,7 +6,7 @@ import {
   lockCognitoIdentityLifecycleInExecutor,
 } from "../../auth/userIdentities";
 import type { DatabaseExecutor } from "../../database";
-import { insertProductAnalyticsIdentityLink } from "../../productAnalytics/writer";
+import { insertProductAnalyticsIdentityLinkInExecutor } from "../../productAnalytics/writer";
 import { HttpError } from "../../shared/errors";
 import {
   guestOwnsUpgradeTransferableDataInExecutor,
@@ -80,24 +80,18 @@ function createGuestIdentityLinkOtherAccountError(): HttpError {
  * the one this repository requires ahead of user-settings, guest-session and workspace lifecycle
  * locks, which is why it is taken before the guest session is loaded.
  *
- * The link is written before the revoke, for the reason spelled out above
- * `recordGuestUpgradeCompletedAnalytics`: losing the link costs that guest's entire resolved
- * history, losing the revoke costs nothing. Unlike the upgrade producer this one is not best effort
- * and does not run after the transaction: a failed link must abort the revoke so the retry can write
- * it again. The analytics writer commits on its own pool, so a link that lands and is then followed
- * by a rolled-back revoke stays committed. That costs nothing as long as the client retries: the
- * pair the link names is this guest and this account either way, and the retry conflicts on that
- * pair, stores nothing new and completes the revoke. That is exactly the property the upgrade path
- * cannot rely on, because a rolled-back upgrade could still end on a different account.
+ * The link and the revoke are both written on this transaction and therefore reach the same commit:
+ * neither can land without the other. That is what makes the pair safe rather than the order of the
+ * two statements, and it is not a refinement. A link without its revoke leaves a guest session live
+ * and unbound, which a later `/guest-auth/upgrade/prepare` can bind to a *different* account, and
+ * `first_guest_upgrade_link` in 0115 is first-link-wins, so the orphan would then attribute that
+ * account's whole pre-account tail to this one permanently, with no repair path. A client retry
+ * closed that window only for the callers that have one; `apps/auth`'s sign-in producer drops the
+ * only copy of the guest token on every outcome and has nothing to retry with.
  *
- * Without that retry the orphan link is not harmless, which is why `docs/auth-service.md` makes
- * retrying a 5xx from this route, with the guest token kept, a client obligation rather than an
- * option. The revoke is the write most likely to be the one that misses a deadline, because the
- * link ahead of it can consume up to ~4s of the request budget on the analytics pool: 2s of
- * acquisition plus a 2s statement timeout. A guest session left live and unbound can still be bound
- * to a *different* account by a later `/guest-auth/upgrade/prepare`, and `first_guest_upgrade_link`
- * in 0115 is first-link-wins, so the orphan link would then attribute that account's whole
- * pre-account tail to this one permanently, with no repair path.
+ * `docs/auth-service.md` still asks a client to retry a 5xx from this route with the guest token
+ * kept, because the guest's tail is still unclaimed — not because a failure left something behind to
+ * repair. A commit whose outcome is unknown is the one shape a repeat may find already done.
  */
 export async function linkGuestAnalyticsIdentityInExecutor(
   executor: DatabaseExecutor,
@@ -171,19 +165,16 @@ export async function linkGuestAnalyticsIdentityInExecutor(
   // that the guest's events carried as subject_user_id, which is the shape
   // analytics.product_events_resolved reads in its server namespace.
   //
-  // This write runs on the analytics pool while this transaction still holds the Cognito identity
-  // lifecycle lock, the guest's org.user_settings row lock and that guest session row's own FOR
-  // UPDATE lock. No workspace lifecycle lock is held on this path.
-  // recordGuestUpgradeCompletedAnalytics documents the opposite choice for the upgrade path,
-  // and the difference is deliberate rather than an oversight. That producer runs after a
-  // committed upgrade and is best effort, so it can afford to sit outside the transaction; here
-  // the link is the entire point of the request, and a link that fails must abort the revoke so
-  // the client's retry can write it again, which is only possible from inside. The hold is bounded
-  // by the writer's own guards: assertAnalyticsPoolCapacity refuses a saturated pool instead of
-  // queueing, acquisition times out after 2s, and the write runs under a 2s statement timeout. The
-  // locks are scoped to one guest and one signing-in account, and are contended only by that same
-  // person's own guest lifecycle, upgrade or account-deletion calls, none of which is a hot path.
-  await insertProductAnalyticsIdentityLink({
+  // Written on this transaction, beside the revoke below, rather than on the analytics writer's own
+  // pool. Both pools resolve the same database URL and so the same role, and 0114 and 0115 grant
+  // that role the INSERT, the source-scoped UPDATE and the row-level policies this statement needs,
+  // so nothing about the write itself changes here.
+  // recordGuestUpgradeCompletedAnalytics keeps the opposite arrangement, deliberately and for the
+  // opposite reason: it runs after an upgrade that has already committed and is best effort, so a
+  // link written inside that transaction could outlive an upgrade that then rolled back. Here the
+  // link is the entire point of the request and the revoke only retires the credential it replaces,
+  // so the two belong in one commit.
+  await insertProductAnalyticsIdentityLinkInExecutor(executor, {
     linkId: randomUUID(),
     anonymousId: guestSession.userId,
     userId: accountMapping.userId,

--- a/apps/backend/src/guestAuth/index.ts
+++ b/apps/backend/src/guestAuth/index.ts
@@ -1,3 +1,4 @@
+import { runDatabaseOperationsWithDeadline } from "../database";
 import { unsafeTransaction } from "../database/unsafe";
 // Report through `observability/runtime`, never through `observability/sentry`, for the reason the
 // product analytics producers spell out: `initializeBackendSentry` installs `captureBackendWarning`
@@ -70,12 +71,35 @@ export async function createGuestSession(
   );
 }
 
+/**
+ * Whole-transaction budget for the identity link, and the only bound this operation has.
+ *
+ * `runDatabaseOperationsWithDeadline` is what `database/deadline.ts` needs to bound this at all: it
+ * derives a `statement_timeout` and `lock_timeout` from what is left of the budget before every
+ * statement, and times the pool checkout from the same remainder rather than from the pool's own
+ * equal `connectionTimeoutMillis`. Without it `unsafeTransaction` opens a plain `BEGIN` under no
+ * timeout at all and the only stop is the 29s API Gateway integration timeout.
+ *
+ * The transaction is a short run of indexed single-row statements, so on a healthy database the
+ * budget is spent waiting rather than running: it takes the Cognito identity lifecycle lock that
+ * account deletion holds across its whole sweep, and locks the guest's `org.user_settings` and
+ * `auth.guest_sessions` rows `FOR UPDATE`. A stop before the commit leaves nothing behind; one at
+ * the commit answers `500 DATABASE_COMMIT_OUTCOME_UNKNOWN` instead. Neither is one attempt of several
+ * for everyone: `apps/auth`'s sign-in producer drops the guest token with the visitor cookie on every
+ * outcome, so a stop there loses that visitor's tail outright. Sized to stay inside the 10s the web
+ * client allows one attempt, so that client sees a status code rather than its own abort.
+ */
+const guestIdentityLinkTransactionBudgetMs = 5_000;
+
 export async function linkGuestAnalyticsIdentity(
   guestToken: string,
   cognitoSubject: string,
 ): Promise<void> {
-  return unsafeTransaction(
-    async (executor) => linkGuestAnalyticsIdentityInExecutor(executor, guestToken, cognitoSubject),
+  return runDatabaseOperationsWithDeadline(
+    Date.now() + guestIdentityLinkTransactionBudgetMs,
+    () => unsafeTransaction(
+      async (executor) => linkGuestAnalyticsIdentityInExecutor(executor, guestToken, cognitoSubject),
+    ),
   );
 }
 

--- a/apps/backend/src/productAnalytics/writer.ts
+++ b/apps/backend/src/productAnalytics/writer.ts
@@ -1,4 +1,5 @@
 import pg from "pg";
+import type { DatabaseExecutor } from "../database";
 import { getDatabaseUrl } from "../database/config";
 import {
   getDatabaseErrorFields,
@@ -26,8 +27,8 @@ const analyticsPoolConnectionTimeoutMs = 2_000;
 // matches nothing isTransientDatabaseError recognises and would otherwise reach a caller as an
 // unclassified failure. The message is the only thing that names it, and it is pg's wording rather
 // than a contract: a pg upgrade that rewords it makes this match fail silently, so the acquisition
-// timeout would take the 503 branch below and the 429 docs/auth-service.md documents for it would
-// never be raised. Re-check the string against pg-pool on every pg upgrade.
+// timeout would take the 503 branch below instead of the 429 the analytics ingest route still
+// answers a saturated pool with. Re-check the string against pg-pool on every pg upgrade.
 const analyticsPoolAcquisitionTimeoutMessage = "timeout exceeded when trying to connect";
 
 type ProductAnalyticsParameterValue = string | number | Date | null;
@@ -261,13 +262,18 @@ async function insertEventRowsInTransaction(
   return result.rowCount ?? 0;
 }
 
+// Beside the statement it feeds, so a column added to one cannot silently miss the other.
+function buildIdentityLinkParameters(link: ProductAnalyticsIdentityLink): Array<string> {
+  return [link.linkId, link.anonymousId, link.userId, link.source];
+}
+
 async function insertIdentityLinkInTransaction(
   client: pg.PoolClient,
   link: ProductAnalyticsIdentityLink,
 ): Promise<number> {
   const result = await client.query(
     insertProductAnalyticsIdentityLinkSql,
-    [link.linkId, link.anonymousId, link.userId, link.source],
+    buildIdentityLinkParameters(link),
   );
   return result.rowCount ?? 0;
 }
@@ -390,4 +396,26 @@ export async function insertProductAnalyticsIdentityLink(
   link: ProductAnalyticsIdentityLink,
 ): Promise<number> {
   return runAnalyticsWrite((client) => insertIdentityLinkInTransaction(client, link));
+}
+
+/**
+ * The same statement on the caller's own transaction, for a producer whose link has to commit with
+ * the rest of its work instead of separately on the analytics pool.
+ *
+ * The analytics pool exists so an analytics spike cannot starve product requests of connections,
+ * which is a rule about analytics traffic rather than about this table: a caller that already holds
+ * a product connection takes no second one by writing here, and takes one fewer than it would by
+ * going through the pool. There is likewise no acquisition to time out and no second commit to
+ * lose. Only the pool's `SET LOCAL statement_timeout` has no counterpart here, and it is a
+ * precondition rather than an omission: the caller must open its transaction under a deadline.
+ */
+export async function insertProductAnalyticsIdentityLinkInExecutor(
+  executor: DatabaseExecutor,
+  link: ProductAnalyticsIdentityLink,
+): Promise<number> {
+  const result = await executor.query(
+    insertProductAnalyticsIdentityLinkSql,
+    buildIdentityLinkParameters(link),
+  );
+  return result.rowCount ?? 0;
 }

--- a/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+AnalyticsGuestCredential.swift
+++ b/apps/ios/Flashcards/Flashcards/Analytics/FlashcardsStore+AnalyticsGuestCredential.swift
@@ -161,9 +161,9 @@ extension FlashcardsStore {
      * signed-in account, or the server named it as a guest that is not this install's to claim.
      *
      * `false` means the credential must be kept. Dropping it there loses that guest's whole analytics
-     * tail permanently, and a session left live after a partial link can later be bound to a different
-     * account. A guest the server says still owns data is kept for the same reason: the upgrade flow
-     * is what transfers that data, and the local token is the only handle onto it.
+     * tail permanently, and a later attempt of this same claim is what writes the link. A guest the
+     * server says still owns data is kept for the same reason: the upgrade flow is what transfers
+     * that data — writing the same link on its way — and the local token is the only handle onto it.
      */
     private func claimGuestAnalyticsIdentity(
         guestSession: StoredGuestCloudSession,
@@ -311,11 +311,10 @@ private enum GuestAnalyticsIdentityLinkVerdict {
  * Everything else keeps the guest token, which is the posture the route's contract asks for.
  * `409 GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED` says the account's identity row does not exist yet, and
  * repeating the identical request cannot create it, so it stops this loop instead of spending its
- * attempts on failures that can only be identical. `429 ANALYTICS_WRITER_BUSY` and every `5xx` are
- * retryable here, and a `5xx` in particular can leave the link written while the guest session is
- * still live, which is exactly the state the retry closes. Dropping the token instead loses that
- * guest's whole analytics tail, permanently and with no repair path, so an unrecognised failure is
- * treated as retryable too.
+ * attempts on failures that can only be identical. Every `5xx` is retryable here: it leaves this
+ * guest's tail unclaimed until a later attempt of this claim, or the upgrade flow, writes the link.
+ * Dropping the token instead loses that guest's whole analytics tail, permanently and with no
+ * repair path, so an unrecognised failure is treated as retryable too.
  */
 private func guestAnalyticsIdentityLinkVerdict(error: Error) -> GuestAnalyticsIdentityLinkVerdict {
     guard let guestCloudAuthError = error as? GuestCloudAuthError,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
@@ -352,8 +352,8 @@ final class GuestCloudAuthService {
             let details = decodeCloudApiErrorDetails(
                 data: data,
                 requestId: requestId,
-                // Carried through so a caller that retries can respect the pace the server asked for,
-                // which the identity link route's `429` contract requires.
+                // Carried through so a caller that retries can respect the pace the server asked for:
+                // a transient-database `503` serves `Retry-After: 1`, an auth-verification one 10.
                 retryAfterDelayNanoseconds: cloudRetryAfterDelayNanoseconds(
                     value: httpResponse.value(forHTTPHeaderField: "Retry-After")
                 )

--- a/apps/web/src/api/endpoints/guestAuth.ts
+++ b/apps/web/src/api/endpoints/guestAuth.ts
@@ -58,9 +58,8 @@ export async function createWebGuestSession(idempotencyKey: string): Promise<Web
  * session and carries the guest token in its body. Auth recovery is skipped because no analytics
  * work may redirect a person to sign in; the caller runs it right after `GET /me`, which is both the
  * CSRF load this session request needs and the request-context call the route requires to have
- * happened first. Transport retries are safe here, unlike on creation: a repeat conflicts on the
- * same guest and account pair, stores nothing new, and completes a revoke that an earlier attempt
- * may have left behind.
+ * happened first. Transport retries are safe here, unlike on creation: a repeat either redoes an
+ * attempt that committed nothing, or meets a revoked token, which is a successful no-op.
  */
 export async function linkWebGuestIdentity(guestToken: string): Promise<void> {
   await requestJson("/guest-auth/identity/link", {

--- a/apps/web/src/appData/session/guest/webGuestIdentityLink.ts
+++ b/apps/web/src/appData/session/guest/webGuestIdentityLink.ts
@@ -90,13 +90,12 @@ function readGuestIdentityLinkVerdict(error: unknown): GuestIdentityLinkVerdict 
     return "unconvergeable";
   }
 
-  // Everything else is kept and repeated. A `429 ANALYTICS_WRITER_BUSY` wrote nothing. A `5xx` may
-  // have committed the link on the analytics pool and then lost the revoke with the request
-  // transaction, leaving a guest session live that a *different* account can later bind — which
-  // would attribute that account's whole pre-account tail to this one, permanently. A transport
-  // failure, or a browser session that lapsed between `/me` and here, says nothing about the guest
-  // token either. Repeating is safe in all of them: the route conflicts on the same guest and
-  // account pair, stores nothing new, and completes the revoke.
+  // Everything else is kept and repeated. A web guest reaches no upgrade flow, so an attempt here is
+  // what claims its tail: a `5xx` leaves that tail unclaimed, and a dropped token loses it
+  // permanently. A transport failure, or a browser session that lapsed between `/me` and here, says
+  // nothing about the guest token either. Repeating is safe in all of them: the route commits the
+  // link and the revoke together, so a repeat either redoes an attempt that stored nothing, or meets
+  // a revoked token and is a no-op.
   return "retryable";
 }
 
@@ -104,7 +103,7 @@ function readGuestIdentityLinkStatusCode(error: unknown): number | null {
   return error instanceof ApiError ? error.statusCode : null;
 }
 
-/** Only the analytics writer's own `429` carries `Retry-After`; everything else backs off locally. */
+/** A served `Retry-After` is honoured under the cap; a refusal that serves none backs off locally. */
 function createLinkRetryDelayMs(attemptCount: number, error: unknown): number {
   const retryAfterMs = error instanceof ApiError ? error.retryAfterMs : null;
   const requestedDelayMs = retryAfterMs ?? linkRetryBaseDelayMs * 2 ** (attemptCount - 1);
@@ -170,8 +169,7 @@ async function runGuestIdentityLink(
 
       if (verdict === "unconvergeable" || attemptCount === maximumLinkAttemptCount) {
         // The envelope is deliberately left in place. Neither refusal was about this guest token,
-        // and dropping the token on one of those loses this visitor's whole analytics tail
-        // permanently — or worse, strands a live guest session with a link already written for it.
+        // and dropping it on one of those loses this visitor's whole analytics tail permanently.
         // Every app start reads the envelope back and retries after its own `GET /me`. What keeps a
         // kept envelope from reaching a different account is the account stamp written before the
         // first attempt: within this load the two guards above hold, and across loads — where the

--- a/apps/web/src/appData/session/guest/webGuestSession.ts
+++ b/apps/web/src/appData/session/guest/webGuestSession.ts
@@ -247,9 +247,9 @@ export function readWebGuestSessionLinkAccountId(): string | null {
 
 /**
  * Records the account an envelope is being offered to, before the offer is made rather than after it
- * is answered: a `5xx` may commit the link and lose the revoke, and a tab closed mid-retry runs no
- * completion path at all, so an envelope that is still in storage afterwards must already carry the
- * account it was spent on.
+ * is answered: a tab closed mid-retry runs no completion path at all, and a response lost after the
+ * commit landed leaves this browser unable to tell a claimed guest from an unclaimed one — so an
+ * envelope still in storage afterwards must already carry the account it was spent on.
  *
  * Guarded on the stored envelope still being the one that is being offered, so that this can only
  * ever describe what is actually in storage: a stamp written over a dropped envelope would outlive

--- a/docs/auth-service.md
+++ b/docs/auth-service.md
@@ -51,25 +51,21 @@ Email + OTP authentication via AWS Cognito (passwordless).
       call again. Never drop the guest token on this code: that guest's whole analytics tail goes with
       it, permanently.
     - `409 GUEST_IDENTITY_LINK_UPGRADE_REQUIRED` means the guest owns data the upgrade flow transfers
-      and must convert through `POST /v1/guest-auth/upgrade/complete` instead. Terminal for this
-      route; retrying it unchanged never succeeds.
+      and must convert through `POST /v1/guest-auth/upgrade/complete`, which writes the same
+      `server_derived` link for the same pair. Terminal here; retrying it unchanged never succeeds.
     - `409 GUEST_IDENTITY_LINK_OTHER_ACCOUNT` means the guest token names a user that is already a
       different real account. Terminal: the client is holding a credential that is not its own and
       should discard it rather than retry.
-    - `429 ANALYTICS_WRITER_BUSY` means the analytics connection pool was saturated: its cap refused
-      the write before a connection was requested, or acquiring a connection timed out. It is raised
-      before the link statement runs, so nothing was written — no identity link row and no revoke —
-      and the guest session stays live with its token still usable. Retryable with nothing to
-      repair: keep the guest token, wait the delay, and call again. The body is the ordinary
-      `error`/`requestId`/`code` envelope; the delay travels only in the `Retry-After` response
-      header, always `1` second on this route.
-    - A `5xx` must be retried, with the guest token kept. The identity link commits on the analytics
-      pool and the revoke commits with the request transaction, so a failure between them can leave
-      the link written and the guest session still live. The retry is safe — it conflicts on the
-      same guest and account pair, stores nothing new, and completes the revoke — and it is not
-      optional: a guest session left live can later be bound to a *different* account, and the
-      orphan link would then attribute that account's whole pre-account analytics tail to this one
-      permanently.
+    - `429 ANALYTICS_WRITER_BUSY` is not raised here. It is the analytics pool's refusal, which the
+      ingest route above still answers a saturated pool with; this route uses its own transaction.
+    - A `5xx` should be retried, with the guest token kept. A connection the database drops or refuses,
+      a deadlock, or a saturated pool, which authentication meets before the transaction's budget
+      exists, is answered `503 SERVICE_UNAVAILABLE` with `Retry-After: 1`, and a cooling-down Cognito
+      JWKS refresh `503 AUTH_VERIFICATION_TEMPORARILY_UNAVAILABLE` with `Retry-After: 10`. A failure at
+      commit is `500 DATABASE_COMMIT_OUTCOME_UNKNOWN`, whose write may still have landed; a lock
+      timeout, a statement timeout and the 5s transaction budget running out are `500 INTERNAL_ERROR`.
+      Neither `500` serves a delay. Retrying is safe: the link and the revoke share one commit, so a
+      repeat either redoes a request that stored nothing or meets the already-revoked no-op above.
 - `POST /v1/guest-auth/session` accepts an optional `idempotencyKey`. A retry carrying a key that
   still names a live session rotates that session's secret and returns the same guest user and
   workspace, so a lost response cannot leave one device with two guest identities. Client contract:


### PR DESCRIPTION
`POST /v1/guest-auth/identity/link` wrote the analytics identity link on the analytics pool, which commits on its own, then revoked the guest session on the request transaction, which commits later. A failure between them left a guest session **live and already linked**.

That state is not inert. If a concurrent report restores the visitor cookie after a sign-in cleared it — a race this repository documents — the surviving token is held again, and because the first link wins the resolved view's ordering and outranks a row's own `user_id`, **the next person's signed-out rows on that browser resolve to the first person's account, permanently, with no repair path.**

The route's own docblock said the split "costs nothing as long as the client retries". Web, iOS and Android do. The auth origin's producer cannot: it runs inside a sign-in under a 150 ms budget and drops the only copy of the guest token on every outcome, so on that surface link-without-revoke was a standing state.

**The fix.** The link now runs on the request executor, so both writes commit or neither does. Same role, existing grants, no migration.

**Two things improve rather than trade off:**

| | Before | After |
|---|---|---|
| Connections per request | 2, from two pools | 1 |
| Locks held across an analytics-pool acquisition | Cognito identity lock, guest settings row, session row — up to ~4s | none |
| Transaction ceiling | no statement or lock timeout; the 29s gateway integration timeout | 5s, and the advisory-lock wait is bounded for the first time |

**Alternatives rejected, with reasons.** Honouring the documented retry cannot fit the sign-in latency budget, and the producer has no token to retry with. Reordering the two calls is *mechanically impossible*: the revoke is durable only at the outer commit, always after the analytics pool's own — swapping the lines changes nothing and widens a lock hold.

**Seven surfaces** explained client retry obligations by the split commit. Each now gives the reason that survives the change: only a success says the link landed, and the guest-upgrade flow is the other producer of the same link. **The retry is still required** — a request that never reached the database still loses the link entirely, and dropping the token loses that guest's tail permanently.

Six review rounds. The code was upheld in the first and unchanged since; the rest was prose, and the last round's sweep for remaining split-commit explanations came back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)