### PR TITLE
Page on auth 5xx only when it persists past one period

### DIFF
--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -259,6 +259,13 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     treatMissingData: cloudwatch.TreatMissingData.BREACHING,
   }), alertTopic);
 
+  // Both auth 5xx alarms need two consecutive periods. A saturated authHandlerReservedConcurrency
+  // reservation surfaces as an API Gateway 500 whose integrationStatus is 429, which
+  // infra/aws/lib/gateways/api-gateway.ts documents as the intended bounded rejection protecting the
+  // Postgres connection budget, so a crawler burst contained in one five-minute period is that bound
+  // working rather than an incident. Auth failure that outlasts a burst still pages here, and an
+  // auth host that stops serving pages through the public-endpoint heartbeat alarm on
+  // auth.<baseDomain> within fifteen minutes.
   notifyAlertTopic(new cloudwatch.Alarm(scope, "AuthApiGateway5xxAlarm", {
     metric: new cloudwatch.Metric({
       namespace: "AWS/ApiGateway",
@@ -268,8 +275,10 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
       statistic: "Sum",
     }),
     threshold: 3,
-    evaluationPeriods: 1,
-    alarmDescription: "Auth API Gateway returned 3+ server errors in 5 minutes",
+    evaluationPeriods: 2,
+    datapointsToAlarm: 2,
+    alarmDescription:
+      "Auth API Gateway returned 3+ server errors in each of two consecutive 5-minute periods",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }), alertTopic);
 
@@ -354,8 +363,10 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
       statistic: "Sum",
     }),
     threshold: 1,
-    evaluationPeriods: 1,
-    alarmDescription: "Auth API access logs include a 5xx response",
+    evaluationPeriods: 2,
+    datapointsToAlarm: 2,
+    alarmDescription:
+      "Auth API access logs include a 5xx response in each of two consecutive 5-minute periods",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }), alertTopic);
 


### PR DESCRIPTION
A saturated `authHandlerReservedConcurrency` reservation reaches the caller as an API Gateway 500 whose `integrationStatus` is 429. `infra/aws/lib/gateways/api-gateway.ts` documents that bounded rejection as the intended trade protecting the Postgres connection budget, so a sub-second crawler burst that hits it is the bound working, not an incident — yet it pages both auth 5xx alarms.

Both alarms now require two consecutive breaching five-minute periods. A one-off burst confined to a single period cannot satisfy that; a sustained auth failure still does.

- Thresholds are unchanged (3 for the gateway alarm, 1 for the access-log alarm). With persistence added they stop being near-duplicates and split into a volume signal and a slow-trickle signal.
- A host that stops serving entirely still pages within fifteen minutes through the existing public-endpoint heartbeat alarm on `auth.<baseDomain>`, which is independent of both.
- Stage throttling and every concurrency reservation are deliberately untouched: the triggering burst was 19 requests inside one second, so a lower burst limit would still have admitted all of them, and the auth API legitimately receives 19-32 requests per second of crawler traffic that produces no 5xx at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)