### PR TITLE
Recover throttled chat live streams

### DIFF
--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.stream-rendering.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.stream-rendering.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { act } from "react";
+import { describe, expect, it, vi } from "vitest";
 import {
   ChatLiveContractErrorMock,
   ChatLiveHttpErrorMock,
   ChatLiveTransportErrorMock,
+  captureWebExceptionMock,
   consumeChatLiveStreamMock,
   createChatActiveRun,
   createChatSnapshot,
   getChatSnapshotMock,
   setupChatPanelTest,
+  startChatRunMock,
 } from "./support/ChatPanelTestSupport";
 
 const {
@@ -16,6 +19,7 @@ const {
   getContainer,
   renderChatPanel,
   sendMessage,
+  unmountChatPanel,
 } = setupChatPanelTest();
 
 function createRecoverableTransportError(): InstanceType<typeof ChatLiveTransportErrorMock> {
@@ -29,6 +33,25 @@ function createRecoverableTransportError(): InstanceType<typeof ChatLiveTranspor
     "TypeError",
     new TypeError("browser stream interrupted"),
   );
+}
+
+function createRecoverableAttachThrottleError(
+  retryAfterMs: number | null,
+): InstanceType<typeof ChatLiveHttpErrorMock> {
+  return new ChatLiveHttpErrorMock(
+    "AI live stream failed with status 429: Too Many Requests",
+    429,
+    "request-throttle-1",
+    null,
+    retryAfterMs,
+  );
+}
+
+async function advanceRecoveryDelay(delayMs: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(delayMs);
+  });
+  await flushAsync();
 }
 
 describe("ChatPanel stream rendering", () => {
@@ -152,6 +175,180 @@ describe("ChatPanel stream rendering", () => {
     expect(getContainer().querySelector('[role="dialog"]')).toBeNull();
   });
 
+  it("recovers a code-less live attach throttle with a terminal authoritative snapshot", async () => {
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot())
+      .mockResolvedValueOnce(createChatSnapshot({
+        sessionId: "session-1",
+        activeRun: null,
+        conversation: {
+          updatedAt: 2,
+          mainContentInvalidationVersion: 0,
+          messages: [{
+            role: "assistant",
+            content: [{ type: "text", text: "Persisted response after throttled attach" }],
+            timestamp: 2,
+            isError: false,
+            isStopped: false,
+          }],
+        },
+      }));
+    consumeChatLiveStreamMock.mockRejectedValueOnce(createRecoverableAttachThrottleError(10_000));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+
+    await advanceRecoveryDelay(3_999);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
+
+    await advanceRecoveryDelay(1);
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(1);
+    expect(getContainer().textContent).toContain("Persisted response after throttled attach");
+    expect(getContainer().querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("reattaches a zero-delay throttled active run only after the scheduled backoff", async () => {
+    const replacementActiveRun = createChatActiveRun({
+      live: {
+        cursor: "authoritative-cursor",
+        stream: {
+          url: "https://chat-live.example.com/authoritative",
+          authorization: "Live authoritative-token",
+          expiresAt: Date.now() + 60_000,
+        },
+      },
+    });
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot())
+      .mockResolvedValueOnce(createChatSnapshot({
+        sessionId: "session-1",
+        activeRun: replacementActiveRun,
+      }));
+    consumeChatLiveStreamMock
+      .mockRejectedValueOnce(createRecoverableAttachThrottleError(0))
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+
+    await advanceRecoveryDelay(499);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
+
+    await advanceRecoveryDelay(1);
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(2);
+    const replacementStreamParams = consumeChatLiveStreamMock.mock.calls[1]?.[0] as Readonly<{
+      liveStream: {
+        url: string;
+        authorization: string;
+      };
+      runId: string;
+      afterCursor: string | null;
+      resumeAttemptId: number | null;
+    }> | undefined;
+    expect(replacementStreamParams).toMatchObject({
+      liveStream: {
+        url: "https://chat-live.example.com/authoritative",
+        authorization: "Live authoritative-token",
+      },
+      runId: "run-1",
+      afterCursor: "authoritative-cursor",
+    });
+    expect(replacementStreamParams?.resumeAttemptId).not.toBeNull();
+    expect(getContainer().querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("does not let a Retry-After hint shorten a later scheduled backoff", async () => {
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot())
+      .mockResolvedValue(createChatSnapshot({
+        sessionId: "session-1",
+        activeRun: createChatActiveRun(),
+      }));
+    consumeChatLiveStreamMock
+      .mockRejectedValueOnce(createRecoverableAttachThrottleError(750))
+      .mockRejectedValueOnce(createRecoverableAttachThrottleError(750))
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+
+    await advanceRecoveryDelay(749);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
+
+    await advanceRecoveryDelay(1);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(2);
+
+    await advanceRecoveryDelay(999);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
+
+    await advanceRecoveryDelay(1);
+    expect(startChatRunMock).toHaveBeenCalledTimes(1);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(3);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("hard-fails exactly once after four throttled live attach recoveries", async () => {
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot())
+      .mockResolvedValue(createChatSnapshot({
+        sessionId: "session-1",
+        activeRun: createChatActiveRun(),
+      }));
+    consumeChatLiveStreamMock.mockImplementation(async () => {
+      throw createRecoverableAttachThrottleError(null);
+    });
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+
+    for (const delayMs of [500, 1_000, 2_000, 4_000]) {
+      await advanceRecoveryDelay(delayMs);
+    }
+
+    expect(startChatRunMock).toHaveBeenCalledTimes(1);
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(5);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(5);
+    expect(captureWebExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureWebExceptionMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "chat_live_stream_failed",
+      scope: expect.objectContaining({
+        requestId: "request-throttle-1",
+        statusCode: 429,
+        code: null,
+      }),
+    }));
+    expect(getContainer().querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it("cancels a pending throttle backoff when the chat surface unmounts", async () => {
+    getChatSnapshotMock.mockResolvedValueOnce(createChatSnapshot());
+    consumeChatLiveStreamMock.mockRejectedValueOnce(createRecoverableAttachThrottleError(null));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+    await unmountChatPanel();
+    await advanceRecoveryDelay(4_000);
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(1);
+    expect(captureWebExceptionMock).not.toHaveBeenCalled();
+  });
+
   it("keeps non-transport live errors on the hard-failure path", async () => {
     getChatSnapshotMock.mockResolvedValueOnce(createChatSnapshot());
     consumeChatLiveStreamMock.mockRejectedValueOnce(new TypeError("network changed"));
@@ -175,6 +372,27 @@ describe("ChatPanel stream rendering", () => {
         503,
         "request-http-1",
         "UPSTREAM_UNAVAILABLE",
+        null,
+      ),
+    ],
+    [
+      "coded HTTP 429",
+      () => new ChatLiveHttpErrorMock(
+        "AI live stream failed with status 429: Account rate limit reached",
+        429,
+        "request-http-2",
+        "CHAT_RATE_LIMITED",
+        1_000,
+      ),
+    ],
+    [
+      "other HTTP 4xx",
+      () => new ChatLiveHttpErrorMock(
+        "AI live stream failed with status 403: Forbidden",
+        403,
+        "request-http-3",
+        null,
+        null,
       ),
     ],
     [

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -124,13 +124,21 @@ const {
     readonly statusCode: number;
     readonly requestId: string | null;
     readonly code: string | null;
+    readonly retryAfterMs: number | null;
 
-    constructor(message: string, statusCode: number, requestId: string | null, code: string | null) {
+    constructor(
+      message: string,
+      statusCode: number,
+      requestId: string | null,
+      code: string | null,
+      retryAfterMs: number | null,
+    ) {
       super(message);
       this.name = "ChatLiveHttpError";
       this.statusCode = statusCode;
       this.requestId = requestId;
       this.code = code;
+      this.retryAfterMs = retryAfterMs;
     }
   },
   ChatLiveTransportErrorMock: class ChatLiveTransportError extends Error {

--- a/apps/web/src/chat/sessionController/snapshotSync/useLiveSession.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useLiveSession.ts
@@ -21,7 +21,23 @@ type ActiveLiveStreamConnection = Readonly<{
   abortController: AbortController;
 }>;
 
+type PendingLiveStreamRecovery = Readonly<{
+  sessionId: string;
+  runId: string;
+  abortController: AbortController;
+}>;
+
+type LiveAttachThrottleRecoveryBudget = Readonly<{
+  runId: string;
+  attemptCount: number;
+}>;
+
+type RecoverableLiveStreamError = ChatLiveHttpError | ChatLiveTransportError;
+
 type LiveStreamDisposition = "pending" | "terminal";
+
+const liveAttachThrottleRecoveryDelaysMs: ReadonlyArray<number> = [500, 1_000, 2_000, 4_000];
+const maximumLiveAttachThrottleRecoveryDelayMs = 4_000;
 
 type UseChatLiveSessionParams = Readonly<{
   applyLiveEvent: (event: ChatLiveEvent) => void;
@@ -31,7 +47,7 @@ type UseChatLiveSessionParams = Readonly<{
   onRecoverableStreamError: (
     sessionId: string,
     runId: string,
-    error: ChatLiveTransportError,
+    error: RecoverableLiveStreamError,
     previousResumeAttemptId: number | null,
   ) => void;
   onUnexpectedStreamEnd: (sessionId: string, runId: string) => void;
@@ -152,6 +168,56 @@ function isRecoverableLiveTransportError(
     );
 }
 
+function isRecoverableLiveAttachThrottle(error: unknown): error is ChatLiveHttpError {
+  return error instanceof ChatLiveHttpError
+    && error.statusCode === 429
+    && error.code === null;
+}
+
+function getLiveAttachThrottleRecoveryDelayMs(
+  error: ChatLiveHttpError,
+  attemptCount: number,
+): number | null {
+  const fallbackDelayMs = liveAttachThrottleRecoveryDelaysMs[attemptCount];
+  if (fallbackDelayMs === undefined) {
+    return null;
+  }
+
+  const retryAfterMs = error.retryAfterMs;
+  const requestedDelayMs = retryAfterMs !== null
+    && Number.isSafeInteger(retryAfterMs)
+    && retryAfterMs >= 0
+    ? retryAfterMs
+    : fallbackDelayMs;
+  return Math.min(
+    Math.max(fallbackDelayMs, requestedDelayMs),
+    maximumLiveAttachThrottleRecoveryDelayMs,
+  );
+}
+
+function waitForLiveAttachThrottleRecovery(delayMs: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const timerId = window.setTimeout(handleDelayCompleted, delayMs);
+
+    function handleDelayCompleted(): void {
+      signal.removeEventListener("abort", handleAbort);
+      resolve(true);
+    }
+
+    function handleAbort(): void {
+      window.clearTimeout(timerId);
+      signal.removeEventListener("abort", handleAbort);
+      resolve(false);
+    }
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+}
+
 /**
  * Owns the browser-side live SSE lifecycle for one visible chat surface.
  * Snapshot loading remains outside this hook. On resume, callers must refresh
@@ -171,6 +237,8 @@ export function useChatLiveSession(
   } = params;
   const [isLiveStreamConnected, setIsLiveStreamConnected] = useState<boolean>(false);
   const activeLiveConnectionRef = useRef<ActiveLiveStreamConnection | null>(null);
+  const pendingLiveStreamRecoveryRef = useRef<PendingLiveStreamRecovery | null>(null);
+  const liveAttachThrottleRecoveryBudgetRef = useRef<LiveAttachThrottleRecoveryBudget | null>(null);
   const preResponseRecoveryRunIdRef = useRef<string | null>(null);
   const isDocumentVisibleRef = useRef<boolean>(isDocumentVisible());
   const applyLiveEventRef = useRef<(event: ChatLiveEvent) => void>(applyLiveEvent);
@@ -179,7 +247,7 @@ export function useChatLiveSession(
   const onRecoverableStreamErrorRef = useRef<(
     sessionId: string,
     runId: string,
-    error: ChatLiveTransportError,
+    error: RecoverableLiveStreamError,
     previousResumeAttemptId: number | null,
   ) => void>(onRecoverableStreamError);
   const onUnexpectedStreamEndRef = useRef<(sessionId: string, runId: string) => void>(onUnexpectedStreamEnd);
@@ -190,21 +258,25 @@ export function useChatLiveSession(
 
   const detachLiveStream = useCallback((sessionId: string | null, runId: string | null): void => {
     const activeConnection = activeLiveConnectionRef.current;
-    if (activeConnection === null) {
-      return;
+    if (
+      activeConnection !== null
+      && (sessionId === null || activeConnection.sessionId === sessionId)
+      && (runId === null || activeConnection.runId === runId)
+    ) {
+      activeConnection.abortController.abort();
+      activeLiveConnectionRef.current = null;
+      setIsLiveStreamConnected(false);
     }
 
-    if (sessionId !== null && activeConnection.sessionId !== sessionId) {
-      return;
+    const pendingRecovery = pendingLiveStreamRecoveryRef.current;
+    if (
+      pendingRecovery !== null
+      && (sessionId === null || pendingRecovery.sessionId === sessionId)
+      && (runId === null || pendingRecovery.runId === runId)
+    ) {
+      pendingRecovery.abortController.abort();
+      pendingLiveStreamRecoveryRef.current = null;
     }
-
-    if (runId !== null && activeConnection.runId !== runId) {
-      return;
-    }
-
-    activeConnection.abortController.abort();
-    activeLiveConnectionRef.current = null;
-    setIsLiveStreamConnected(false);
   }, []);
 
   useEffect(() => {
@@ -251,6 +323,10 @@ export function useChatLiveSession(
   ): void => {
     detachLiveStream(null, null);
 
+    if (liveAttachThrottleRecoveryBudgetRef.current?.runId !== runId) {
+      liveAttachThrottleRecoveryBudgetRef.current = { runId, attemptCount: 0 };
+    }
+
     if (indexedDbOpenRecoveryState.hasFailed() || isDocumentVisibleRef.current === false) {
       return;
     }
@@ -290,6 +366,7 @@ export function useChatLiveSession(
         if (preResponseRecoveryRunIdRef.current === runId) {
           preResponseRecoveryRunIdRef.current = null;
         }
+        liveAttachThrottleRecoveryBudgetRef.current = { runId, attemptCount: 0 };
 
         if (event.type === "run_terminal") {
           liveStreamDisposition = "terminal";
@@ -338,6 +415,49 @@ export function useChatLiveSession(
         }
         onRecoverableStreamErrorRef.current(sessionId, runId, error, resumeAttemptId);
         return;
+      }
+
+      if (isRecoverableLiveAttachThrottle(error)) {
+        const recoveryBudget = liveAttachThrottleRecoveryBudgetRef.current?.runId === runId
+          ? liveAttachThrottleRecoveryBudgetRef.current
+          : { runId, attemptCount: 0 };
+        const delayMs = getLiveAttachThrottleRecoveryDelayMs(error, recoveryBudget.attemptCount);
+        if (delayMs !== null) {
+          liveAttachThrottleRecoveryBudgetRef.current = {
+            runId,
+            attemptCount: recoveryBudget.attemptCount + 1,
+          };
+          const recoveryAbortController = new AbortController();
+          const pendingRecovery: PendingLiveStreamRecovery = {
+            sessionId,
+            runId,
+            abortController: recoveryAbortController,
+          };
+          const {
+            signal: recoverySignal,
+            dispose: disposeRecoverySignal,
+          } = combineAbortSignals([
+            indexedDbOpenRecoveryState.signal,
+            recoveryAbortController.signal,
+          ]);
+          pendingLiveStreamRecoveryRef.current = pendingRecovery;
+          void waitForLiveAttachThrottleRecovery(delayMs, recoverySignal).then((didCompleteWait) => {
+            if (
+              didCompleteWait === false
+              || indexedDbOpenRecoveryState.hasFailed()
+              || isDocumentVisibleRef.current === false
+              || pendingLiveStreamRecoveryRef.current !== pendingRecovery
+            ) {
+              return;
+            }
+
+            pendingLiveStreamRecoveryRef.current = null;
+            onRecoverableStreamErrorRef.current(sessionId, runId, error, resumeAttemptId);
+          }).finally(() => {
+            disposeRecoverySignal();
+          });
+          return;
+        }
       }
 
       const normalizedError = normalizeCaughtError(error);

--- a/apps/web/src/chat/streaming/liveStream.test.ts
+++ b/apps/web/src/chat/streaming/liveStream.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ChatLiveContractError,
+  ChatLiveHttpError,
   ChatLiveTransportError,
   consumeChatLiveStream,
   parseChatLiveEvent,
@@ -153,6 +154,143 @@ describe("consumeChatLiveStream", () => {
       code: null,
       originalErrorName: "TypeError",
     } satisfies Partial<ChatLiveTransportError>);
+  });
+
+  it("preserves the application request ID and delta-seconds Retry-After on HTTP errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: "Live attach refused",
+      requestId: "body-request-id",
+      code: null,
+    }), {
+      status: 429,
+      headers: {
+        "Retry-After": "2",
+        "X-Amzn-RequestId": "lambda-request-id",
+        "X-Request-Id": "application-request-id",
+      },
+    }));
+
+    const promise = consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ChatLiveHttpError);
+    await expect(promise).rejects.toMatchObject({
+      requestId: "application-request-id",
+      statusCode: 429,
+      code: null,
+      retryAfterMs: 2_000,
+    } satisfies Partial<ChatLiveHttpError>);
+  });
+
+  it.each([
+    ["zero delta-seconds", () => "0"],
+    ["past HTTP-date", () => new Date(Date.now() - 5_000).toUTCString()],
+  ])("falls back to the Lambda request ID and parses a %s Retry-After", async (_retryAfterKind, getRetryAfter) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: "Live attach refused",
+      requestId: "body-request-id",
+      code: null,
+    }), {
+      status: 429,
+      headers: {
+        "Retry-After": getRetryAfter(),
+        "X-Amzn-RequestId": "lambda-request-id",
+      },
+    }));
+
+    await expect(consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    })).rejects.toMatchObject({
+      requestId: "lambda-request-id",
+      statusCode: 429,
+      code: null,
+      retryAfterMs: 0,
+    } satisfies Partial<ChatLiveHttpError>);
+  });
+
+  it.each([
+    ["delta-seconds", () => "60"],
+    ["HTTP-date", () => new Date(Date.now() + 60_000).toUTCString()],
+  ])("caps an oversized %s Retry-After at the metadata boundary", async (_retryAfterKind, getRetryAfter) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: "Live attach refused",
+      requestId: "body-request-id",
+      code: null,
+    }), {
+      status: 429,
+      headers: {
+        "Retry-After": getRetryAfter(),
+      },
+    }));
+
+    await expect(consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    })).rejects.toMatchObject({
+      retryAfterMs: 4_000,
+    } satisfies Partial<ChatLiveHttpError>);
+  });
+
+  it("retains response-body error metadata and rejects an invalid Retry-After", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: "Coded refusal",
+      requestId: "body-request-id",
+      code: "LIVE_ATTACH_FORBIDDEN",
+    }), {
+      status: 403,
+      headers: {
+        "Retry-After": "not-a-delay",
+      },
+    }));
+
+    await expect(consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    })).rejects.toMatchObject({
+      requestId: "body-request-id",
+      statusCode: 403,
+      code: "LIVE_ATTACH_FORBIDDEN",
+      retryAfterMs: null,
+    } satisfies Partial<ChatLiveHttpError>);
   });
 
   it("wraps post-response body read failures as transport errors with response metadata", async () => {

--- a/apps/web/src/chat/streaming/liveStream.ts
+++ b/apps/web/src/chat/streaming/liveStream.ts
@@ -98,6 +98,8 @@ type ChatLiveErrorMetadata = Readonly<{
   code: string | null;
 }>;
 
+const maximumRetryAfterDelayMs = 4_000;
+
 export class ChatLiveContractError extends Error {
   readonly eventType: string | null;
   readonly payloadSnippet: string;
@@ -120,13 +122,21 @@ export class ChatLiveHttpError extends Error {
   readonly statusCode: number;
   readonly requestId: string | null;
   readonly code: string | null;
+  readonly retryAfterMs: number | null;
 
-  constructor(message: string, statusCode: number, requestId: string | null, code: string | null) {
+  constructor(
+    message: string,
+    statusCode: number,
+    requestId: string | null,
+    code: string | null,
+    retryAfterMs: number | null,
+  ) {
     super(message);
     this.name = "ChatLiveHttpError";
     this.statusCode = statusCode;
     this.requestId = requestId;
     this.code = code;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 
@@ -521,16 +531,43 @@ function buildLiveStreamUrl(
   return url.toString();
 }
 
-function buildLiveStreamHttpError(statusCode: number, responseText: string, headerRequestId: string | null): ChatLiveHttpError {
+function getLiveResponseRequestId(response: Response): string | null {
+  return normalizeMetadataString(response.headers.get("X-Request-Id"))
+    ?? normalizeMetadataString(response.headers.get("X-Amzn-RequestId"));
+}
+
+function getRetryAfterMs(response: Response): number | null {
+  const value = response.headers.get("Retry-After")?.trim();
+  if (value === undefined || value === "") {
+    return null;
+  }
+
+  if (/^\d+$/.test(value)) {
+    const delaySeconds = Number(value);
+    const delayMs = delaySeconds * 1000;
+    return Math.min(delayMs, maximumRetryAfterDelayMs);
+  }
+
+  const retryAtMs = Date.parse(value);
+  return Number.isFinite(retryAtMs)
+    ? Math.min(
+      Math.max(0, retryAtMs - Date.now()),
+      maximumRetryAfterDelayMs,
+    )
+    : null;
+}
+
+function buildLiveStreamHttpError(response: Response, responseText: string): ChatLiveHttpError {
+  const statusCode = response.status;
   const payload = parseJsonObject(responseText);
-  const normalizedHeaderRequestId = normalizeMetadataString(headerRequestId);
+  const headerRequestId = getLiveResponseRequestId(response);
   const backendMessage = payload === null
     ? responseText.trim()
     : readStringField(payload, "error");
   const bodyRequestId = payload === null
     ? null
     : readStringField(payload, "requestId");
-  const requestId = normalizedHeaderRequestId ?? bodyRequestId;
+  const requestId = headerRequestId ?? normalizeMetadataString(bodyRequestId);
   const code = payload === null
     ? null
     : readStringField(payload, "code");
@@ -542,7 +579,7 @@ function buildLiveStreamHttpError(statusCode: number, responseText: string, head
     ? `AI live stream failed with status ${String(statusCode)}: ${baseMessage}`
     : `AI live stream failed with status ${String(statusCode)}: ${baseMessage} (requestId: ${requestId})`;
 
-  return new ChatLiveHttpError(message, statusCode, requestId, code);
+  return new ChatLiveHttpError(message, statusCode, requestId, code, getRetryAfterMs(response));
 }
 
 function consumeSSEBlock(
@@ -614,14 +651,13 @@ export async function consumeChatLiveStream(
 
   if (response.ok === false) {
     throw buildLiveStreamHttpError(
-      response.status,
+      response,
       await response.text(),
-      response.headers.get("X-Request-Id"),
     );
   }
 
   const responseMetadata: ChatLiveErrorMetadata = {
-    requestId: normalizeMetadataString(response.headers.get("X-Request-Id")),
+    requestId: getLiveResponseRequestId(response),
     statusCode: response.status,
     code: null,
   };


### PR DESCRIPTION
## Summary

- preserve Lambda throttle metadata on chat-live attach failures
- recover code-less HTTP 429 attaches through bounded, abortable backoff and authoritative snapshots
- keep run creation single-shot and retain hard failures for coded 429 and other HTTP errors

## Validation

- focused stream and chat-panel module-boundary coverage exercises metadata, terminal recovery, active reattach, exhaustion, cancellation, and non-retry behavior
- required PR checks own the web build and test suite
- after merge, the automatic AWS/Web Release and post-deploy smoke must pass