### PR TITLE
chore: bump version to 1.24.0

### DIFF
--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-admin",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "d3": "^7.9.0",
         "react": "^19.2.8",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -156,7 +156,7 @@ android {
         minSdk = androidMinSdk
         targetSdk = 37
         versionCode = androidVersionCode ?: 1
-        versionName = "1.23.0"
+        versionName = "1.24.0"
         testInstrumentationRunner = "com.flashcardsopensourceapp.app.FlashcardsAndroidTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         buildConfigField("int", "ANDROID_MIN_SDK", androidMinSdk.toString())

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-auth",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-auth",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1118.0",
         "@hono/node-server": "^2.1.1",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-auth",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-backend",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1118.0",
         "@aws-sdk/client-lambda": "^3.1118.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/entrypoints/index.ts",

--- a/apps/ios/Flashcards/Config/Base.xcconfig
+++ b/apps/ios/Flashcards/Config/Base.xcconfig
@@ -1,6 +1,6 @@
 APP_DISPLAY_NAME = Flashcards
 APP_BUNDLE_IDENTIFIER = com.flashcards-open-source-app.app
-APP_MARKETING_VERSION = 1.23.0
+APP_MARKETING_VERSION = 1.24.0
 // Keep the repository default build number stable. Signed archives should
 // override this locally or in CI when a higher App Store Connect build number is required.
 APP_CURRENT_PROJECT_VERSION = 1

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-web",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.9",
         "@sentry/react": "^10.71.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-aws",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.2",
         "@aws-sdk/client-cloudwatch": "^3.1118.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.flashcards-open-source-app/flashcards",
   "title": "Flashcards Open Source App",
   "description": "Read and write open-source flashcards through split read/write MCP tools.",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "websiteUrl": "https://flashcards-open-source-app.com",
   "icons": [
     {


### PR DESCRIPTION
Bumps every repo-owned version surface to `1.24.0` after the [v1.23.0](https://github.com/kirill-markin/flashcards-open-source-app/releases/tag/v1.23.0) tag, GitHub Release, and the manual Android / Apple iOS / MCP server release actions were completed.

Follows the shared-version default in [docs/version-bump.md](docs/version-bump.md): backend, web, Android, and iOS all move together.

Surfaces updated:

- `apps/backend/package.json`, `apps/admin/package.json`, `apps/auth/package.json`, `infra/aws/package.json` and their `package-lock.json` top-level version fields
- `server.json` (MCP registry manifest)
- `apps/web/package.json` + lockfile
- `apps/android/app/build.gradle.kts` (`versionName`)
- `apps/ios/Flashcards/Config/Base.xcconfig` (`APP_MARKETING_VERSION`)

Deliberately untouched:

- `apps/backend/src/productAnalytics/writer.postgres.integration.ts` keeps its `1.23.0` literals — test fixtures do not track the release version.
- Android `versionCode` (CI supplies `ANDROID_VERSION_CODE` at release time) and the iOS build number.
- No compatibility comment in the repo names the released client version, so none needed updating.

Runtime version readers stay wired to their checked-in sources; no new literals or fallbacks were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)