### PR TITLE
Bound agent SQL execution with a database time budget

### DIFF
--- a/apps/backend/src/aiTools/agentSql.ts
+++ b/apps/backend/src/aiTools/agentSql.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto";
 import { createAgentEnvelope } from "../agent/envelope";
+import {
+  DatabaseDeadlineExceededError,
+  runDatabaseOperationsWithDeadline,
+} from "../database";
+import { getDatabaseErrorFields } from "../database/transient";
 import { HttpError } from "../shared/errors";
 import { logAgentSqlEvent } from "../server/logging";
 import {
@@ -288,6 +293,157 @@ function getAgentSqlErrorClass(error: unknown): string {
 }
 
 /**
+ * Wall-clock budget for the database work of one agent SQL execution.
+ *
+ * Nothing else bounds how long an agent's statement runs: the dialect's row
+ * limits bound what comes back, not the work it takes to get there. The
+ * tightest surface such a statement reaches is MCP, whose Lambda is killed at
+ * 30 s and whose HTTP API integration gives up at 29 s
+ * (`infra/aws/lib/gateways/mcp-gateway.ts`), and a killed Lambda answers
+ * nothing at all: the caller gets an opaque API Gateway 5xx, the `agent_sql`
+ * record below is never written, and the invocation counts as a Lambda error.
+ *
+ * The 29 s is not all this budget's to spend, and what is left of it is the
+ * value:
+ *
+ *   29 s  MCP integration timeout
+ *   - 8 s post-commit analytics tail
+ *   - 6 s cold start, token verification, envelope building and the response
+ *   = 15 s
+ *
+ * The tail is the term this deadline cannot shorten. A write that commits then
+ * drains the server facts it collected on the analytics pool, outside this
+ * deadline and after the transaction returned, for up to the 4 s budget plus
+ * one operation of up to 4 s already in flight
+ * (`apps/backend/src/productAnalytics/serverFacts/postCommitBudget.ts`, which
+ * sizes that ceiling against the same 29 s). Its wall time is therefore
+ * additive: at 20 s this budget would leave a committing write about a second
+ * of the request for everything else, which is the killed Lambda again.
+ *
+ * The 6 s is the rest of one MCP request: a VPC cold start that loads a secret
+ * and opens a TLS connection to Postgres, OAuth token verification, SQL
+ * parsing, and the envelope and JSON response after the statement. Far above
+ * what a warm invocation spends, and well under the 10 s the direct image
+ * ingestion route reserves for its own on-demand init
+ * (`directImageIngestionMaximumOnDemandInitSeconds`), whose Lambda carries the
+ * sharp bundle this one does not.
+ *
+ * What the value costs, stated rather than hidden. Against a median execution
+ * of 80 ms, the slowest this surface has served were a five-statement batch at
+ * 17.0 s and a SELECT returning four rows at 13.8 s, whose cost is the scan
+ * behind the rows and not the rows. Both were measured before this deadline,
+ * and the deadline is not free: publishing one moves the execution onto the
+ * `deadline.ts` executor, which re-arms `statement_timeout` and `lock_timeout`
+ * against the remaining budget before every statement, so each executor query
+ * costs a second round trip. Their number follows rows touched rather than the
+ * caller's statement count - one affected row on the mutation path is four
+ * executor queries, so a full `MAX_SQL_BATCH_STATEMENT_COUNT` x
+ * `MAX_SQL_RECORD_LIMIT` batch is tens of thousands of them. Less therefore
+ * fits under 15 s than those two wall times suggest: the batch ends in the
+ * error below instead of answering, and the SELECT is marginal at best. That is
+ * the intent - both are on the same curve as the two executions that reached
+ * 30 s and killed the Lambda - and raising the value to keep them is what the
+ * arithmetic above forbids. Re-arming once per transaction would buy the cost
+ * back and is deliberately not done: a timeout armed at transaction start with
+ * the whole budget lets a late statement outlive the deadline on the server,
+ * which is the runaway this exists to prevent.
+ */
+const AGENT_SQL_DATABASE_TIME_BUDGET_MS = 15_000;
+
+// Bounds the cause walk below, which follows errors this process wrapped rather than any input, so
+// the real chains are one or two links long. The bound only keeps a cyclic `cause` from hanging a
+// request thread.
+const AGENT_SQL_ERROR_CAUSE_MAX_DEPTH = 8;
+
+function matchesDatabaseTimeBudgetExpiry(error: unknown): boolean {
+  if (error instanceof DatabaseDeadlineExceededError) {
+    return true;
+  }
+
+  const { sqlState } = getDatabaseErrorFields(error);
+  return sqlState === "57014" || sqlState === "55P03";
+}
+
+/**
+ * Recognizes every way that budget expires. One deadline becomes three bounds
+ * in `apps/backend/src/database/deadline.ts`: a client-side timer, a Postgres
+ * `statement_timeout`, and a `lock_timeout` derived from the same deadline. So
+ * the same expiry arrives as a `DatabaseDeadlineExceededError`, as SQLSTATE
+ * 57014, or as SQLSTATE 55P03, depending on which of them fired first.
+ *
+ * The cause chain is walked because a batch reaches this through
+ * `wrapBatchExecutionError`, which reports which statement failed and keeps the
+ * failure it wraps as the `cause`. Reading only the outermost error would
+ * classify every batch expiry as an unexpected server error, on the very shape
+ * that spends the most time.
+ */
+function isAgentSqlDatabaseTimeBudgetExpiry(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < AGENT_SQL_ERROR_CAUSE_MAX_DEPTH; depth += 1) {
+    if (matchesDatabaseTimeBudgetExpiry(current)) {
+      return true;
+    }
+    if (!(current instanceof Error)) {
+      return false;
+    }
+    current = current.cause;
+  }
+
+  return false;
+}
+
+/**
+ * Keeps whatever context wrapped the expiry in front of the remedy. For a batch
+ * that context is `wrapBatchExecutionError`'s `SQL batch statement N failed`,
+ * the only thing that says which statement of the batch spent the budget, and
+ * the locator every other batch failure on this surface already carries. It is
+ * dropped when the expiry is the outermost error, where the driver's own
+ * wording says nothing the remedy does not.
+ *
+ * That context can quote the caller's own SQL back to them, which is fine here
+ * and is why the `agent_sql` record deliberately carries no message at all.
+ */
+function buildDatabaseTimeBudgetExpiryMessage(error: unknown): string {
+  const remedy = `The statement exceeded the ${AGENT_SQL_DATABASE_TIME_BUDGET_MS} ms database time budget and was cancelled, so it changed nothing. Narrow the work and retry: add or lower LIMIT, add WHERE filters to touch fewer rows, or split a batch into fewer statements.`;
+  if (matchesDatabaseTimeBudgetExpiry(error)) {
+    return remedy;
+  }
+
+  const context = error instanceof Error ? error.message : String(error);
+  return `${context} ${remedy}`;
+}
+
+/**
+ * Runs one execution's database work under the budget above and reports an
+ * expired budget the way the result-size budget reports an oversized payload:
+ * an actionable 400 naming the limit, rather than the opaque INTERNAL_ERROR
+ * that an unmapped driver error becomes on both the MCP and the REST surface.
+ * Nothing survives the cancellation, since the statement takes its transaction
+ * down with it, so the caller is told to narrow the work rather than to go and
+ * check what landed.
+ */
+async function executeWithinDatabaseTimeBudget<Result extends AgentSqlExecutionResult>(
+  execute: () => Promise<AgentSqlEmission<Result>>,
+): Promise<AgentSqlEmission<Result>> {
+  try {
+    return await runDatabaseOperationsWithDeadline(
+      Date.now() + AGENT_SQL_DATABASE_TIME_BUDGET_MS,
+      execute,
+    );
+  } catch (error) {
+    if (!isAgentSqlDatabaseTimeBudgetExpiry(error)) {
+      throw error;
+    }
+
+    throw new HttpError(
+      400,
+      buildDatabaseTimeBudgetExpiryMessage(error),
+      "QUERY_TIME_LIMIT_EXCEEDED",
+    );
+  }
+}
+
+/**
  * Emits exactly one structured `agent_sql` record per execution, on success and
  * on failure alike, so the failure ratio of the agent SQL surface is computable
  * per surface and per caller instead of being invisible.
@@ -311,8 +467,14 @@ function getAgentSqlErrorClass(error: unknown): string {
  * helpers already measured for it, so `resultChars` is the size of the payload
  * the surface really sent and can never drift from the size the guard enforces.
  *
- * Instrumentation only: the caller's result is returned and the caller's error
- * is rethrown untouched.
+ * The wrapped execution is also the one place every agent SQL surface passes
+ * through, so it is where the database time budget is applied. It bounds the
+ * database work of the execution, not `durationMs`, which is measured from here
+ * and so also covers the post-commit server-facts drain that the budget
+ * deliberately leaves outside itself: a committing write is legitimately
+ * recorded above the budget by that tail. An execution the budget cancels is
+ * recorded here as a failure like any other. Nothing else is changed on the way
+ * through.
  */
 async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
   context: AgentSqlContext,
@@ -331,7 +493,7 @@ async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
   };
 
   try {
-    const { result, resultChars } = await execute();
+    const { result, resultChars } = await executeWithinDatabaseTimeBudget(execute);
     logAgentSqlEvent({
       ...executionDetails,
       succeeded: true,

--- a/apps/backend/src/aiTools/agentSql/shared.ts
+++ b/apps/backend/src/aiTools/agentSql/shared.ts
@@ -545,13 +545,28 @@ export function previewSqlStatement(sql: string): string {
   return sql.length <= 120 ? sql : `${sql.slice(0, 117)}...`;
 }
 
+/**
+ * Names the failing statement of a batch, which the executors otherwise lose, and keeps the failure
+ * it wraps as the `cause`.
+ *
+ * The message and the HTTP status are not the whole error here: a database failure also carries the
+ * class and the SQLSTATE that classifiers read to map it to something actionable, and a rewrite that
+ * kept only the status and the code would silently reclassify every such failure in a batch. The
+ * agent SQL time budget (../agentSql.ts) is the first classifier to depend on this.
+ */
 export function wrapBatchExecutionError(error: unknown, statementIndex: number, sql: string): never {
   const message = error instanceof Error ? error.message : String(error);
   const prefixedMessage = `SQL batch statement ${statementIndex + 1} failed: ${message}. Statement: ${previewSqlStatement(sql)}`;
 
   if (error instanceof HttpError) {
-    throw new HttpError(error.statusCode, prefixedMessage, error.code ?? undefined, error.details ?? undefined);
+    throw new HttpError(
+      error.statusCode,
+      prefixedMessage,
+      error.code ?? undefined,
+      error.details ?? undefined,
+      error,
+    );
   }
 
-  throw new Error(prefixedMessage);
+  throw new Error(prefixedMessage, { cause: error });
 }

--- a/apps/backend/src/shared/errors.ts
+++ b/apps/backend/src/shared/errors.ts
@@ -119,13 +119,16 @@ export class HttpError extends Error {
   readonly code: string | null;
   readonly details: HttpErrorDetails | null;
 
+  // `cause` carries the error this one was built from, for a caller that rewrites a failure into a
+  // new HttpError and would otherwise leave a classifier with nothing but the status and the code.
   constructor(
     statusCode: number,
     message: string,
     code?: string,
     details?: HttpErrorDetails,
+    cause?: unknown,
   ) {
-    super(message);
+    super(message, cause === undefined ? undefined : { cause });
     this.statusCode = statusCode;
     this.code = code ?? null;
     this.details = details ?? null;

--- a/db/migrations/0124_backend_app_statement_timeout.sql
+++ b/db/migrations/0124_backend_app_statement_timeout.sql
@@ -1,0 +1,33 @@
+-- Migration status: Current / additive.
+-- Introduces: a role-level statement_timeout for backend_app, which had none. It is the last-resort
+--   bound on a single statement issued by the application runtime role, for the case where the
+--   client that issued it is already gone: PostgreSQL does not stop a running statement when its
+--   client disappears, and the RDS log for the 2026-09-01 MCP incident window, where two
+--   invocations were killed at the Lambda's own 30-second timeout, carries "could not receive data
+--   from client: Connection reset by peer".
+-- Schemas touched/read explicitly: none. ALTER ROLE stores a role-level configuration default and
+--   resolves no schema object.
+
+-- This is a guard, not a budget. It bounds one statement, not one invocation, and it is not what
+-- keeps a request responsive: a path that needs a real budget sets its own per-transaction
+-- SET LOCAL statement_timeout and lock_timeout (apps/backend/src/database/deadline.ts), which
+-- overrides this default wherever it applies. Agent-written SQL, the traffic that raised the
+-- incident above, is bounded that way in apps/backend/src/aiTools/agentSql.ts.
+--
+-- 300 seconds is deliberately far above every statement this product issues, because a value close
+-- to real work would turn a last-resort guard into an unpredictable failure mode. backend_app is
+-- the runtime role of the backend API handler, the chat worker, the chat live handler, the MCP
+-- handler, the direct image ingestion handler, the scheduled jobs and the catalog dump. Their
+-- Lambda budgets range from 15 seconds to 15 minutes, but a Lambda budget covers a whole
+-- invocation: many statements, with model calls and object-storage work between them. A single
+-- statement still running after five minutes is a runaway, not a workload. This is why the value
+-- cannot be the 30 seconds that db/migrations/0044_reporting_readonly_role.sql sets on
+-- reporting_readonly.
+--
+-- A role-level setting is read when a session starts, so pooled connections already open in a warm
+-- Lambda container keep the old unbounded value until that container is replaced.
+--
+-- Migrations are unaffected: the migration runner connects with the database owner credentials
+-- (infra/aws/lib/migration-runner.ts), not as backend_app, so the long backfills that set their own
+-- SET LOCAL statement_timeout keep the value they chose.
+ALTER ROLE backend_app SET statement_timeout = '300s';


### PR DESCRIPTION
On 2026-09-01 two MCP `POST /v1` requests ran the full 30 s and were killed by Lambda (`platform.report` `status: "timeout"`, `producedBytes: 0`). `McpLambdaErrorAlarm` fired and the client got an opaque API Gateway `503`. RDS was healthy the whole time — CPU max 27 %, full CPU credits, sub-millisecond latency — so agent SQL simply had no time bound. The same session's slowest successful executions were 17.0 s and 13.8 s against a daily median of 80 ms.

## What changes

- Agent SQL runs inside `runDatabaseOperationsWithDeadline` with a **15 s** budget, wrapped at `withAgentSqlTelemetry` — the single choke point for the MCP `sql_query`/`sql_execute` tools, `POST /agent/sql/*`, and the in-app chat `sql` tool.
- An expiry becomes `400 QUERY_TIME_LIMIT_EXCEEDED` naming the budget and the remedy, so the Lambda answers normally instead of dying and the agent can narrow its own query.
- `wrapBatchExecutionError` previously rebuilt every batch failure from message and status alone, destroying the error class and the SQLSTATE the classifier reads — so on the batch path, the incident's own hot path, an expiry would still have surfaced as an opaque `INTERNAL_ERROR`. It now preserves the original as `cause`, `HttpError` accepts one, and the classifier walks the chain. The statement locator stays in front of the remedy, so a batch expiry reads `SQL batch statement N failed: … exceeded the 15000 ms database time budget`.
- Migration `0124` sets `statement_timeout = '300s'` on `backend_app` as a last-resort guard. Postgres does not stop a running scan when its client disappears, and the incident window contains `could not receive data from client: Connection reset by peer`.

## Why 15 s

`29 s integration timeout − 8 s post-commit analytics tail − 6 s cold start, token verification, envelope and response`. The analytics drain runs on its own pool outside this deadline and is additive, so it has to be subtracted rather than assumed away. Observed MCP cold start is ~723 ms, so the 6 s term is padded.

## Deliberate consequence

The previously observed 17.0 s five-statement batch no longer completes; it fails with the actionable 400. It cannot be kept — 17 + 8 = 25 s against a 30 s kill leaves 4 s, which is not headroom. It was previously succeeding three seconds from the incident outcome.

`configureTransactionTimeouts` is deliberately **not** hoisted out of the per-statement path, even though it costs a round trip per statement: it re-arms `statement_timeout` against the remaining budget, so issuing it once per transaction would let a late statement outlive the deadline server-side — precisely the runaway migration 0124 exists to bound.

## Tests

No new unit tests, per the repository testing policy. No existing test asserts on the changed messages or on `wrapBatchExecutionError`, so none became false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)