### PR TITLE
Stop paging on undeliverable sign-in addresses

### DIFF
--- a/apps/auth/src/agentAuthRoutes.test.ts
+++ b/apps/auth/src/agentAuthRoutes.test.ts
@@ -137,7 +137,7 @@ test("agent send-code uses Cognito OTP for non-demo emails", async () => {
   const app = createAgentSendCodeApp({
     initiateEmailOtp: async (email) => {
       initiateEmailOtpCalled = true;
-      assert.equal(email, "user@example.com");
+      assert.equal(email, "user@flashcards-open-source-app.com");
       return { session: "cognito-session-1" };
     },
     getDemoEmailPassword: async () => null,
@@ -159,7 +159,7 @@ test("agent send-code uses Cognito OTP for non-demo emails", async () => {
       "content-type": "application/json",
     },
     body: JSON.stringify({
-      email: "user@example.com",
+      email: "user@flashcards-open-source-app.com",
     }),
   });
 
@@ -167,7 +167,7 @@ test("agent send-code uses Cognito OTP for non-demo emails", async () => {
 
   assert.equal(response.status, 200);
   assert.equal(payload.ok, true);
-  assert.equal(payload.data.email, "user@example.com");
+  assert.equal(payload.data.email, "user@flashcards-open-source-app.com");
   assert.equal(payload.data.otpSessionToken, "AGENT-OTP-TOKEN");
   assert.equal(payload.actions[0]?.name, "verify_code");
   assert.deepEqual(payload.docs, {
@@ -191,7 +191,7 @@ test("agent send-code avoids retry-after guidance after post-email transient DB 
   const app = createAgentSendCodeApp({
     initiateEmailOtp: async (email) => {
       initiateEmailOtpCalled = true;
-      assert.equal(email, "user@example.com");
+      assert.equal(email, "user@flashcards-open-source-app.com");
       return { session: "cognito-session-1" };
     },
     getDemoEmailPassword: async () => null,
@@ -212,7 +212,7 @@ test("agent send-code avoids retry-after guidance after post-email transient DB 
       "content-type": "application/json",
     },
     body: JSON.stringify({
-      email: "user@example.com",
+      email: "user@flashcards-open-source-app.com",
     }),
   });
 

--- a/apps/auth/src/otpRouteTransientErrors.test.ts
+++ b/apps/auth/src/otpRouteTransientErrors.test.ts
@@ -53,7 +53,7 @@ test("send-code returns non-retry-guided 503 after post-email transient DB failu
   const app = createTestApp(createSendCodeApp({
     initiateEmailOtp: async (email) => {
       initiateEmailOtpCalled = true;
-      assert.equal(email, "user@example.com");
+      assert.equal(email, "user@flashcards-open-source-app.com");
       return { session: "cognito-session-1" };
     },
     signInWithPassword: async () => {
@@ -84,7 +84,7 @@ test("send-code returns non-retry-guided 503 after post-email transient DB failu
       "content-type": "application/json",
     },
     body: JSON.stringify({
-      email: "user@example.com",
+      email: "user@flashcards-open-source-app.com",
     }),
   });
   const payload = await response.json() as ServiceUnavailableResponse;

--- a/apps/auth/src/routes/agent/agentSendCode.ts
+++ b/apps/auth/src/routes/agent/agentSendCode.ts
@@ -15,6 +15,7 @@ import { initiateEmailOtp } from "../../server/cognito/cognitoAuth.js";
 import { type AuthAppEnv, getRequestId } from "../../server/apiErrors.js";
 import { createAgentEnvelope, createAgentErrorEnvelope } from "../../server/agent/agentEnvelope.js";
 import { getDemoEmailPassword } from "../../server/demoEmailAccess.js";
+import { isReservedEmailDomain } from "../../server/reservedEmailDomains.js";
 import {
   createAgentOtpChallenge,
   reissueLatestAgentOtpChallenge,
@@ -142,6 +143,31 @@ export function createAgentSendCodeApp(dependencies: AgentSendCodeDependencies):
         }],
         DEMO_SEND_CODE_INSTRUCTIONS,
       ));
+    }
+
+    // Placed after the demo lookup on purpose: the review account allowlist above is restricted to
+    // @example.com, so refusing reserved domains any earlier would break Apple and Google sign-in.
+    // Cognito accepts these addresses and the asynchronous custom email sender cannot report back,
+    // so without this branch the agent is told a code was sent that Resend permanently refuses.
+    if (isReservedEmailDomain(email)) {
+      log({
+        domain: "auth",
+        action: "agent_send_code_error",
+        requestId,
+        route: c.req.path,
+        statusCode: 400,
+        code: "INVALID_EMAIL",
+        reasonCategory: "reserved_email_domain",
+      });
+      return c.json(
+        createAgentErrorEnvelope(
+          c.req.url,
+          "INVALID_EMAIL",
+          "Enter a valid email address.",
+          "This address uses a reserved documentation or testing domain that cannot receive email. Ask the user for a real email address, then call POST /api/agent/send-code again.",
+        ),
+        400,
+      );
     }
 
     const ipAddress = getClientIpAddress(c.req.raw);

--- a/apps/auth/src/routes/browser/sendCode.ts
+++ b/apps/auth/src/routes/browser/sendCode.ts
@@ -23,6 +23,7 @@ import {
 import { setBrowserSessionCookies } from "../../server/browserSession.js";
 import { sign, verify } from "../../server/crypto.js";
 import { getDemoEmailPassword } from "../../server/demoEmailAccess.js";
+import { isReservedEmailDomain } from "../../server/reservedEmailDomains.js";
 import {
   decideOtpRateLimit,
   loadLatestSentOtpSessionToken,
@@ -166,6 +167,24 @@ export function createSendCodeApp(dependencies: SendCodeDependencies): Hono<Auth
         refreshToken: tokens.refreshToken,
         expiresIn: tokens.expiresIn,
       });
+    }
+
+    // Placed after the demo lookup on purpose: the review account allowlist above is restricted to
+    // @example.com, so refusing reserved domains any earlier would break Apple and Google sign-in.
+    // Cognito accepts these addresses and the asynchronous custom email sender cannot report back,
+    // so without this branch the person is told a code was sent that Resend permanently refuses.
+    if (isReservedEmailDomain(email)) {
+      log({
+        domain: "auth",
+        action: "send_code_error",
+        requestId,
+        route: c.req.path,
+        statusCode: 400,
+        code: "INVALID_EMAIL",
+        reasonCategory: "reserved_email_domain",
+      });
+      await reportSignInFailed(c, "server_error");
+      return jsonAuthError(c, 400, "INVALID_EMAIL", "Enter a valid email address.");
     }
 
     const ipAddress = getClientIpAddress(c.req.raw);

--- a/apps/auth/src/server/reservedEmailDomains.ts
+++ b/apps/auth/src/server/reservedEmailDomains.ts
@@ -1,0 +1,32 @@
+/**
+ * RFC 2606 reserved names exist for documentation and testing and can never
+ * receive mail, so the transactional email provider refuses them permanently.
+ *
+ * Entries are matched as domain suffixes: the reserved second-level domains and
+ * the reserved top-level domains, each also covering everything below them.
+ */
+const RESERVED_EMAIL_DOMAIN_SUFFIXES: ReadonlyArray<string> = [
+  "example.com",
+  "example.net",
+  "example.org",
+  "test",
+  "example",
+  "invalid",
+  "localhost",
+];
+
+function matchesDomainSuffix(domain: string, suffix: string): boolean {
+  return domain === suffix || domain.endsWith(`.${suffix}`);
+}
+
+/**
+ * Expects an address that already passed the caller's email format check.
+ */
+export function isReservedEmailDomain(email: string): boolean {
+  const domain = email.slice(email.lastIndexOf("@") + 1).trim().toLowerCase();
+  if (domain === "") {
+    return false;
+  }
+
+  return RESERVED_EMAIL_DOMAIN_SUFFIXES.some((suffix) => matchesDomainSuffix(domain, suffix));
+}

--- a/infra/aws/lambda/custom-email-sender/index.ts
+++ b/infra/aws/lambda/custom-email-sender/index.ts
@@ -295,6 +295,78 @@ export async function decryptSecretCode(
   return Buffer.from(plaintext).toString("utf-8");
 }
 
+const RESEND_VALIDATION_ERROR_STATUS = 422;
+const RESEND_VALIDATION_ERROR_NAME = "validation_error";
+const RESEND_TO_FIELD_REJECTION_PATTERN = /invalid\s+`?to`?\s+field/i;
+
+type ResendErrorBody = Readonly<{
+  message: string;
+  name: string;
+}>;
+
+function parseResendErrorBody(responseText: string): ResendErrorBody | null {
+  let parsedBody: unknown;
+  try {
+    parsedBody = JSON.parse(responseText);
+  } catch {
+    return null;
+  }
+
+  if (parsedBody === null || typeof parsedBody !== "object") {
+    return null;
+  }
+
+  const { message, name } = parsedBody as Readonly<Record<string, unknown>>;
+  if (typeof message !== "string" || typeof name !== "string") {
+    return null;
+  }
+
+  return { message, name };
+}
+
+/**
+ * Resend refuses an address it will never deliver to, such as an RFC 2606 reserved domain, with
+ * `422 validation_error` and a message naming the `to` field.
+ *
+ * Do not simplify this to status-and-name matching: Resend reuses `validation_error` for
+ * account-wide sending failures such as an unverified sending domain, so that would swallow a total
+ * sending outage and leave `CustomEmailSenderLambdaErrorAlarm` silent. Requiring positive evidence
+ * that the recipient is at fault keeps the failure direction safe — a reworded message stops
+ * matching and the send throws again, which pages but never hides.
+ */
+function isPermanentRecipientRejection(statusCode: number, responseText: string): boolean {
+  if (statusCode !== RESEND_VALIDATION_ERROR_STATUS) {
+    return false;
+  }
+
+  const errorBody = parseResendErrorBody(responseText);
+  if (errorBody === null || errorBody.name !== RESEND_VALIDATION_ERROR_NAME) {
+    return false;
+  }
+
+  return RESEND_TO_FIELD_REJECTION_PATTERN.test(errorBody.message);
+}
+
+function reportPermanentRecipientRejection(
+  payload: ResendEmailPayload,
+  statusCode: number,
+  responseText: string,
+): void {
+  Sentry.withScope((scope) => {
+    scope.setTag("action", "custom_email_sender_permanent_recipient_rejection");
+    // Keys and values are chosen to survive `scrubCustomEmailSenderEvent`: a `statusCode` key
+    // matches SENSITIVE_KEY_PATTERN, and even a masked address still matches EMAIL_PATTERN, so both
+    // would arrive redacted. The bare domain names the refused recipient without exposing anyone.
+    scope.setContext("custom_email_sender", {
+      recipientDomain: payload.toEmail.slice(payload.toEmail.lastIndexOf("@") + 1),
+      resendErrorBody: responseText,
+      resendStatus: statusCode,
+      subject: payload.subject,
+    });
+    Sentry.captureMessage("custom_email_sender_permanent_recipient_rejection", "warning");
+  });
+}
+
 export async function sendResendEmail(
   payload: ResendEmailPayload,
   fetchFn: FetchFunction,
@@ -335,6 +407,14 @@ export async function sendResendEmail(
     statusCode: response.status,
     subject: payload.subject,
   }));
+
+  if (isPermanentRecipientRejection(response.status, responseText)) {
+    // Cognito invokes this trigger asynchronously and retries a failed invocation twice, so throwing
+    // on a rejection that can never succeed only multiplies the Lambda error metric that pages.
+    reportPermanentRecipientRejection(payload, response.status, responseText);
+    return;
+  }
+
   throw new Error(`Resend email send failed with status ${response.status}: ${responseText}`);
 }
 


### PR DESCRIPTION
On 2026-09-01 `CustomEmailSenderLambdaErrorAlarm` fired for a sign-in requested on an `@example.com` address. Resend answered `422 validation_error` ("Invalid `to` field..."), `sendResendEmail` threw, and because Cognito invokes the custom sender trigger asynchronously Lambda retried each failure twice — two attempts became six error datapoints against a threshold of one per 15 minutes. Retrying a recipient rejection can never succeed, so all six were noise.

## What changes

- `sendResendEmail` returns instead of throwing when Resend permanently refuses **the recipient**, and reports that case to Sentry as a handled event so it stays visible without paging.
- The guard requires positive evidence that the recipient is at fault: status `422`, body name `validation_error`, **and** a message naming the `to` field. Resend serves the same `validation_error` name at `403` for account-wide sending failures (unverified domain, sending restrictions), so `401`/`403`/`429`/`5xx` and any reworded message keep throwing and keep paging. The failure direction is deliberately safe: if Resend changes its copy, the predicate stops matching and we return to today's noisy-but-correct behaviour.
- The Sentry context reports `recipientDomain` (bare domain, no `@`) and `resendStatus` rather than `maskedEmail`/`statusCode`, because the module's own scrubber would otherwise redact both — `statusCode` matches its sensitive-key pattern and the masked address matches its email pattern.
- Both send-code routes refuse RFC 2606 reserved domains with their existing `400 INVALID_EMAIL`, so a bogus address gets an honest error instead of a silent "code sent".

## The ordering that matters

The review-account allowlist in `apps/auth/src/server/demoEmailAccess.ts` is restricted to `@example.com` addresses. The reserved-domain refusal therefore sits **after** the allowlist lookup in both routes — refusing earlier would break App Store and Play review sign-in. The live and smoke consumers that depend on this (`FLASHCARDS_LIVE_REVIEW_EMAIL`, `check-agent-api-smoke.sh`, `check-mcp-smoke.sh`) all use the allowlisted address and still take the demo branch.

## Tests

No new unit tests, per the repository testing policy. Three existing route tests drove the non-demo path with `user@example.com`, which now legitimately returns `400`; their address is changed to a real domain.

## Known residual

A user-typo domain that Resend refuses with one of its *documented* `422` names, or accepts and then hard-bounces, still behaves as before. Both are the deliberate safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)