### PR TITLE
Suppress stale Android progress warnings after identity reset

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressSummaryIdentityTransitionIntegrationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressSummaryIdentityTransitionIntegrationTest.kt
@@ -1,0 +1,196 @@
+package com.flashcardsopensourceapp.data.local.repository.progress
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
+import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
+import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
+import com.flashcardsopensourceapp.data.local.repository.SyncRepository
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.FakeCloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.ProgressLocalCacheReadinessCoordinator
+import com.flashcardsopensourceapp.data.local.repository.progress.inputs.createProgressClockSnapshot
+import com.flashcardsopensourceapp.data.local.repository.progress.inputs.observeProgressInputs
+import com.flashcardsopensourceapp.data.local.repository.progress.orchestration.ProgressSummaryOrchestration
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressBackgroundLauncher
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressObservationVersions
+import com.flashcardsopensourceapp.data.local.repository.shared.SystemTimeProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProgressSummaryIdentityTransitionIntegrationTest {
+    private lateinit var environment: CloudIdentityTestEnvironment
+
+    @Before
+    fun setUp() = runBlocking {
+        environment = CloudIdentityTestEnvironment.create()
+    }
+
+    @After
+    fun tearDown() {
+        environment.close()
+    }
+
+    @Test
+    fun linkedRefreshQueuedAcrossIdentityResetDoesNotEmitRemoteLoadWarning() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val syncRepository = TestSyncRepository()
+        val observability = RecordingAppObservability()
+        val appJob = SupervisorJob(coroutineContext[Job])
+        val appScope = CoroutineScope(context = coroutineContext + appJob)
+
+        try {
+            environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+            val linkedInputs = observeProgressInputs(
+                database = environment.database,
+                preferencesStore = environment.cloudPreferencesStore,
+                syncRepository = syncRepository,
+                timeProvider = SystemTimeProvider
+            ).first()
+            assertEquals(CloudAccountState.LINKED, linkedInputs.cloudSettings.cloudState)
+            assertTrue(linkedInputs.syncStates.isNotEmpty())
+            val clockSnapshot = createProgressClockSnapshot(timeProvider = SystemTimeProvider)
+
+            val orchestration = ProgressSummaryOrchestration(
+                database = environment.database,
+                cloudAccountRepository = environment.createCloudAccountRepository(
+                    remoteGateway = remoteGateway
+                ),
+                syncRepository = syncRepository,
+                timeProvider = SystemTimeProvider,
+                cacheReadinessCoordinator = ProgressLocalCacheReadinessCoordinator(
+                    localProgressCacheStore = LocalProgressCacheStore(
+                        database = environment.database,
+                        timeProvider = SystemTimeProvider
+                    ),
+                    timeProvider = SystemTimeProvider
+                ),
+                backgroundLauncher = ProgressBackgroundLauncher(
+                    appScope = appScope,
+                    observability = observability,
+                    observationVersions = testObservationVersions
+                ),
+                observability = observability,
+                observationVersions = testObservationVersions
+            )
+            orchestration.handleInputs(
+                inputs = linkedInputs,
+                clockSnapshot = clockSnapshot
+            )
+            val handledInputs = orchestration.handleInputs(
+                inputs = linkedInputs.copy(
+                    syncStates = linkedInputs.syncStates.map { syncState ->
+                        syncState.copy(lastReviewSequenceId = syncState.lastReviewSequenceId + 1L)
+                    },
+                    syncStatus = linkedInputs.syncStatus.copy(lastSuccessfulSyncAtMillis = 200L)
+                ),
+                clockSnapshot = clockSnapshot
+            )
+            val lockAcquired = CompletableDeferred<Unit>()
+            val resetAllowed = CompletableDeferred<Unit>()
+            val lockJob = launch {
+                environment.operationCoordinator.runExclusive {
+                    lockAcquired.complete(Unit)
+                    resetAllowed.await()
+                    environment.resetCoordinator.resetLocalStateForCloudIdentityChange()
+                }
+            }
+            try {
+                lockAcquired.await()
+
+                orchestration.launchSyncCompletedRefreshIfNeeded(handledInputs = handledInputs)
+                val refreshJob = requireNotNull(appJob.children.singleOrNull()) {
+                    "Expected one queued Progress summary refresh."
+                }
+                yield()
+                assertFalse(refreshJob.isCompleted)
+
+                resetAllowed.complete(Unit)
+                lockJob.join()
+                refreshJob.join()
+
+                assertEquals(
+                    CloudAccountState.DISCONNECTED,
+                    environment.cloudPreferencesStore.currentCloudSettings().cloudState
+                )
+                assertTrue(observability.warnings.isEmpty())
+                assertTrue(observability.exceptions.isEmpty())
+            } finally {
+                resetAllowed.complete(Unit)
+                lockJob.join()
+            }
+        } finally {
+            appScope.cancel()
+        }
+    }
+}
+
+private class TestSyncRepository : SyncRepository {
+    private val status = MutableStateFlow(
+        SyncStatusSnapshot(
+            status = SyncStatus.Idle,
+            lastSuccessfulSyncAtMillis = 100L,
+            lastErrorMessage = ""
+        )
+    )
+
+    override fun observeSyncStatus(): Flow<SyncStatusSnapshot> {
+        return status
+    }
+
+    override suspend fun scheduleSync() {
+        error("Sync is not expected for a sync-completed Progress refresh.")
+    }
+
+    override suspend fun syncNow() {
+        error("Sync is not expected for a sync-completed Progress refresh.")
+    }
+}
+
+private class RecordingAppObservability : AppObservability {
+    val warnings = mutableListOf<AndroidWarningIssueEvent>()
+    val exceptions = mutableListOf<AndroidExceptionIssueEvent>()
+
+    override fun setCloudIdentity(identity: CloudObservationIdentity) = Unit
+
+    override fun clearCloudIdentity() = Unit
+
+    override fun addBreadcrumb(event: AndroidBreadcrumbEvent) = Unit
+
+    override fun captureWarning(event: AndroidWarningIssueEvent) {
+        warnings.add(event)
+    }
+
+    override fun captureException(event: AndroidExceptionIssueEvent) {
+        exceptions.add(event)
+    }
+}
+
+private val testObservationVersions = ProgressObservationVersions(
+    appVersion = "1.0.0",
+    clientVersion = "1.0.0",
+    versionCode = 1
+)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/progress/CloudProgressRemoteReader.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/progress/CloudProgressRemoteReader.kt
@@ -19,6 +19,12 @@ import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.Authe
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudSessionProvider
 
+internal class ProgressCloudIdentityTransitionException(
+    val cloudState: CloudAccountState
+) : IllegalStateException(
+    "Progress refresh crossed a cloud identity transition to ${cloudState.name}."
+)
+
 internal class CloudProgressRemoteReader(
     private val preferencesStore: CloudPreferencesStore,
     private val remoteService: CloudRemoteGateway,
@@ -147,8 +153,11 @@ internal class CloudProgressRemoteReader(
                 )
             }
 
-            else -> {
-                throw IllegalStateException("Progress requires a linked or guest cloud account.")
+            CloudAccountState.DISCONNECTED,
+            CloudAccountState.LINKING_READY -> {
+                throw ProgressCloudIdentityTransitionException(
+                    cloudState = cloudSettings.cloudState
+                )
             }
         }
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSummaryOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSummaryOrchestration.kt
@@ -3,9 +3,11 @@ package com.flashcardsopensourceapp.data.local.repository.progress.orchestration
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.progress.ProgressCloudIdentityTransitionException
 import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.ProgressLocalCacheReadinessCoordinator
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCacheEntity
@@ -24,7 +26,6 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
-import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreInputs
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
@@ -279,10 +280,8 @@ internal class ProgressSummaryOrchestration(
             throw error
         } catch (error: Exception) {
             if (
-                shouldSuppressProgressSummaryRemoteLoadWarning(
-                    latestStoreState = currentStoreState(),
-                    refreshStoreState = resolvedRefreshStoreState
-                )
+                error is ProgressCloudIdentityTransitionException &&
+                resolvedRefreshStoreState.cloudState == CloudAccountState.LINKED
             ) {
                 return
             }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
@@ -9,7 +9,6 @@ import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIo
 import com.flashcardsopensourceapp.data.local.network.isRetryableHttpStatusCode
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreState
-import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -205,23 +204,6 @@ internal fun supportsServerRefresh(
     cloudState: CloudAccountState
 ): Boolean {
     return cloudState == CloudAccountState.GUEST || cloudState == CloudAccountState.LINKED
-}
-
-internal fun shouldSuppressProgressSummaryRemoteLoadWarning(
-    latestStoreState: ProgressSummaryStoreState?,
-    refreshStoreState: ProgressSummaryStoreState
-): Boolean {
-    if (latestStoreState == null) {
-        return true
-    }
-    if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
-        return true
-    }
-    if (supportsServerRefresh(cloudState = latestStoreState.cloudState).not()) {
-        return true
-    }
-
-    return latestStoreState.isLocalCacheReady.not()
 }
 
 internal fun shouldSuppressProgressSeriesRemoteLoadWarning(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
@@ -7,16 +7,13 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewSched
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
-import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.isExpectedTransientProgressRefreshError
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressReviewScheduleRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSeriesRemoteLoadWarning
-import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreState
-import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
 import java.net.UnknownHostException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -62,77 +59,6 @@ class ProgressRemoteLoadWarningSuppressionTest {
         assertFalse(
             isExpectedTransientProgressRefreshError(
                 error = IllegalStateException("Progress sync invariant failed.")
-            )
-        )
-    }
-
-    @Test
-    fun summaryRemoteLoadWarningIsSuppressedOnlyForStaleState(): Unit {
-        val refreshStoreState: ProgressSummaryStoreState = createSummaryStoreState(
-            scopeId = "linked:user-1",
-            cloudState = CloudAccountState.LINKED,
-            isLocalCacheReady = true
-        )
-        val validLatestStoreState: ProgressSummaryStoreState = createSummaryStoreState(
-            scopeId = "linked:user-1",
-            cloudState = CloudAccountState.LINKED,
-            isLocalCacheReady = true
-        )
-        val changedScopeStoreState: ProgressSummaryStoreState = createSummaryStoreState(
-            scopeId = "linked:user-2",
-            cloudState = CloudAccountState.LINKED,
-            isLocalCacheReady = true
-        )
-        val disconnectedStoreState: ProgressSummaryStoreState = createSummaryStoreState(
-            scopeId = "linked:user-1",
-            cloudState = CloudAccountState.DISCONNECTED,
-            isLocalCacheReady = true
-        )
-        val linkingStoreState: ProgressSummaryStoreState = createSummaryStoreState(
-            scopeId = "linked:user-1",
-            cloudState = CloudAccountState.LINKING_READY,
-            isLocalCacheReady = true
-        )
-        val unreadyCacheStoreState: ProgressSummaryStoreState = createSummaryStoreState(
-            scopeId = "linked:user-1",
-            cloudState = CloudAccountState.LINKED,
-            isLocalCacheReady = false
-        )
-
-        assertFalse(
-            shouldSuppressProgressSummaryRemoteLoadWarning(
-                latestStoreState = validLatestStoreState,
-                refreshStoreState = refreshStoreState
-            )
-        )
-        assertTrue(
-            shouldSuppressProgressSummaryRemoteLoadWarning(
-                latestStoreState = null,
-                refreshStoreState = refreshStoreState
-            )
-        )
-        assertTrue(
-            shouldSuppressProgressSummaryRemoteLoadWarning(
-                latestStoreState = changedScopeStoreState,
-                refreshStoreState = refreshStoreState
-            )
-        )
-        assertTrue(
-            shouldSuppressProgressSummaryRemoteLoadWarning(
-                latestStoreState = disconnectedStoreState,
-                refreshStoreState = refreshStoreState
-            )
-        )
-        assertTrue(
-            shouldSuppressProgressSummaryRemoteLoadWarning(
-                latestStoreState = linkingStoreState,
-                refreshStoreState = refreshStoreState
-            )
-        )
-        assertTrue(
-            shouldSuppressProgressSummaryRemoteLoadWarning(
-                latestStoreState = unreadyCacheStoreState,
-                refreshStoreState = refreshStoreState
             )
         )
     }
@@ -262,26 +188,6 @@ class ProgressRemoteLoadWarningSuppressionTest {
             )
         )
     }
-
-}
-
-private fun createSummaryStoreState(
-    scopeId: String,
-    cloudState: CloudAccountState,
-    isLocalCacheReady: Boolean
-): ProgressSummaryStoreState {
-    return ProgressSummaryStoreState(
-        scopeKey = ProgressSummaryScopeKey(
-            scopeId = scopeId,
-            timeZone = testTimeZone,
-            referenceLocalDate = testDate
-        ),
-        cloudState = cloudState,
-        snapshot = null,
-        isLocalCacheReady = isLocalCacheReady,
-        reviewHistoryFingerprint = testFingerprint,
-        syncStatus = createTestSyncStatus()
-    )
 }
 
 private fun createSeriesStoreState(


### PR DESCRIPTION
## Summary

- model the stale Android Progress refresh caused by an identity reset as a narrow cloud identity-transition exception
- suppress only that expected linked-refresh race while preserving genuine remote-load warnings
- cover the linked-refresh/reset interaction with a real `data:local` instrumentation flow

## Scope

- leaves `analytics_identity_boundary_discarded` unchanged
- does not broaden or alter the telemetry schema
- does not trigger an Android release

## Validation

- fresh full static review: no P0-P4 issues
- local project checks intentionally not run; required GitHub PR CI owns executable validation
