### PR TITLE
Extract Android analytics identity linking

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/AnalyticsGuestIdentityLinkCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/AnalyticsGuestIdentityLinkCoordinatorTest.kt
@@ -1,0 +1,291 @@
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.guest
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
+import com.flashcardsopensourceapp.data.local.model.cloud.makeOfficialCloudServiceConfiguration
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.FakeCloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createCloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createCloudWorkspaceSummary
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createStoredGuestAiSession
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AnalyticsGuestIdentityLinkCoordinatorTest {
+    private lateinit var environment: CloudIdentityTestEnvironment
+
+    @Before
+    fun setUp() = runBlocking {
+        environment = CloudIdentityTestEnvironment.create()
+    }
+
+    @After
+    fun tearDown() {
+        environment.close()
+    }
+
+    @Test
+    fun analyticsGuestIdentityLinkSendsStoredGuestTokenAndClearsStoredSessions() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
+        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        assertEquals(listOf("analytics-guest-token"), remoteGateway.linkGuestIdentityGuestTokens)
+        // The account's identity row is written by the first request that loads a request context,
+        // so exactly one has to precede the link or it earns `409 ACCOUNT_REQUIRED`.
+        assertEquals(1, remoteGateway.fetchCloudAccountCalls)
+        assertNull(
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )
+        )
+    }
+
+    @Test
+    fun analyticsGuestIdentityLinkSkipsGuestSessionThatOwnsCloudData() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = null,
+            session = createStoredGuestAiSession(
+                workspaceId = "guest-workspace",
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "cloud-guest-token",
+                userId = "cloud-guest-user"
+            )
+        )
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        // That guest converts through `/guest-auth/upgrade/complete`, which writes the same identity
+        // link; this route would revoke the session that flow still needs.
+        assertTrue(remoteGateway.linkGuestIdentityGuestTokens.isEmpty())
+        assertEquals(
+            "cloud-guest-token",
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )?.guestToken
+        )
+    }
+
+    @Test
+    fun analyticsGuestIdentityLinkKeepsGuestTokenAndStopsRetryingWhenUpgradeIsRequired() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        remoteGateway.setLinkGuestIdentityError(
+            error = createCloudRemoteError(
+                statusCode = 409,
+                errorCode = "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED",
+                path = "/guest-auth/identity/link"
+            )
+        )
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
+        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        // The token is kept: it names the owner of data only the upgrade flow can transfer.
+        val retiredSession = environment.guestAiSessionStore.loadAnySession(
+            configuration = makeOfficialCloudServiceConfiguration()
+        )
+        assertEquals("analytics-guest-token", retiredSession?.guestToken)
+        assertEquals(false, retiredSession?.isAnalyticsOnly)
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        // Correcting the marker is what stops a link that can never succeed from being retried on
+        // every app start and every sign-in.
+        assertEquals(listOf("analytics-guest-token"), remoteGateway.linkGuestIdentityGuestTokens)
+    }
+
+    @Test
+    fun analyticsGuestIdentityLinkDropsGuestTokenOwnedByAnotherAccount() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        remoteGateway.setLinkGuestIdentityError(
+            error = createCloudRemoteError(
+                statusCode = 409,
+                errorCode = "GUEST_IDENTITY_LINK_OTHER_ACCOUNT",
+                path = "/guest-auth/identity/link"
+            )
+        )
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
+        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        assertEquals(listOf("analytics-guest-token"), remoteGateway.linkGuestIdentityGuestTokens)
+        // Terminal: the credential is not this install's, so it must not stay as an analytics one.
+        assertNull(
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )
+        )
+    }
+
+    @Test
+    fun analyticsGuestIdentityLinkKeepsGuestTokenWhenTheLinkFailsRetryably() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        remoteGateway.setLinkGuestIdentityError(
+            error = createCloudRemoteError(
+                statusCode = 500,
+                errorCode = null,
+                path = "/guest-auth/identity/link"
+            )
+        )
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
+        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
+
+        try {
+            coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+            throw AssertionError("Expected a retryable link failure to be rethrown.")
+        } catch (error: CloudRemoteException) {
+            assertEquals(500, error.statusCode)
+        }
+
+        // A 5xx leaves this guest's tail unclaimed, because a success is what says the link landed,
+        // so the retry is mandatory and the token has to survive for it.
+        val keptSession = environment.guestAiSessionStore.loadAnySession(
+            configuration = makeOfficialCloudServiceConfiguration()
+        )
+        assertEquals("analytics-guest-token", keptSession?.guestToken)
+        assertTrue(keptSession?.isAnalyticsOnly == true)
+    }
+
+    /**
+     * The credential must belong to the account this install is linked to. Linking on a mismatch
+     * would attribute the guest's whole pre-sign-in tail to the wrong account, and
+     * `analytics.identity_links` is first-link-wins with no repair path — while answering the
+     * mismatch the way `authenticatedSession()` does would destroy local data instead.
+     */
+    @Test
+    fun analyticsGuestIdentityLinkBailsWhenTheCredentialIsForAnotherAccount() = runBlocking {
+        val preservationState = seedCredentialRecoveryLocalData(environment = environment)
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-2",
+                email = "other@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = preservationState.workspaceId,
+                        name = "Personal",
+                        createdAtMillis = 100L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = preservationState.workspaceId)
+        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        assertTrue(remoteGateway.linkGuestIdentityGuestTokens.isEmpty())
+        assertCredentialRecoveryPreservedLocalData(
+            environment = environment,
+            preservationState = preservationState
+        )
+        assertEquals(
+            "analytics-guest-token",
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )?.guestToken
+        )
+    }
+
+    /**
+     * The background link runs unattended on every app start and after every sign-in. A deleted
+     * account must therefore never reach a destructive local reset from here: sync answers that
+     * condition by preserving local data, and nothing about analytics may pre-empt it.
+     */
+    @Test
+    fun analyticsGuestIdentityLinkPreservesLocalDataWhenTheAccountIsDeleted() = runBlocking {
+        val preservationState = seedCredentialRecoveryLocalData(environment = environment)
+        val remoteGateway = FakeCloudRemoteGateway.forFetchAccountError(
+            fetchAccountError = createCloudRemoteError(
+                statusCode = 410,
+                errorCode = "ACCOUNT_DELETED",
+                path = "/me"
+            )
+        )
+        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = preservationState.workspaceId)
+        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
+
+        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
+
+        assertTrue(remoteGateway.linkGuestIdentityGuestTokens.isEmpty())
+        assertCredentialRecoveryPreservedLocalData(
+            environment = environment,
+            preservationState = preservationState
+        )
+        assertEquals(
+            preservationState.installationId,
+            environment.cloudPreferencesStore.currentCloudSettings().installationId
+        )
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(
+            "analytics-guest-token",
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )?.guestToken
+        )
+    }
+
+    private fun storeAnalyticsOnlyGuestSession(guestToken: String) {
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = null,
+            session = createStoredGuestAiSession(
+                workspaceId = "analytics-guest-workspace",
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = guestToken,
+                userId = "analytics-guest-user",
+                isAnalyticsOnly = true
+            )
+        )
+    }
+
+    private fun createCloudRemoteError(
+        statusCode: Int,
+        errorCode: String?,
+        path: String
+    ): CloudRemoteException {
+        return CloudRemoteException(
+            message = "Cloud request failed with status $statusCode for $path",
+            statusCode = statusCode,
+            responseBody = JSONObject()
+                .put("code", errorCode ?: JSONObject.NULL)
+                .put("requestId", "request-1")
+                .toString(),
+            errorCode = errorCode,
+            requestId = "request-1",
+            syncConflict = null,
+            androidObservationAlreadyCaptured = false
+        )
+    }
+}

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.ai.remote.GuestCloudSessionCreator
 import com.flashcardsopensourceapp.data.local.cloud.PendingGuestUpgradeState
-import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
@@ -23,11 +22,9 @@ import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.creat
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createCloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createStoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createStoredGuestAiSession
-import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createSyncCardOutboxEntry
 import java.net.SocketTimeoutException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -81,7 +78,7 @@ class CloudGuestSessionCoordinatorTest {
 
     @Test
     fun linkedStateWithMissingCredentialsMarksRecoveryAndPreservesLocalData() = runBlocking {
-        val preservationState = seedCredentialRecoveryLocalData()
+        val preservationState = seedCredentialRecoveryLocalData(environment = environment)
         val coordinator = environment.createCloudGuestSessionCoordinator(
             remoteGateway = FakeCloudRemoteGateway.standard()
         )
@@ -107,7 +104,10 @@ class CloudGuestSessionCoordinatorTest {
         assertEquals("user@example.com", recoveryState.linkedEmail)
         assertEquals(CloudServiceConfigurationMode.OFFICIAL, recoveryState.configurationMode)
         assertEquals("https://api.flashcards-open-source-app.com/v1", recoveryState.apiBaseUrl)
-        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertCredentialRecoveryPreservedLocalData(
+            environment = environment,
+            preservationState = preservationState
+        )
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(preservationState.installationId, environment.cloudPreferencesStore.currentCloudSettings().installationId)
         assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
@@ -115,7 +115,7 @@ class CloudGuestSessionCoordinatorTest {
 
     @Test
     fun linkedStateWithInvalidActiveWorkspaceAndMissingCredentialsMarksRecovery() = runBlocking {
-        val preservationState = seedCredentialRecoveryLocalData()
+        val preservationState = seedCredentialRecoveryLocalData(environment = environment)
         val coordinator = environment.createCloudGuestSessionCoordinator(
             remoteGateway = FakeCloudRemoteGateway.standard()
         )
@@ -135,14 +135,17 @@ class CloudGuestSessionCoordinatorTest {
         assertEquals(CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING, recoveryState.reason)
         assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
         assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
-        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertCredentialRecoveryPreservedLocalData(
+            environment = environment,
+            preservationState = preservationState
+        )
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
     }
 
     @Test
     fun guestStateWithMissingSessionMarksRecoveryAndPreservesLocalData() = runBlocking {
-        val preservationState = seedCredentialRecoveryLocalData()
+        val preservationState = seedCredentialRecoveryLocalData(environment = environment)
         val coordinator = environment.createCloudGuestSessionCoordinator(
             remoteGateway = FakeCloudRemoteGateway.standard()
         )
@@ -166,7 +169,10 @@ class CloudGuestSessionCoordinatorTest {
         assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
         assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
         assertNull(recoveryState.linkedEmail)
-        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertCredentialRecoveryPreservedLocalData(
+            environment = environment,
+            preservationState = preservationState
+        )
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(preservationState.installationId, environment.cloudPreferencesStore.currentCloudSettings().installationId)
         assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
@@ -174,7 +180,7 @@ class CloudGuestSessionCoordinatorTest {
 
     @Test
     fun guestStateWithInvalidActiveWorkspaceAndMissingSessionMarksRecovery() = runBlocking {
-        val preservationState = seedCredentialRecoveryLocalData()
+        val preservationState = seedCredentialRecoveryLocalData(environment = environment)
         val coordinator = environment.createCloudGuestSessionCoordinator(
             remoteGateway = FakeCloudRemoteGateway.standard()
         )
@@ -194,7 +200,10 @@ class CloudGuestSessionCoordinatorTest {
         assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, recoveryState.reason)
         assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
         assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
-        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertCredentialRecoveryPreservedLocalData(
+            environment = environment,
+            preservationState = preservationState
+        )
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
     }
@@ -746,220 +755,6 @@ class CloudGuestSessionCoordinatorTest {
         )
     }
 
-    @Test
-    fun analyticsGuestIdentityLinkSendsStoredGuestTokenAndClearsStoredSessions() = runBlocking {
-        val localWorkspaceId = environment.requireLocalWorkspaceId()
-        val remoteGateway = FakeCloudRemoteGateway.standard()
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
-        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        assertEquals(listOf("analytics-guest-token"), remoteGateway.linkGuestIdentityGuestTokens)
-        // The account's identity row is written by the first request that loads a request context,
-        // so exactly one has to precede the link or it earns `409 ACCOUNT_REQUIRED`.
-        assertEquals(1, remoteGateway.fetchCloudAccountCalls)
-        assertNull(
-            environment.guestAiSessionStore.loadAnySession(
-                configuration = makeOfficialCloudServiceConfiguration()
-            )
-        )
-    }
-
-    @Test
-    fun analyticsGuestIdentityLinkSkipsGuestSessionThatOwnsCloudData() = runBlocking {
-        val localWorkspaceId = environment.requireLocalWorkspaceId()
-        val remoteGateway = FakeCloudRemoteGateway.standard()
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
-        environment.guestAiSessionStore.saveSession(
-            localWorkspaceId = null,
-            session = createStoredGuestAiSession(
-                workspaceId = "guest-workspace",
-                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
-                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
-                guestToken = "cloud-guest-token",
-                userId = "cloud-guest-user"
-            )
-        )
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        // That guest converts through `/guest-auth/upgrade/complete`, which writes the same identity
-        // link; this route would revoke the session that flow still needs.
-        assertTrue(remoteGateway.linkGuestIdentityGuestTokens.isEmpty())
-        assertEquals(
-            "cloud-guest-token",
-            environment.guestAiSessionStore.loadAnySession(
-                configuration = makeOfficialCloudServiceConfiguration()
-            )?.guestToken
-        )
-    }
-
-    @Test
-    fun analyticsGuestIdentityLinkKeepsGuestTokenAndStopsRetryingWhenUpgradeIsRequired() = runBlocking {
-        val localWorkspaceId = environment.requireLocalWorkspaceId()
-        val remoteGateway = FakeCloudRemoteGateway.standard()
-        remoteGateway.setLinkGuestIdentityError(
-            error = createCloudRemoteError(
-                statusCode = 409,
-                errorCode = "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED",
-                path = "/guest-auth/identity/link"
-            )
-        )
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
-        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        // The token is kept: it names the owner of data only the upgrade flow can transfer.
-        val retiredSession = environment.guestAiSessionStore.loadAnySession(
-            configuration = makeOfficialCloudServiceConfiguration()
-        )
-        assertEquals("analytics-guest-token", retiredSession?.guestToken)
-        assertEquals(false, retiredSession?.isAnalyticsOnly)
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        // Correcting the marker is what stops a link that can never succeed from being retried on
-        // every app start and every sign-in.
-        assertEquals(listOf("analytics-guest-token"), remoteGateway.linkGuestIdentityGuestTokens)
-    }
-
-    @Test
-    fun analyticsGuestIdentityLinkDropsGuestTokenOwnedByAnotherAccount() = runBlocking {
-        val localWorkspaceId = environment.requireLocalWorkspaceId()
-        val remoteGateway = FakeCloudRemoteGateway.standard()
-        remoteGateway.setLinkGuestIdentityError(
-            error = createCloudRemoteError(
-                statusCode = 409,
-                errorCode = "GUEST_IDENTITY_LINK_OTHER_ACCOUNT",
-                path = "/guest-auth/identity/link"
-            )
-        )
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
-        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        assertEquals(listOf("analytics-guest-token"), remoteGateway.linkGuestIdentityGuestTokens)
-        // Terminal: the credential is not this install's, so it must not stay as an analytics one.
-        assertNull(
-            environment.guestAiSessionStore.loadAnySession(
-                configuration = makeOfficialCloudServiceConfiguration()
-            )
-        )
-    }
-
-    @Test
-    fun analyticsGuestIdentityLinkKeepsGuestTokenWhenTheLinkFailsRetryably() = runBlocking {
-        val localWorkspaceId = environment.requireLocalWorkspaceId()
-        val remoteGateway = FakeCloudRemoteGateway.standard()
-        remoteGateway.setLinkGuestIdentityError(
-            error = createCloudRemoteError(
-                statusCode = 500,
-                errorCode = null,
-                path = "/guest-auth/identity/link"
-            )
-        )
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = localWorkspaceId)
-        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
-
-        try {
-            coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-            throw AssertionError("Expected a retryable link failure to be rethrown.")
-        } catch (error: CloudRemoteException) {
-            assertEquals(500, error.statusCode)
-        }
-
-        // A 5xx leaves this guest's tail unclaimed, because a success is what says the link landed,
-        // so the retry is mandatory and the token has to survive for it.
-        val keptSession = environment.guestAiSessionStore.loadAnySession(
-            configuration = makeOfficialCloudServiceConfiguration()
-        )
-        assertEquals("analytics-guest-token", keptSession?.guestToken)
-        assertTrue(keptSession?.isAnalyticsOnly == true)
-    }
-
-    /**
-     * The credential must belong to the account this install is linked to. Linking on a mismatch
-     * would attribute the guest's whole pre-sign-in tail to the wrong account, and
-     * `analytics.identity_links` is first-link-wins with no repair path — while answering the
-     * mismatch the way `authenticatedSession()` does would destroy local data instead.
-     */
-    @Test
-    fun analyticsGuestIdentityLinkBailsWhenTheCredentialIsForAnotherAccount() = runBlocking {
-        val preservationState = seedCredentialRecoveryLocalData()
-        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
-            accountSnapshot = createCloudAccountSnapshot(
-                userId = "user-2",
-                email = "other@example.com",
-                workspaces = listOf(
-                    createCloudWorkspaceSummary(
-                        workspaceId = preservationState.workspaceId,
-                        name = "Personal",
-                        createdAtMillis = 100L,
-                        isSelected = true
-                    )
-                )
-            )
-        )
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = preservationState.workspaceId)
-        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        assertTrue(remoteGateway.linkGuestIdentityGuestTokens.isEmpty())
-        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
-        assertEquals(
-            "analytics-guest-token",
-            environment.guestAiSessionStore.loadAnySession(
-                configuration = makeOfficialCloudServiceConfiguration()
-            )?.guestToken
-        )
-    }
-
-    /**
-     * The background link runs unattended on every app start and after every sign-in. A deleted
-     * account must therefore never reach a destructive local reset from here: sync answers that
-     * condition by preserving local data, and nothing about analytics may pre-empt it.
-     */
-    @Test
-    fun analyticsGuestIdentityLinkPreservesLocalDataWhenTheAccountIsDeleted() = runBlocking {
-        val preservationState = seedCredentialRecoveryLocalData()
-        val remoteGateway = FakeCloudRemoteGateway.forFetchAccountError(
-            fetchAccountError = createCloudRemoteError(
-                statusCode = 410,
-                errorCode = "ACCOUNT_DELETED",
-                path = "/me"
-            )
-        )
-        val coordinator = environment.createCloudGuestSessionCoordinator(remoteGateway = remoteGateway)
-        environment.prepareLinkedCloudIdentity(localWorkspaceId = preservationState.workspaceId)
-        storeAnalyticsOnlyGuestSession(guestToken = "analytics-guest-token")
-
-        coordinator.linkAnalyticsGuestIdentityToSignedInAccount()
-
-        assertTrue(remoteGateway.linkGuestIdentityGuestTokens.isEmpty())
-        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
-        assertEquals(
-            preservationState.installationId,
-            environment.cloudPreferencesStore.currentCloudSettings().installationId
-        )
-        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
-        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
-        assertEquals(
-            "analytics-guest-token",
-            environment.guestAiSessionStore.loadAnySession(
-                configuration = makeOfficialCloudServiceConfiguration()
-            )?.guestToken
-        )
-    }
 
     /**
      * The creation idempotency key is minted once and kept until the session is committed, so a
@@ -1017,82 +812,7 @@ class CloudGuestSessionCoordinatorTest {
         assertNull(environment.guestAiSessionStore.loadPendingCreationIdempotencyKey())
     }
 
-    private fun storeAnalyticsOnlyGuestSession(guestToken: String) {
-        environment.guestAiSessionStore.saveSession(
-            localWorkspaceId = null,
-            session = createStoredGuestAiSession(
-                workspaceId = "analytics-guest-workspace",
-                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
-                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
-                guestToken = guestToken,
-                userId = "analytics-guest-user",
-                isAnalyticsOnly = true
-            )
-        )
-    }
-
-    private fun createCloudRemoteError(
-        statusCode: Int,
-        errorCode: String?,
-        path: String
-    ): CloudRemoteException {
-        return CloudRemoteException(
-            message = "Cloud request failed with status $statusCode for $path",
-            statusCode = statusCode,
-            responseBody = JSONObject()
-                .put("code", errorCode ?: JSONObject.NULL)
-                .put("requestId", "request-1")
-                .toString(),
-            errorCode = errorCode,
-            requestId = "request-1",
-            syncConflict = null,
-            androidObservationAlreadyCaptured = false
-        )
-    }
-
-    private suspend fun seedCredentialRecoveryLocalData(): CredentialRecoveryPreservationState {
-        val workspaceId = environment.requireLocalWorkspaceId()
-        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
-        val cardId = environment.seedWorkspaceData(workspaceId = workspaceId)
-        val card = requireNotNull(environment.database.cardDao().loadCard(cardId = cardId)) {
-            "Expected seeded card."
-        }
-        environment.database.outboxDao().insertOutboxEntry(
-            createSyncCardOutboxEntry(
-                outboxEntryId = "outbox-recovery-$workspaceId",
-                workspaceId = workspaceId,
-                installationId = installationId,
-                card = card,
-                createdAtMillis = 300L
-            )
-        )
-        return CredentialRecoveryPreservationState(
-            workspaceId = workspaceId,
-            installationId = installationId,
-            cardId = cardId
-        )
-    }
-
-    private suspend fun assertCredentialRecoveryPreservedLocalData(
-        preservationState: CredentialRecoveryPreservationState
-    ) {
-        assertEquals(
-            preservationState.workspaceId,
-            environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId
-        )
-        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
-        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = preservationState.workspaceId).count())
-        assertNotNull(environment.database.cardDao().loadCard(cardId = preservationState.cardId))
-        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = preservationState.workspaceId))
-        assertEquals(1, environment.database.outboxDao().countOutboxEntries())
-    }
 }
-
-private data class CredentialRecoveryPreservationState(
-    val workspaceId: String,
-    val installationId: String,
-    val cardId: String
-)
 
 /**
  * [initialFailureCount] fails that many attempts before succeeding, standing in for a creation whose

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionTestSupport.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionTestSupport.kt
@@ -1,0 +1,52 @@
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.guest
+
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createSyncCardOutboxEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+internal data class CredentialRecoveryPreservationState(
+    val workspaceId: String,
+    val installationId: String,
+    val cardId: String
+)
+
+internal suspend fun seedCredentialRecoveryLocalData(
+    environment: CloudIdentityTestEnvironment
+): CredentialRecoveryPreservationState {
+    val workspaceId = environment.requireLocalWorkspaceId()
+    val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+    val cardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+    val card = requireNotNull(environment.database.cardDao().loadCard(cardId = cardId)) {
+        "Expected seeded card."
+    }
+    environment.database.outboxDao().insertOutboxEntry(
+        createSyncCardOutboxEntry(
+            outboxEntryId = "outbox-recovery-$workspaceId",
+            workspaceId = workspaceId,
+            installationId = installationId,
+            card = card,
+            createdAtMillis = 300L
+        )
+    )
+    return CredentialRecoveryPreservationState(
+        workspaceId = workspaceId,
+        installationId = installationId,
+        cardId = cardId
+    )
+}
+
+internal suspend fun assertCredentialRecoveryPreservedLocalData(
+    environment: CloudIdentityTestEnvironment,
+    preservationState: CredentialRecoveryPreservationState
+) {
+    assertEquals(
+        preservationState.workspaceId,
+        environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId
+    )
+    assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+    assertEquals(1, environment.database.cardDao().loadCards(workspaceId = preservationState.workspaceId).count())
+    assertNotNull(environment.database.cardDao().loadCard(cardId = preservationState.cardId))
+    assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = preservationState.workspaceId))
+    assertEquals(1, environment.database.outboxDao().countOutboxEntries())
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/AnalyticsGuestIdentityLinkCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/AnalyticsGuestIdentityLinkCoordinator.kt
@@ -1,0 +1,227 @@
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.guest
+
+import com.flashcardsopensourceapp.data.local.ai.store.GuestAiSessionStore
+import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
+import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.cloud.shouldRefreshCloudIdToken
+import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.CloudIdentityResetCoordinator
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudSessionProvider
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.isRemoteAccountDeletedError
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class AnalyticsGuestIdentityLinkCoordinator(
+    private val preferencesStore: CloudPreferencesStore,
+    private val remoteService: CloudRemoteGateway,
+    private val operationCoordinator: CloudOperationCoordinator,
+    resetCoordinator: CloudIdentityResetCoordinator,
+    private val guestSessionStore: GuestAiSessionStore
+) {
+    private val sessionProvider: CloudSessionProvider = CloudSessionProvider(
+        preferencesStore = preferencesStore,
+        remoteService = remoteService,
+        operationCoordinator = operationCoordinator,
+        resetCoordinator = resetCoordinator
+    )
+
+    /**
+     * Deliberately not [operationCoordinator]: the link awaits a request context of its own, and
+     * holding the cloud operation lock across that would make a user action wait for analytics.
+     */
+    private val analyticsGuestIdentityLinkMutex = Mutex()
+
+    suspend fun linkAnalyticsGuestIdentityToSignedInAccount() {
+        analyticsGuestIdentityLinkMutex.withLock {
+            val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+            if (cloudSettings.cloudState != CloudAccountState.LINKED) {
+                return@withLock
+            }
+            if (preferencesStore.loadCloudCredentialRecoveryState() != null) {
+                return@withLock
+            }
+            val configuration: CloudServiceConfiguration = preferencesStore.currentServerConfiguration()
+            val guestSession: StoredGuestAiSession = guestSessionStore.loadAnySession(
+                configuration = configuration
+            )?.takeIf { session -> session.isAnalyticsOnly } ?: return@withLock
+            val credentials: StoredCloudCredentials = analyticsGuestIdentityLinkCredentialsOrNull(
+                configuration = configuration
+            ) ?: return@withLock
+
+            try {
+                // Loads a request context first, which is what writes the account's identity row.
+                // The link has no way to sequence that for itself and earns
+                // `409 GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED` without it.
+                val accountSnapshot: CloudAccountSnapshot = sessionProvider.fetchCloudAccount(
+                    credentials = credentials,
+                    configuration = configuration
+                )
+                // The credential has to belong to the account this install is linked to.
+                // `authenticatedSession()` tests the same thing and answers a mismatch with a
+                // destructive reset; here it is only a reason not to link, because
+                // `analytics.identity_links` is first-link-wins and this guest's whole tail would
+                // be attributed to the wrong account with no repair path.
+                if (isSignedInAccountStillLinkedIdentity(accountSnapshot = accountSnapshot).not()) {
+                    return@withLock
+                }
+                remoteService.linkGuestIdentity(
+                    apiBaseUrl = configuration.apiBaseUrl,
+                    bearerToken = credentials.idToken,
+                    guestToken = guestSession.guestToken
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                // Terminal, and deliberately silent here. Sync owns deleted-account handling and
+                // does it through `disconnectDeletedCloudIdentityPreservingLocalState`, which keeps
+                // local data; nothing about analytics may pre-empt that with a reset of its own.
+                if (isRemoteAccountDeletedError(error = error)) {
+                    return@withLock
+                }
+                if (error !is CloudRemoteException) {
+                    throw error
+                }
+                if (isGuestIdentityUpgradeRequiredError(error = error)) {
+                    retireAnalyticsOnlyGuestForUpgradePath(guestSession = guestSession)
+                    return@withLock
+                }
+                if (isGuestIdentityOwnedByOtherAccountError(error = error).not()) {
+                    throw error
+                }
+            }
+            if (storedAnalyticsGuestStillMatchingOrNull(guestSession = guestSession) == null) {
+                return@withLock
+            }
+            // Not the two keys this session happens to sit under: any other stored session would
+            // survive and later be presented as an analytics credential or sent here again.
+            guestSessionStore.clearStoredSessions()
+        }
+    }
+
+    /**
+     * The stored analytics-only guest re-read after the request, or null once it is no longer what
+     * this install holds — the precondition for every store write this link makes afterwards.
+     *
+     * The capture above happens before a request context and the link itself, and
+     * [analyticsGuestIdentityLinkMutex] deliberately does not hold the cloud operation lock across
+     * them, so a logout and a fresh guest cloud session can both land in between. Without this
+     * re-read [GuestAiSessionStore.clearStoredSessions] would delete that live cloud guest — leaving
+     * `GUEST` with nothing stored, which reconciliation answers with the `GUEST_SESSION_MISSING`
+     * credential-recovery gate — and [retireAnalyticsOnlyGuestForUpgradePath] would re-persist the
+     * departed person's guest, which `CloudGuestSessionCoordinator`'s `loadAnySession` fallback
+     * would later adopt as the next user's cloud guest.
+     *
+     * `LINKED` is re-read too: a boundary crossed since the capture leaves this install signed out,
+     * and nothing about that install's guest is this account's business any more.
+     */
+    private fun storedAnalyticsGuestStillMatchingOrNull(
+        guestSession: StoredGuestAiSession
+    ): StoredGuestAiSession? {
+        if (preferencesStore.currentCloudSettings().cloudState != CloudAccountState.LINKED) {
+            return null
+        }
+        // Re-read as well, so a configuration change since the capture cannot make this lookup drop
+        // sessions that are valid for the configuration in force now.
+        val configuration: CloudServiceConfiguration = preferencesStore.currentServerConfiguration()
+        val storedSession: StoredGuestAiSession = guestSessionStore.loadAnySession(
+            configuration = configuration
+        ) ?: return null
+        if (storedSession.isAnalyticsOnly.not() || storedSession.guestToken != guestSession.guestToken) {
+            return null
+        }
+
+        return storedSession
+    }
+
+    /**
+     * Re-read rather than taken from the settings this call started with: a sign-in to another
+     * account can land while the request context is in flight, and its guest belongs to that account
+     * rather than this one.
+     */
+    private fun isSignedInAccountStillLinkedIdentity(accountSnapshot: CloudAccountSnapshot): Boolean {
+        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+        if (cloudSettings.cloudState != CloudAccountState.LINKED) {
+            return false
+        }
+
+        val linkedUserId: String = cloudSettings.linkedUserId?.trim()?.ifEmpty { null } ?: return true
+        return linkedUserId == accountSnapshot.userId
+    }
+
+    /**
+     * The stored credential for the signed-in account, refreshed in memory only when it has expired.
+     *
+     * Deliberately **not** [CloudSessionProvider.authenticatedSession]. That helper turns a
+     * `410 ACCOUNT_DELETED`, and a `linkedUserId` that does not match the fetched account, into
+     * `resetLocalStateForCloudIdentityChange()` — which runs `database.clearAllTables()`. This path
+     * is the only unattended caller in the app: it runs on every app start and after every sign-in,
+     * with no user action behind it and no way back, so it must never reach a destructive reset.
+     * A deleted account is sync's business, and sync answers it by preserving local data.
+     *
+     * Nothing is persisted here either. This path holds no cloud operation lock, so a refreshed
+     * credential written back — or the account preferences [CloudSessionProvider.authenticatedSession]
+     * also saves — could land after a concurrent logout had already cleared them, leaving
+     * `DISCONNECTED` with an orphan credential. The refreshed token lives for this request only.
+     */
+    private suspend fun analyticsGuestIdentityLinkCredentialsOrNull(
+        configuration: CloudServiceConfiguration
+    ): StoredCloudCredentials? {
+        val storedCredentials: StoredCloudCredentials = preferencesStore.loadCredentials() ?: return null
+        if (
+            shouldRefreshCloudIdToken(
+                idTokenExpiresAtMillis = storedCredentials.idTokenExpiresAtMillis,
+                nowMillis = System.currentTimeMillis()
+            ).not()
+        ) {
+            return storedCredentials
+        }
+
+        return remoteService.refreshIdToken(
+            refreshToken = storedCredentials.refreshToken,
+            authBaseUrl = configuration.authBaseUrl
+        )
+    }
+
+    /**
+     * `409 GUEST_IDENTITY_LINK_UPGRADE_REQUIRED` says the guest owns data only
+     * `/guest-auth/upgrade/complete` can transfer, so the stored marker was wrong and is corrected
+     * to match the server. The token is kept — dropping it would lose that data's owner.
+     *
+     * Correcting the marker is what stops this link from being attempted again, and that is the
+     * whole of what this achieves: retrying unchanged can never succeed, and every attempt costs a
+     * request context on top of the request, on every app start and every sign-in, forever.
+     *
+     * It does **not** route a later sign-in through the upgrade flow, and cannot: the only routes to
+     * another sign-in on this install are logout and account deletion, and both clear every stored
+     * session. That guest's cloud data stays with the guest account on the server.
+     *
+     * A conditional update rather than a write: it corrects a marker on a session that is still
+     * stored, and must never re-create one deleted since the capture. See
+     * [storedAnalyticsGuestStillMatchingOrNull] for what that would cost.
+     */
+    private fun retireAnalyticsOnlyGuestForUpgradePath(guestSession: StoredGuestAiSession) {
+        val storedSession: StoredGuestAiSession = storedAnalyticsGuestStillMatchingOrNull(
+            guestSession = guestSession
+        ) ?: return
+        guestSessionStore.saveSession(
+            localWorkspaceId = storedSession.workspaceId,
+            session = storedSession.copy(isAnalyticsOnly = false)
+        )
+    }
+
+    private fun isGuestIdentityOwnedByOtherAccountError(error: CloudRemoteException): Boolean {
+        return error.statusCode == 409 && error.errorCode == "GUEST_IDENTITY_LINK_OTHER_ACCOUNT"
+    }
+
+    private fun isGuestIdentityUpgradeRequiredError(error: CloudRemoteException): Boolean {
+        return error.statusCode == 409 && error.errorCode == "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED"
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -18,22 +18,15 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
-import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
-import com.flashcardsopensourceapp.data.local.model.cloud.shouldRefreshCloudIdToken
-import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
 import com.flashcardsopensourceapp.data.local.network.isRetryableHttpStatusCode
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.CloudIdentityResetCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
-import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudSessionProvider
-import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.isRemoteAccountDeletedError
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.androidClientPlatform
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 internal data class CloudIdentityReconciliationResult(
@@ -66,18 +59,13 @@ class CloudGuestSessionCoordinator(
     private val creationCoordinator: GuestCloudSessionCreationCoordinator,
     private val appVersion: String
 ) {
-    private val sessionProvider: CloudSessionProvider = CloudSessionProvider(
+    private val analyticsGuestIdentityLinkCoordinator = AnalyticsGuestIdentityLinkCoordinator(
         preferencesStore = preferencesStore,
         remoteService = remoteService,
         operationCoordinator = operationCoordinator,
-        resetCoordinator = resetCoordinator
+        resetCoordinator = resetCoordinator,
+        guestSessionStore = guestSessionStore
     )
-
-    /**
-     * Deliberately not [operationCoordinator]: the link awaits a request context of its own, and
-     * holding the cloud operation lock across that would make a user action wait for analytics.
-     */
-    private val analyticsGuestIdentityLinkMutex = Mutex()
 
     suspend fun reconcilePersistedCloudStateForStartup() {
         operationCoordinator.runExclusive {
@@ -119,181 +107,7 @@ class CloudGuestSessionCoordinator(
      * A second caller has to carry that gate too.
      */
     suspend fun linkAnalyticsGuestIdentityToSignedInAccount() {
-        analyticsGuestIdentityLinkMutex.withLock {
-            val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
-            if (cloudSettings.cloudState != CloudAccountState.LINKED) {
-                return@withLock
-            }
-            if (preferencesStore.loadCloudCredentialRecoveryState() != null) {
-                return@withLock
-            }
-            val configuration: CloudServiceConfiguration = preferencesStore.currentServerConfiguration()
-            val guestSession: StoredGuestAiSession = guestSessionStore.loadAnySession(
-                configuration = configuration
-            )?.takeIf { session -> session.isAnalyticsOnly } ?: return@withLock
-            val credentials: StoredCloudCredentials = analyticsGuestIdentityLinkCredentialsOrNull(
-                configuration = configuration
-            ) ?: return@withLock
-
-            try {
-                // Loads a request context first, which is what writes the account's identity row.
-                // The link has no way to sequence that for itself and earns
-                // `409 GUEST_IDENTITY_LINK_ACCOUNT_REQUIRED` without it.
-                val accountSnapshot: CloudAccountSnapshot = sessionProvider.fetchCloudAccount(
-                    credentials = credentials,
-                    configuration = configuration
-                )
-                // The credential has to belong to the account this install is linked to.
-                // `authenticatedSession()` tests the same thing and answers a mismatch with a
-                // destructive reset; here it is only a reason not to link, because
-                // `analytics.identity_links` is first-link-wins and this guest's whole tail would
-                // be attributed to the wrong account with no repair path.
-                if (isSignedInAccountStillLinkedIdentity(accountSnapshot = accountSnapshot).not()) {
-                    return@withLock
-                }
-                remoteService.linkGuestIdentity(
-                    apiBaseUrl = configuration.apiBaseUrl,
-                    bearerToken = credentials.idToken,
-                    guestToken = guestSession.guestToken
-                )
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                // Terminal, and deliberately silent here. Sync owns deleted-account handling and
-                // does it through `disconnectDeletedCloudIdentityPreservingLocalState`, which keeps
-                // local data; nothing about analytics may pre-empt that with a reset of its own.
-                if (isRemoteAccountDeletedError(error = error)) {
-                    return@withLock
-                }
-                if (error !is CloudRemoteException) {
-                    throw error
-                }
-                if (isGuestIdentityUpgradeRequiredError(error = error)) {
-                    retireAnalyticsOnlyGuestForUpgradePath(guestSession = guestSession)
-                    return@withLock
-                }
-                if (isGuestIdentityOwnedByOtherAccountError(error = error).not()) {
-                    throw error
-                }
-            }
-            if (storedAnalyticsGuestStillMatchingOrNull(guestSession = guestSession) == null) {
-                return@withLock
-            }
-            // Not the two keys this session happens to sit under: any other stored session would
-            // survive and later be presented as an analytics credential or sent here again.
-            guestSessionStore.clearStoredSessions()
-        }
-    }
-
-    /**
-     * The stored analytics-only guest re-read after the request, or null once it is no longer what
-     * this install holds — the precondition for every store write this link makes afterwards.
-     *
-     * The capture above happens before a request context and the link itself, and
-     * [analyticsGuestIdentityLinkMutex] deliberately does not hold the cloud operation lock across
-     * them, so a logout and a fresh guest cloud session can both land in between. Without this
-     * re-read [GuestAiSessionStore.clearStoredSessions] would delete that live cloud guest — leaving
-     * `GUEST` with nothing stored, which reconciliation answers with the `GUEST_SESSION_MISSING`
-     * credential-recovery gate — and [retireAnalyticsOnlyGuestForUpgradePath] would re-persist the
-     * departed person's guest, which [loadGuestSessionForCurrentConfiguration]'s `loadAnySession`
-     * fallback would later adopt as the next user's cloud guest.
-     *
-     * `LINKED` is re-read too: a boundary crossed since the capture leaves this install signed out,
-     * and nothing about that install's guest is this account's business any more.
-     */
-    private fun storedAnalyticsGuestStillMatchingOrNull(
-        guestSession: StoredGuestAiSession
-    ): StoredGuestAiSession? {
-        if (preferencesStore.currentCloudSettings().cloudState != CloudAccountState.LINKED) {
-            return null
-        }
-        // Re-read as well, so a configuration change since the capture cannot make this lookup drop
-        // sessions that are valid for the configuration in force now.
-        val configuration: CloudServiceConfiguration = preferencesStore.currentServerConfiguration()
-        val storedSession: StoredGuestAiSession = guestSessionStore.loadAnySession(
-            configuration = configuration
-        ) ?: return null
-        if (storedSession.isAnalyticsOnly.not() || storedSession.guestToken != guestSession.guestToken) {
-            return null
-        }
-
-        return storedSession
-    }
-
-    /**
-     * Re-read rather than taken from the settings this call started with: a sign-in to another
-     * account can land while the request context is in flight, and its guest belongs to that account
-     * rather than this one.
-     */
-    private fun isSignedInAccountStillLinkedIdentity(accountSnapshot: CloudAccountSnapshot): Boolean {
-        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
-        if (cloudSettings.cloudState != CloudAccountState.LINKED) {
-            return false
-        }
-
-        val linkedUserId: String = cloudSettings.linkedUserId?.trim()?.ifEmpty { null } ?: return true
-        return linkedUserId == accountSnapshot.userId
-    }
-
-    /**
-     * The stored credential for the signed-in account, refreshed in memory only when it has expired.
-     *
-     * Deliberately **not** [CloudSessionProvider.authenticatedSession]. That helper turns a
-     * `410 ACCOUNT_DELETED`, and a `linkedUserId` that does not match the fetched account, into
-     * `resetLocalStateForCloudIdentityChange()` — which runs `database.clearAllTables()`. This path
-     * is the only unattended caller in the app: it runs on every app start and after every sign-in,
-     * with no user action behind it and no way back, so it must never reach a destructive reset.
-     * A deleted account is sync's business, and sync answers it by preserving local data.
-     *
-     * Nothing is persisted here either. This path holds no cloud operation lock, so a refreshed
-     * credential written back — or the account preferences [CloudSessionProvider.authenticatedSession]
-     * also saves — could land after a concurrent logout had already cleared them, leaving
-     * `DISCONNECTED` with an orphan credential. The refreshed token lives for this request only.
-     */
-    private suspend fun analyticsGuestIdentityLinkCredentialsOrNull(
-        configuration: CloudServiceConfiguration
-    ): StoredCloudCredentials? {
-        val storedCredentials: StoredCloudCredentials = preferencesStore.loadCredentials() ?: return null
-        if (
-            shouldRefreshCloudIdToken(
-                idTokenExpiresAtMillis = storedCredentials.idTokenExpiresAtMillis,
-                nowMillis = System.currentTimeMillis()
-            ).not()
-        ) {
-            return storedCredentials
-        }
-
-        return remoteService.refreshIdToken(
-            refreshToken = storedCredentials.refreshToken,
-            authBaseUrl = configuration.authBaseUrl
-        )
-    }
-
-    /**
-     * `409 GUEST_IDENTITY_LINK_UPGRADE_REQUIRED` says the guest owns data only
-     * `/guest-auth/upgrade/complete` can transfer, so the stored marker was wrong and is corrected
-     * to match the server. The token is kept — dropping it would lose that data's owner.
-     *
-     * Correcting the marker is what stops this link from being attempted again, and that is the
-     * whole of what this achieves: retrying unchanged can never succeed, and every attempt costs a
-     * request context on top of the request, on every app start and every sign-in, forever.
-     *
-     * It does **not** route a later sign-in through the upgrade flow, and cannot: the only routes to
-     * another sign-in on this install are logout and account deletion, and both clear every stored
-     * session. That guest's cloud data stays with the guest account on the server.
-     *
-     * A conditional update rather than a write: it corrects a marker on a session that is still
-     * stored, and must never re-create one deleted since the capture. See
-     * [storedAnalyticsGuestStillMatchingOrNull] for what that would cost.
-     */
-    private fun retireAnalyticsOnlyGuestForUpgradePath(guestSession: StoredGuestAiSession) {
-        val storedSession: StoredGuestAiSession = storedAnalyticsGuestStillMatchingOrNull(
-            guestSession = guestSession
-        ) ?: return
-        guestSessionStore.saveSession(
-            localWorkspaceId = storedSession.workspaceId,
-            session = storedSession.copy(isAnalyticsOnly = false)
-        )
+        analyticsGuestIdentityLinkCoordinator.linkAnalyticsGuestIdentityToSignedInAccount()
     }
 
     suspend fun deleteStoredGuestCloudSessionIfPresent() {
@@ -699,14 +513,6 @@ class CloudGuestSessionCoordinator(
     private fun isCloudAuthorizationError(error: Exception): Boolean {
         return error is CloudRemoteException &&
             (error.statusCode == 401 || error.statusCode == 403)
-    }
-
-    private fun isGuestIdentityOwnedByOtherAccountError(error: CloudRemoteException): Boolean {
-        return error.statusCode == 409 && error.errorCode == "GUEST_IDENTITY_LINK_OTHER_ACCOUNT"
-    }
-
-    private fun isGuestIdentityUpgradeRequiredError(error: CloudRemoteException): Boolean {
-        return error.statusCode == 409 && error.errorCode == "GUEST_IDENTITY_LINK_UPGRADE_REQUIRED"
     }
 
     private fun isGuestSessionInvalidError(error: Exception): Boolean {


### PR DESCRIPTION
## Summary

- move analytics guest-identity linking into its own serialized coordinator
- keep the existing facade and preserve all seven instrumentation scenarios
- share credential-recovery preservation helpers between focused test classes

## Validation

- local project checks intentionally not run; cloud PR checks own Android build, lint, tests, and data:local instrumentation