### PR TITLE
Group backend analytics server facts

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -75,7 +75,7 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 125,
     testFiles: Object.freeze([
       "src/catalog/distribution/install/install.postgres.integration.ts",
-      "src/productAnalytics/serverEvents.postgres.integration.ts",
+      "src/productAnalytics/serverFacts/serverEvents.postgres.integration.ts",
       "src/productAnalytics/writer.postgres.integration.ts",
     ]),
   }),

--- a/apps/backend/src/aiTools/agentSql/batchMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.ts
@@ -17,7 +17,7 @@ import {
   type DeckFilterDefinition,
   type UpdateDeckInput,
 } from "../../decks";
-import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/contentCreations";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/serverFacts/contentCreations";
 import { HttpError } from "../../shared/errors";
 import type { LegacyEffortLevel } from "../../sync/contracts/legacyEffort";
 import { isLegacyEffortLevel } from "../../sync/contracts/legacyEffort";

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -6,7 +6,7 @@ import {
 import {
   collectContentCreation,
   transactionWithWorkspaceScopeReportingContentCreations,
-} from "../productAnalytics/contentCreations";
+} from "../productAnalytics/serverFacts/contentCreations";
 import { HttpError } from "../shared/errors";
 import {
   incomingLwwMetadataWins,

--- a/apps/backend/src/cards/review/reviews.ts
+++ b/apps/backend/src/cards/review/reviews.ts
@@ -17,12 +17,12 @@ import {
 } from "../../sync/conflicts/fork";
 import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
 import { getWorkspaceSchedulerConfig } from "../../scheduling/workspaceSettings";
-import { createPostCommitAnalyticsBudget } from "../../productAnalytics/postCommitBudget";
+import { createPostCommitAnalyticsBudget } from "../../productAnalytics/serverFacts/postCommitBudget";
 import {
   collectReviewAnswer,
   runTransactionReportingReviewAnswers,
   type ReviewAnsweredServerAnchor,
-} from "../../productAnalytics/reviewAnswers";
+} from "../../productAnalytics/serverFacts/reviewAnswers";
 import { assertConsistentFsrsState } from "./fsrs";
 import {
   CARD_COLUMNS,

--- a/apps/backend/src/catalog/distribution/install/index.ts
+++ b/apps/backend/src/catalog/distribution/install/index.ts
@@ -15,7 +15,7 @@ import {
 import {
   deriveServerDerivedProductAnalyticsEventId,
   emitServerDerivedProductAnalyticsEvent,
-} from "../../../productAnalytics/serverEvents";
+} from "../../../productAnalytics/serverFacts/serverEvents";
 import { HttpError } from "../../../shared/errors";
 import { normalizeCardImportTagOptions } from "../../../shared/cardImportTags";
 import { normalizeIsoTimestamp } from "../../../sync/conflicts/lww";

--- a/apps/backend/src/chat/runs/analytics.ts
+++ b/apps/backend/src/chat/runs/analytics.ts
@@ -1,7 +1,7 @@
 import {
   deriveServerDerivedProductAnalyticsEventId,
   emitServerDerivedProductAnalyticsEvent,
-} from "../../productAnalytics/serverEvents";
+} from "../../productAnalytics/serverFacts/serverEvents";
 import type { ChatRunActor } from "./types";
 
 /**

--- a/apps/backend/src/community/analytics.ts
+++ b/apps/backend/src/community/analytics.ts
@@ -1,7 +1,7 @@
 import {
   deriveServerDerivedProductAnalyticsEventId,
   emitServerDerivedProductAnalyticsEvent,
-} from "../productAnalytics/serverEvents";
+} from "../productAnalytics/serverFacts/serverEvents";
 
 export type FriendInvitationCreatedFact = Readonly<{
   friendInvitationId: string;

--- a/apps/backend/src/decks/index.ts
+++ b/apps/backend/src/decks/index.ts
@@ -35,7 +35,7 @@ import { appendLegacyEffortTag } from "../cards/shared";
 import {
   collectContentCreation,
   transactionWithWorkspaceScopeReportingContentCreations,
-} from "../productAnalytics/contentCreations";
+} from "../productAnalytics/serverFacts/contentCreations";
 
 type TimestampValue = Date | string;
 type ErrorFactory = (message: string) => Error;

--- a/apps/backend/src/guestAuth/index.ts
+++ b/apps/backend/src/guestAuth/index.ts
@@ -9,17 +9,17 @@ import {
   captureBackendRuntimeWarning,
   createBackendObservationScope,
 } from "../observability/runtime";
-import { unsafeTransactionReportingContentCreations } from "../productAnalytics/contentCreations";
+import { unsafeTransactionReportingContentCreations } from "../productAnalytics/serverFacts/contentCreations";
 import {
   createPostCommitAnalyticsBudget,
   type PostCommitAnalyticsBudget,
-} from "../productAnalytics/postCommitBudget";
-import { runTransactionReportingReviewAnswers } from "../productAnalytics/reviewAnswers";
+} from "../productAnalytics/serverFacts/postCommitBudget";
+import { runTransactionReportingReviewAnswers } from "../productAnalytics/serverFacts/reviewAnswers";
 import {
   deriveServerDerivedProductAnalyticsEventId,
   emitServerDerivedProductAnalyticsEvent,
   linkServerDerivedProductAnalyticsIdentity,
-} from "../productAnalytics/serverEvents";
+} from "../productAnalytics/serverFacts/serverEvents";
 import {
   deleteGuestSessionInExecutor,
 } from "./delete/index";
@@ -243,7 +243,8 @@ export async function completeGuestUpgrade(
   // post-commit analytics budget created here instead of each carrying a bound of its own, which
   // would sum. Three of the four are gated on it; the identity link is exempt, for the reason
   // recordGuestUpgradeCompletedAnalytics gives. That puts this path's tail at 12.0s against the 29s
-  // integration timeout, and every other path's at 8.0s. See ../productAnalytics/postCommitBudget.ts.
+  // integration timeout, and every other path's at 8.0s. See
+  // ../productAnalytics/serverFacts/postCommitBudget.ts.
   const analyticsBudget = createPostCommitAnalyticsBudget();
   // The merge re-inserts the guest's review events into the target workspace under their original
   // review_event_id, so each collects a review_answered row that derives the id the guest's own

--- a/apps/backend/src/productAnalytics/serverFacts/contentCreations.ts
+++ b/apps/backend/src/productAnalytics/serverFacts/contentCreations.ts
@@ -2,8 +2,8 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
   type WorkspaceDatabaseScope,
-} from "../database";
-import { unsafeTransaction } from "../database/unsafe";
+} from "../../database";
+import { unsafeTransaction } from "../../database/unsafe";
 // Report through `observability/runtime`, never through `observability/sentry`. Deck writes reach
 // this module from `decks/index.ts`, which the direct image ingestion Lambda pulls in through
 // `guestAuth/store/decks.ts`, and that bundle deliberately excludes the Sentry SDK -
@@ -17,8 +17,8 @@ import { unsafeTransaction } from "../database/unsafe";
 import {
   captureBackendRuntimeWarning,
   createBackendObservationScope,
-} from "../observability/runtime";
-import type { ProductAnalyticsEventName } from "./catalog";
+} from "../../observability/runtime";
+import type { ProductAnalyticsEventName } from "../catalog";
 import {
   createPostCommitAnalyticsBudget,
   type PostCommitAnalyticsBudget,
@@ -28,7 +28,7 @@ import {
   emitServerDerivedProductAnalyticsEvents,
   type ServerDerivedProductAnalyticsEvent,
 } from "./serverEvents";
-import { productAnalyticsMaxEventAgeMs } from "./validation";
+import { productAnalyticsMaxEventAgeMs } from "../validation";
 
 export type ContentCreationEntityType = "card" | "deck";
 

--- a/apps/backend/src/productAnalytics/serverFacts/postCommitBudget.ts
+++ b/apps/backend/src/productAnalytics/serverFacts/postCommitBudget.ts
@@ -1,7 +1,7 @@
 // The wall clock one request may spend on analytics after its product transaction committed.
 //
 // Every server-derived producer does its work post-commit, on the request's own clock, and every
-// operation it does there costs up to ~4s: up to analyticsPoolConnectionTimeoutMs (2s, ./writer.ts)
+// operation it does there costs up to ~4s: up to analyticsPoolConnectionTimeoutMs (2s, ../writer.ts)
 // acquiring an analytics connection, then up to 2s under the SET LOCAL statement_timeout = '2s' that
 // runAnalyticsWrite sets. That is paid for a chunk the writer stores just as much as for one it
 // refuses, so no stop rule keyed on refusal alone bounds it.
@@ -26,7 +26,7 @@
 // content-only path alike. The guest upgrade is the one path above that figure, by choice: its
 // analytics identity link is exempt from the stop and always attempted, because it is the one write
 // here with no repair path, so that path's tail is 8.0s + 4.0s = 12.0s and it still keeps 17.0s.
-// ../guestAuth/index.ts states the exemption and what it buys.
+// ../../guestAuth/index.ts states the exemption and what it buys.
 //
 // What each path paid before this file existed: 16.0s on the guest upgrade - an 8.0s content drain
 // plus its two 4.0s writes - 8.0s on the sync push, and nothing at all on the review history import,
@@ -38,12 +38,12 @@
 // SET LOCAL / COMMIT round trips around the insert, nor the first `getAnalyticsPool()` of a cold
 // container, whose getDatabaseUrl() reaches Secrets Manager with SDK timeouts and retries of its own
 // (the product transaction that just committed has normally resolved that already, since
-// ../database/config.ts memoizes it process-wide, but nothing here guarantees it). The first
+// ../../database/config.ts memoizes it process-wide, but nothing here guarantees it). The first
 // post-commit operation of a cold invocation can therefore run past 4s and carry the whole tail past
 // the figures above, so read them as the shape of the bound and not as an unconditional cap.
 // Second, the budget bounds only the stages wired to it - the content creations drain, the review
 // answers drain and the guest upgrade's completion event. recordFriendshipCreatedAnalytics
-// (../community/analytics.ts) runs two sequential post-commit writes, and the catalog install and ai
+// (../../community/analytics.ts) runs two sequential post-commit writes, and the catalog install and ai
 // message producers one each, none of them drawing on a budget, so a request that reaches one of
 // those pays its cost outside this bound; wiring them in is separate work.
 //

--- a/apps/backend/src/productAnalytics/serverFacts/reviewAnswers.ts
+++ b/apps/backend/src/productAnalytics/serverFacts/reviewAnswers.ts
@@ -1,5 +1,5 @@
-import { transactionWithWorkspaceScopeDeadline, type DatabaseExecutor } from "../database";
-import { getDatabaseErrorFields } from "../database/transient";
+import { transactionWithWorkspaceScopeDeadline, type DatabaseExecutor } from "../../database";
+import { getDatabaseErrorFields } from "../../database/transient";
 // Report through `observability/runtime`, never through `observability/sentry`. This is the shared
 // discipline for product analytics producers, spelled out at length in contentCreations.ts:
 // `entrypoints/directImageIngestion/lambda.test.ts` walks the direct image ingestion Lambda's
@@ -13,15 +13,15 @@ import { getDatabaseErrorFields } from "../database/transient";
 import {
   captureBackendRuntimeWarning,
   createBackendObservationScope,
-} from "../observability/runtime";
-import type { ProductAnalyticsPlatform } from "./catalog";
+} from "../../observability/runtime";
+import type { ProductAnalyticsPlatform } from "../catalog";
 import type { PostCommitAnalyticsBudget } from "./postCommitBudget";
 import {
   deriveServerDerivedProductAnalyticsEventId,
   emitServerDerivedProductAnalyticsEvents,
   type ServerDerivedProductAnalyticsEvent,
 } from "./serverEvents";
-import { productAnalyticsMaxEventAgeMs } from "./validation";
+import { productAnalyticsMaxEventAgeMs } from "../validation";
 
 // db/migrations/0001_initial_schema.sql declares content.review_events.rating as
 // SMALLINT NOT NULL CHECK (rating BETWEEN 0 AND 3), and its column comment names the four values:
@@ -533,7 +533,7 @@ function reportAbandonedReviewAnswers(
  * Awaited, and that cannot lengthen the review write: the transaction has committed and released its
  * locks before the first chunk is built. Nothing here is left running past the response instead,
  * because a Lambda container is frozen and killed unpredictably and anything buffered across that
- * would be lost silently, which is the invariant ./writer.ts states and every sibling producer keeps.
+ * would be lost silently, which is the invariant ../writer.ts states and every sibling producer keeps.
  *
  * A chunk is one analytics transaction on one analytics connection and the chunks are awaited in
  * sequence, so this producer holds one connection at a time however large the transaction was. The

--- a/apps/backend/src/productAnalytics/serverFacts/serverEvents.postgres.integration.ts
+++ b/apps/backend/src/productAnalytics/serverFacts/serverEvents.postgres.integration.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
-import type { ProductAnalyticsEventName } from "./catalog";
+import type { ProductAnalyticsEventName } from "../catalog";
 import { deriveServerDerivedProductAnalyticsEventId } from "./serverEvents";
 
 // analytics.derive_server_event_id (migration 0119) is a hand-written twin of

--- a/apps/backend/src/productAnalytics/serverFacts/serverEvents.ts
+++ b/apps/backend/src/productAnalytics/serverFacts/serverEvents.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { getDatabaseErrorFields } from "../database/transient";
+import { getDatabaseErrorFields } from "../../database/transient";
 // Report through `observability/runtime`, never through `observability/sentry`, for the reason
 // spelled out in contentCreations.ts: the content-creation drain calls the batch emission below, and
 // it runs inside the direct image ingestion Lambda's import graph, whose bundle must reach no
@@ -9,15 +9,15 @@ import { getDatabaseErrorFields } from "../database/transient";
 import {
   captureBackendRuntimeWarning,
   createBackendObservationScope,
-} from "../observability/runtime";
+} from "../../observability/runtime";
 import {
   productAnalyticsSchemaVersion,
   type ProductAnalyticsEventName,
   type ProductAnalyticsEventProperties,
   type ProductAnalyticsPlatform,
-} from "./catalog";
-import type { ProductAnalyticsEventDetails, ProductAnalyticsEventRow } from "./types";
-import { insertProductAnalyticsEvents, insertProductAnalyticsIdentityLink } from "./writer";
+} from "../catalog";
+import type { ProductAnalyticsEventDetails, ProductAnalyticsEventRow } from "../types";
+import { insertProductAnalyticsEvents, insertProductAnalyticsIdentityLink } from "../writer";
 
 // A server-derived emission carries only what the backend observed itself. There is no field for
 // client context here on purpose: the row below leaves client_occurred_at, client_sent_at,

--- a/apps/backend/src/sync/replication/bootstrap.ts
+++ b/apps/backend/src/sync/replication/bootstrap.ts
@@ -3,7 +3,7 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../../database";
-import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/contentCreations";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/serverFacts/contentCreations";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
 import { HttpError } from "../../shared/errors";
 import {

--- a/apps/backend/src/sync/replication/push.ts
+++ b/apps/backend/src/sync/replication/push.ts
@@ -7,9 +7,9 @@ import {
   type CurrentUserPublicProfileResolver,
 } from "../../community/reviewActivityFacts";
 import type { DatabaseExecutor } from "../../database";
-import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/contentCreations";
-import { createPostCommitAnalyticsBudget } from "../../productAnalytics/postCommitBudget";
-import { runTransactionReportingReviewAnswers } from "../../productAnalytics/reviewAnswers";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../productAnalytics/serverFacts/contentCreations";
+import { createPostCommitAnalyticsBudget } from "../../productAnalytics/serverFacts/postCommitBudget";
+import { runTransactionReportingReviewAnswers } from "../../productAnalytics/serverFacts/reviewAnswers";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
 import { normalizeIsoTimestamp } from "../conflicts/lww";
 import { ensureWorkspaceReplicaInExecutor } from "../identity/replica";

--- a/apps/backend/src/sync/replication/reviewHistory.ts
+++ b/apps/backend/src/sync/replication/reviewHistory.ts
@@ -4,8 +4,8 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../../database";
-import { createPostCommitAnalyticsBudget } from "../../productAnalytics/postCommitBudget";
-import { runTransactionReportingReviewAnswers } from "../../productAnalytics/reviewAnswers";
+import { createPostCommitAnalyticsBudget } from "../../productAnalytics/serverFacts/postCommitBudget";
+import { runTransactionReportingReviewAnswers } from "../../productAnalytics/serverFacts/reviewAnswers";
 import { HttpError } from "../../shared/errors";
 import { ensureWorkspaceReplicaInExecutor } from "../identity/replica";
 import { annotateSyncConflictHttpError } from "../conflicts/fork";

--- a/apps/backend/src/workspacePackages/import/apply/importCards.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importCards.ts
@@ -9,7 +9,7 @@ import type {
   DatabaseExecutor,
   WorkspaceDatabaseScope,
 } from "../../../database";
-import { transactionWithWorkspaceScopeReportingContentCreations } from "../../../productAnalytics/contentCreations";
+import { transactionWithWorkspaceScopeReportingContentCreations } from "../../../productAnalytics/serverFacts/contentCreations";
 import { HttpError } from "../../../shared/errors";
 import { workspacePackageImportZipDefaultMaxCards } from "../importZip";
 import {


### PR DESCRIPTION
## Summary

- move server-originated analytics lifecycle modules under `productAnalytics/serverFacts/`
- preserve narrow direct imports across Lambda entrypoints
- update the explicit PostgreSQL integration-test path

## Validation

- local project checks intentionally not run; cloud PR CI owns validation