### PR TITLE
Let reporting SQL see which emails hold admin access

### DIFF
--- a/db/migrations/0125_reporting_readonly_admin_users.sql
+++ b/db/migrations/0125_reporting_readonly_admin_users.sql
@@ -1,0 +1,14 @@
+-- Migration status: Current / additive.
+-- Introduces: read-only reporting access to the admin entitlement key, so an admin report can tell
+--   which reporting rows belong to an active admin and exclude that activity.
+-- Schemas touched/read explicitly: auth.
+
+-- The column pair is the whole entitlement identity a report needs. email is already lower/btrim
+-- normalized by the admin_users_email_normalized CHECK in db/migrations/0045_admin_users.sql, so a
+-- report joins it directly against a folded org.user_settings.email, and revoked_at IS NULL is what
+-- "active admin" means. granted_at, granted_by, note and source are operator prose and stay hidden.
+--
+-- auth.admin_users has no row-level security, so no policy accompanies this grant, and
+-- db/migrations/0066_reporting_readonly_operational_analytics.sql already granted
+-- USAGE ON SCHEMA auth to reporting_readonly.
+GRANT SELECT (email, revoked_at) ON TABLE auth.admin_users TO reporting_readonly;

--- a/docs/analytics-db-access.md
+++ b/docs/analytics-db-access.md
@@ -190,6 +190,7 @@ The role gets `SELECT` on these tables only:
 - `auth.guest_ai_monthly_usage`
 - selected audit columns on `auth.guest_upgrade_history`
 - `auth.guest_replica_aliases`
+- selected entitlement columns on `auth.admin_users`, the join key an admin report uses to exclude admin-generated activity
 - selected metadata columns on `ai.chat_sessions`
 - selected metadata columns on `ai.chat_runs`
 - selected metadata columns on `ai.chat_composer_suggestion_generations`
@@ -302,7 +303,7 @@ Use guest and account-conversion tables when the investigation needs guest activ
 - `auth.guest_upgrade_history`
 - `auth.guest_replica_aliases`
 
-Guest analytics intentionally do not expose guest session secret hashes, replay secret hashes, raw provider subjects, OTP challenge state, API key hashes, or admin entitlement rows.
+Guest analytics intentionally do not expose guest session secret hashes, replay secret hashes, raw provider subjects, OTP challenge state, or API key hashes.
 
 Use AI operational tables when the investigation needs chat session volume, run health, model/cost-policy distribution, or stuck/failed run timing:
 


### PR DESCRIPTION
`reporting_readonly` had no access to `auth.admin_users`, so an admin report could not tell rows produced by an active admin apart from anyone else's. A query touching that table failed as an opaque HTTP 500 `INTERNAL_ERROR` rather than a readable permission error.

Migration `0125` grants exactly the two columns that answer the question. `email` is already lower/btrim-normalized by the table's own `admin_users_email_normalized` CHECK, so it joins directly against a folded `org.user_settings.email`; `revoked_at IS NULL` is what active access means. `granted_at`, `granted_by`, `note` and `source` stay hidden. `auth.admin_users` has no row-level security, so no policy is added, and `GRANT USAGE ON SCHEMA auth TO reporting_readonly` already exists from `0066`.

`docs/analytics-db-access.md` gains the relation in its granted list, and loses the clause that claimed admin entitlement rows are never exposed — this change makes that sentence false.

Nothing consumes the grant yet. The catalog deck installs admin section that will exclude admin installs is a separate follow-up, and it needs this migration deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)