### PR TITLE
Give the admin dashboard a shell and named sections

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -6,7 +6,7 @@ import {
   type ReviewEventsByDateReport,
 } from "./adminApi";
 import { getAdminAppConfig, type AdminAppConfig } from "./config";
-import { ReviewEventsByDateDashboard } from "./reports/reviewEventsByDate/ReviewEventsByDateDashboard";
+import { AdminDashboard } from "./dashboard/AdminDashboard";
 import {
   loadReviewEventsByDateDefaultRange,
   loadReviewEventsByDateReport,
@@ -281,7 +281,7 @@ export default function App(): JSX.Element {
   }
 
   return (
-    <ReviewEventsByDateDashboard
+    <AdminDashboard
       report={appState.report}
       adminEmail={appState.session.email}
       defaultRange={appState.defaultRange}

--- a/apps/admin/src/charts/chartRenderers.ts
+++ b/apps/admin/src/charts/chartRenderers.ts
@@ -3,7 +3,7 @@ import {
   reviewEventPlatforms,
   type ReviewEventPlatform,
   type ReviewEventsByDateUser,
-} from "../../../adminApi";
+} from "../adminApi";
 import {
   chartMargin,
   chartWidth,
@@ -18,8 +18,8 @@ import {
   type MatrixChartEntry,
   type StackedChartRectEntry,
   type UniqueUserCohortKey,
-} from "./chartModel";
-import { escapeHtml, formatCompactDateLabel, formatDateRangeLabel } from "../formatting";
+} from "../reports/reviewEventsByDate/charts/chartModel";
+import { escapeHtml, formatCompactDateLabel, formatDateRangeLabel } from "../reports/reviewEventsByDate/formatting";
 
 type ChartFrameParams = Readonly<{
   chartHeight: number;

--- a/apps/admin/src/dashboard/AdminDashboard.tsx
+++ b/apps/admin/src/dashboard/AdminDashboard.tsx
@@ -6,26 +6,22 @@ import {
   type ReviewEventPlatform,
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUser,
-} from "../../adminApi";
-import { ReviewEventsByDateCharts } from "./charts/ReviewEventsByDateCharts";
-import { buildReviewEventsByDateChartModel } from "./charts/chartModel";
-import { ReviewEventsByDateFilters } from "./filters/ReviewEventsByDateFilters";
-import {
-  buildReviewEventsByDateSummaryCards,
-  ReviewEventsByDateSummary,
-} from "./ReviewEventsByDateSummary";
-import { formatDateRangeLabel } from "./formatting";
+} from "../adminApi";
+import { ReviewActivitySection } from "../reports/reviewEventsByDate/ReviewActivitySection";
+import { ReviewEventsByDateFilters } from "../reports/reviewEventsByDate/filters/ReviewEventsByDateFilters";
 import {
   buildActiveUserFilters,
   buildSearchableUserFilterOptions,
   doesUserMatchSearch,
   getNormalizedSearchValue,
   visibleUserFilterOptionLimit,
-} from "./filters/userFilters";
+} from "../reports/reviewEventsByDate/filters/userFilters";
+import { formatDateRangeLabel } from "../reports/reviewEventsByDate/formatting";
 import {
   filterReviewEventsByDateReport,
   type ReviewEventsByDateRange,
-} from "./query";
+} from "../reports/reviewEventsByDate/query";
+import { getStableUserColorDomain, getUserColorScale } from "./userColors";
 
 function buildUserById(
   reviewUsers: ReadonlyArray<ReviewEventsByDateUser>,
@@ -84,7 +80,7 @@ function getUpdatedPlatformFilterSelection(
   return currentPlatforms.filter((currentPlatform) => currentPlatform !== platform);
 }
 
-export function ReviewEventsByDateDashboard(
+export function AdminDashboard(
   props: Readonly<{
     report: ReviewEventsByDateReport;
     adminEmail: string;
@@ -199,6 +195,10 @@ export function ReviewEventsByDateDashboard(
     () => buildUserById(filteredReport.users, filteredReport.communityOnlyUsers),
     [filteredReport.communityOnlyUsers, filteredReport.users],
   );
+  const userColorScale = useMemo(
+    () => getUserColorScale(getStableUserColorDomain(userFilterOptionUsers)),
+    [userFilterOptionUsers],
+  );
   const activeUserFilters = useMemo(
     () => buildActiveUserFilters(selectedUserIds, reportUserById),
     [selectedUserIds, reportUserById],
@@ -222,29 +222,14 @@ export function ReviewEventsByDateDashboard(
     [matchingUserFilterOptions],
   );
   const hiddenUserFilterOptionCount = matchingUserFilterOptions.length - visibleUserFilterOptions.length;
-  const chartModel = useMemo(
-    () => buildReviewEventsByDateChartModel(filteredReport, userFilterOptionUsers),
-    [filteredReport, userFilterOptionUsers],
-  );
-  const summaryCards = useMemo(
-    () => buildReviewEventsByDateSummaryCards(
-      filteredReport,
-      chartModel.peakDailyVolume,
-      chartModel.peakDailyUniqueUsers,
-    ),
-    [chartModel.peakDailyUniqueUsers, chartModel.peakDailyVolume, filteredReport],
-  );
 
   return (
     <main className="shell">
       <section className="hero">
         <div>
           <p className="eyebrow">Admin Analytics</p>
-          <h1>Review Events By Date</h1>
+          <h1>Product Analytics</h1>
         </div>
-        <p className="subhead">
-          Daily unique reviewers, stacked review-event volume, platform activity, friend invite links, and existing friend connections by calendar date. Dates are grouped in <strong>UTC</strong>.
-        </p>
         <div className="hero-meta">
           <span className="hero-badge">Signed in as {props.adminEmail}</span>
           <span className="hero-badge">Range {formatDateRangeLabel(props.report.from)} to {formatDateRangeLabel(props.report.to)}</span>
@@ -273,7 +258,7 @@ export function ReviewEventsByDateDashboard(
         matchingUserFilterOptionCount={matchingUserFilterOptions.length}
         hiddenUserFilterOptionCount={hiddenUserFilterOptionCount}
         activeUserFilters={activeUserFilters}
-        userColorScale={chartModel.userColorScale}
+        userColorScale={userColorScale}
         onFromDateChange={handleFromDateChange}
         onToDateChange={handleToDateChange}
         onDateRangeSubmit={handleDateRangeSubmit}
@@ -287,13 +272,12 @@ export function ReviewEventsByDateDashboard(
         onAllFiltersReset={handleAllFiltersReset}
       />
 
-      <ReviewEventsByDateSummary cards={summaryCards} />
-
-      <ReviewEventsByDateCharts
-        chartModel={chartModel}
+      <ReviewActivitySection
+        filteredReport={filteredReport}
         generatedAtUtc={props.report.generatedAtUtc}
         isReportLoading={props.isReportLoading}
-        userById={filteredUserById}
+        filteredUserById={filteredUserById}
+        userColorScale={userColorScale}
         onUserFilterApply={handleChartUserFilterApply}
       />
     </main>

--- a/apps/admin/src/dashboard/userColors.ts
+++ b/apps/admin/src/dashboard/userColors.ts
@@ -1,0 +1,34 @@
+import * as d3 from "d3";
+import type { ReviewEventsByDateUser } from "../adminApi";
+
+export type UserColorScale = d3.ScaleOrdinal<string, string>;
+
+const userColorPalette: ReadonlyArray<string> = [
+  ...d3.schemeTableau10,
+  ...d3.schemeSet2,
+  ...d3.schemeDark2,
+  "#e15759",
+  "#76b7b2",
+  "#f28e2b",
+  "#59a14f",
+];
+
+export function getUserColorScale(userIds: ReadonlyArray<string>): UserColorScale {
+  const colors = userIds.map((userId) => userColorPalette[getUserColorPaletteIndex(userId)]);
+
+  return d3.scaleOrdinal<string, string>(userIds, colors);
+}
+
+export function getStableUserColorDomain(users: ReadonlyArray<ReviewEventsByDateUser>): ReadonlyArray<string> {
+  return users.map((user) => user.userId).sort((leftUserId, rightUserId) => leftUserId.localeCompare(rightUserId));
+}
+
+function getUserColorPaletteIndex(userId: string): number {
+  let hash = 0;
+
+  for (const character of userId) {
+    hash = ((hash << 5) - hash + character.charCodeAt(0)) | 0;
+  }
+
+  return Math.abs(hash) % userColorPalette.length;
+}

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewActivitySection.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewActivitySection.tsx
@@ -1,0 +1,55 @@
+import { useMemo, type JSX } from "react";
+import type { ReviewEventsByDateReport, ReviewEventsByDateUser } from "../../adminApi";
+import type { UserColorScale } from "../../dashboard/userColors";
+import { ReviewEventsByDateCharts } from "./charts/ReviewEventsByDateCharts";
+import { buildReviewEventsByDateChartModel } from "./charts/chartModel";
+import {
+  buildReviewEventsByDateSummaryCards,
+  ReviewEventsByDateSummary,
+} from "./ReviewEventsByDateSummary";
+
+export function ReviewActivitySection(
+  props: Readonly<{
+    filteredReport: ReviewEventsByDateReport;
+    generatedAtUtc: string;
+    isReportLoading: boolean;
+    filteredUserById: ReadonlyMap<string, ReviewEventsByDateUser>;
+    userColorScale: UserColorScale;
+    onUserFilterApply: (userId: string) => void;
+  }>,
+): JSX.Element {
+  const chartModel = useMemo(
+    () => buildReviewEventsByDateChartModel(props.filteredReport),
+    [props.filteredReport],
+  );
+  const summaryCards = useMemo(
+    () => buildReviewEventsByDateSummaryCards(
+      props.filteredReport,
+      chartModel.peakDailyVolume,
+      chartModel.peakDailyUniqueUsers,
+    ),
+    [chartModel.peakDailyUniqueUsers, chartModel.peakDailyVolume, props.filteredReport],
+  );
+
+  return (
+    <section className="dashboard-section">
+      <header className="dashboard-section-header">
+        <h2>Review activity</h2>
+        <p className="dashboard-section-description">
+          Daily unique reviewers, stacked review-event volume, platform activity, friend invite links, and existing friend connections by calendar date. Dates are grouped in <strong>UTC</strong>.
+        </p>
+      </header>
+
+      <ReviewEventsByDateSummary cards={summaryCards} />
+
+      <ReviewEventsByDateCharts
+        chartModel={chartModel}
+        generatedAtUtc={props.generatedAtUtc}
+        isReportLoading={props.isReportLoading}
+        userById={props.filteredUserById}
+        userColorScale={props.userColorScale}
+        onUserFilterApply={props.onUserFilterApply}
+      />
+    </section>
+  );
+}

--- a/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
@@ -16,7 +16,8 @@ import {
   renderPlatformActiveUsersChart,
   renderPlatformReviewEventsChart,
   renderUserReviewEventsChart,
-} from "./chartRenderers";
+} from "../../../charts/chartRenderers";
+import type { UserColorScale } from "../../../dashboard/userColors";
 import { formatGeneratedAt } from "../formatting";
 
 type ReviewEventsByDateChartsProps = Readonly<{
@@ -24,6 +25,7 @@ type ReviewEventsByDateChartsProps = Readonly<{
   generatedAtUtc: string;
   isReportLoading: boolean;
   userById: ReadonlyMap<string, ReviewEventsByDateUser>;
+  userColorScale: UserColorScale;
   onUserFilterApply: (userId: string) => void;
 }>;
 
@@ -143,7 +145,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
       tickDates: props.chartModel.tickDates,
       userMatrix: props.chartModel.userMatrix,
       userIds: props.chartModel.userIds,
-      userColorScale: props.chartModel.userColorScale,
+      userColorScale: props.userColorScale,
       userById: props.userById,
       totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
       peakDailyVolume: props.chartModel.peakDailyVolume,
@@ -175,7 +177,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
       tickDates: props.chartModel.tickDates,
       friendInvitationUserMatrix: props.chartModel.friendInvitationUserMatrix,
       friendInvitationUserIds: props.chartModel.friendInvitationUserIds,
-      userColorScale: props.chartModel.userColorScale,
+      userColorScale: props.userColorScale,
       userById: props.userById,
       totalFriendInvitationsByDate: props.chartModel.totalFriendInvitationsByDate,
       friendInvitationTotalsByUserId: props.chartModel.friendInvitationTotalsByUserId,
@@ -190,7 +192,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
       tickDates: props.chartModel.tickDates,
       friendshipUserMatrix: props.chartModel.friendshipUserMatrix,
       friendshipUserIds: props.chartModel.friendshipUserIds,
-      userColorScale: props.chartModel.userColorScale,
+      userColorScale: props.userColorScale,
       userById: props.userById,
       totalFriendshipsByDate: props.chartModel.totalFriendshipsByDate,
       peakDailyFriendships: props.chartModel.peakDailyFriendships,
@@ -202,6 +204,7 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
     props.chartModel,
     props.isReportLoading,
     props.userById,
+    props.userColorScale,
     handleUserFilterApply,
   ]);
 

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
@@ -7,7 +7,6 @@ import {
   type ReviewEventsByDateCommunityRow,
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUniqueUserCohort,
-  type ReviewEventsByDateUser,
 } from "../../../adminApi";
 
 export type ChartTooltipState = Readonly<{
@@ -45,7 +44,6 @@ export type ReviewEventsByDateChartModel = Readonly<{
   dates: ReadonlyArray<string>;
   tickDates: ReadonlyArray<string>;
   userIds: ReadonlyArray<string>;
-  userColorScale: d3.ScaleOrdinal<string, string>;
   dailyUniqueUserCohortMatrix: ReadonlyArray<MatrixChartEntry>;
   friendInvitationUserIds: ReadonlyArray<string>;
   friendshipUserIds: ReadonlyArray<string>;
@@ -105,25 +103,12 @@ export const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string
   new: "#2e6f95",
 };
 
-const userColorPalette: ReadonlyArray<string> = [
-  ...d3.schemeTableau10,
-  ...d3.schemeSet2,
-  ...d3.schemeDark2,
-  "#e15759",
-  "#76b7b2",
-  "#f28e2b",
-  "#59a14f",
-];
-
 export function buildReviewEventsByDateChartModel(
   report: ReviewEventsByDateReport,
-  stableUsers: ReadonlyArray<ReviewEventsByDateUser>,
 ): ReviewEventsByDateChartModel {
   const dates = report.dateTotals.map((item) => item.date);
   const tickDates = createTickDates(dates);
-  const allUserIds = getStableUserColorDomain(stableUsers);
   const userIds = report.users.map((user) => user.userId);
-  const userColorScale = getUserColorScale(allUserIds);
   const dailyUniqueUserCohortMatrix = buildDailyUniqueUserCohortMatrix(report.dailyUniqueUserCohorts);
   const dailyUniqueUserTotals = report.dailyUniqueUserCohorts.map((item) => ({
     date: item.date,
@@ -176,7 +161,6 @@ export function buildReviewEventsByDateChartModel(
     dates,
     tickDates,
     userIds,
-    userColorScale,
     dailyUniqueUserCohortMatrix,
     friendInvitationUserIds,
     friendshipUserIds,
@@ -326,26 +310,6 @@ function getPeakStackedValue(items: ReadonlyArray<MatrixChartEntry>): number {
 
 function getPeakGroupedValue(items: ReadonlyArray<MatrixChartEntry>): number {
   return d3.max(items, (item) => d3.max(reviewEventPlatforms, (platform) => item.valuesByKey[platform] ?? 0) ?? 0) ?? 0;
-}
-
-function getUserColorScale(userIds: ReadonlyArray<string>): d3.ScaleOrdinal<string, string> {
-  const colors = userIds.map((userId) => userColorPalette[getUserColorPaletteIndex(userId)]);
-
-  return d3.scaleOrdinal<string, string>(userIds, colors);
-}
-
-function getUserColorPaletteIndex(userId: string): number {
-  let hash = 0;
-
-  for (const character of userId) {
-    hash = ((hash << 5) - hash + character.charCodeAt(0)) | 0;
-  }
-
-  return Math.abs(hash) % userColorPalette.length;
-}
-
-function getStableUserColorDomain(users: ReadonlyArray<ReviewEventsByDateUser>): ReadonlyArray<string> {
-  return users.map((user) => user.userId).sort((leftUserId, rightUserId) => leftUserId.localeCompare(rightUserId));
 }
 
 function createTickDates(dates: ReadonlyArray<string>): ReadonlyArray<string> {

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -106,13 +106,24 @@ h2 {
   line-height: 1;
 }
 
-.subhead,
+.dashboard-section-description,
 .state-copy {
   margin: 0;
   max-width: 920px;
   color: var(--muted);
   font-size: 15px;
   line-height: 1.6;
+}
+
+.dashboard-section {
+  margin-top: 32px;
+  padding-top: 32px;
+  border-top: 1px solid var(--panel-border);
+}
+
+.dashboard-section-header {
+  display: grid;
+  gap: 12px;
 }
 
 .summary-grid {

--- a/docs/admin-app.md
+++ b/docs/admin-app.md
@@ -153,7 +153,7 @@ The admin frontend fails fast on any other non-local hostname. Do not serve the 
 
 - `https://admin.<domain>` returns `200`
 - unauthenticated access redirects to the login flow
-- a listed admin email loads the dashboard
+- a listed admin email loads the dashboard, where the shared hero and filter row sit above titled report sections, each separated by a divider
 - a signed-in non-admin sees the access denied page
 - network traces show `POST /v1/admin/reports/query` for dashboard data
 - the default date filter starts on the first review, friend invite, or friendship day and ends on today


### PR DESCRIPTION
The admin page was a single component that owned the shell, the hero, all filter state and the review report at once, so a second report had nowhere to go.

`AdminDashboard` now owns `<main className="shell">`, the hero and every shared filter, and renders report sections as siblings. The review report becomes the `Review activity` section behind its own heading and divider, taking the filtered report and the shared user colour scale as props. The sentence that enumerated the review charts moves from the page hero into that section's description.

The per-user colour scale (`dashboard/userColors.ts`) and the chart renderers (`charts/chartRenderers.ts`) move out of the review report so later sections can reuse them. The scale is built once per page instead of once per chart model; its domain and its per-user-id hash are unchanged, so no colour moves.

Pure restructure: no SQL, no change to what is loaded, and no number on screen changes. The daily active users and catalog deck installs sections that will render above `Review activity` are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)