### PR TITLE
Show which catalog decks people install, and when

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -49,16 +49,18 @@ Do not host the browser entry on a raw CloudFront or other non-admin hostname, e
 
 ## Current scope
 
-v1 includes one dashboard page only, carrying two report sections in page order:
+v1 includes one dashboard page only, carrying three report sections in page order:
 
 - `daily-active-users`
+- `catalog-deck-installs`
 - `review-events-by-date`
 
-The dashboard shows nine charts:
+The dashboard shows ten charts:
 
 - daily unique active users, new vs returning
 - daily active users by platform
 - daily active users stacked by user
+- daily catalog deck installs, stacked by deck
 - daily unique users with at least 1 review event, new vs returning
 - stacked review events by user
 - daily reviewing users by platform
@@ -73,11 +75,14 @@ Its SQL lives in the admin frontend as a chart-owned query and runs through the 
 
 ### Where the data comes from
 
-Every chart reads `analytics.product_events_resolved` and no other product table; the only other relation it touches is `org.user_settings`, joined from `actor_id` for the email the `%@example.com` exclusion needs. The dashboard does not join `content.review_events`, `sync.workspace_replicas`, `community.friend_invitations`, or `community.friendships` any more.
+Every chart reads `analytics.product_events_resolved` and no other product table. It touches two more relations and nothing else: `org.user_settings`, joined from `actor_id` for the email the `%@example.com` exclusion needs, and `auth.admin_users`, read by the installs chart alone to drop installs made by active admins. The dashboard does not join `content.review_events`, `sync.workspace_replicas`, `catalog.packages`, `community.friend_invitations`, or `community.friendships` any more.
 
 - review series: `review_answered`
+- catalog deck installs: `catalog_deck_installed`, with the deck named by its `package_slug` property
 - friend invite links: `friend_invitation_created`
 - friend connections at the end of each day: a running sum of `friendship_created`
+
+The installs chart is nearly empty on production data on purpose: installs of the delisted `test` fixture deck and installs by active admins are both excluded, and almost every real install so far is an admin install. That event carries no platform, so picking any device platform empties that section. See [docs/admin-app.md](../../docs/admin-app.md) for the full attribution contract.
 
 Rows are grouped by `actor_id`, never by `user_id`. The view already collapses a guest and the account that guest became into one person, so the previous `actor_kind` filter and the inline guest-merge reasoning are gone. `actor_id` is not always an account id: a guest who never upgraded stays on the guest user id.
 

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -3,11 +3,13 @@ import {
   AdminApiError,
   fetchAdminSession,
   type AdminSession,
+  type CatalogInstallsReport,
   type DailyActiveUsersReport,
   type ReviewEventsByDateReport,
 } from "./adminApi";
 import { getAdminAppConfig, type AdminAppConfig } from "./config";
 import { AdminDashboard } from "./dashboard/AdminDashboard";
+import { loadCatalogInstallsReport } from "./reports/catalogInstalls/query";
 import { loadDailyActiveUsersReport } from "./reports/dailyActiveUsers/query";
 import {
   loadReviewEventsByDateDefaultRange,
@@ -27,6 +29,7 @@ type AppState =
       defaultRange: ReviewEventsByDateRange;
       report: ReviewEventsByDateReport;
       dailyActiveUsersReport: DailyActiveUsersReport;
+      catalogInstallsReport: CatalogInstallsReport;
       isReportLoading: boolean;
       dateRangeError: string;
     }>;
@@ -166,9 +169,10 @@ export default function App(): JSX.Element {
         config = getAdminAppConfig();
         const session = await fetchAdminSession(config);
         const defaultRange = await loadReviewEventsByDateDefaultRange(config);
-        const [report, dailyActiveUsersReport] = await Promise.all([
+        const [report, dailyActiveUsersReport, catalogInstallsReport] = await Promise.all([
           loadReviewEventsByDateReport(config, defaultRange.from, defaultRange.to),
           loadDailyActiveUsersReport(config, defaultRange.from, defaultRange.to),
+          loadCatalogInstallsReport(config, defaultRange.from, defaultRange.to),
         ]);
 
         if (cancelled) {
@@ -182,6 +186,7 @@ export default function App(): JSX.Element {
           defaultRange,
           report,
           dailyActiveUsersReport,
+          catalogInstallsReport,
           isReportLoading: false,
           dateRangeError: "",
         });
@@ -230,9 +235,10 @@ export default function App(): JSX.Element {
     });
 
     try {
-      const [report, dailyActiveUsersReport] = await Promise.all([
+      const [report, dailyActiveUsersReport, catalogInstallsReport] = await Promise.all([
         loadReviewEventsByDateReport(readyState.config, range.from, range.to),
         loadDailyActiveUsersReport(readyState.config, range.from, range.to),
+        loadCatalogInstallsReport(readyState.config, range.from, range.to),
       ]);
 
       setAppState((currentState) => {
@@ -244,6 +250,7 @@ export default function App(): JSX.Element {
           ...currentState,
           report,
           dailyActiveUsersReport,
+          catalogInstallsReport,
           isReportLoading: false,
           dateRangeError: "",
         };
@@ -291,6 +298,7 @@ export default function App(): JSX.Element {
     <AdminDashboard
       report={appState.report}
       dailyActiveUsersReport={appState.dailyActiveUsersReport}
+      catalogInstallsReport={appState.catalogInstallsReport}
       adminEmail={appState.session.email}
       defaultRange={appState.defaultRange}
       isReportLoading={appState.isReportLoading}

--- a/apps/admin/src/adminApi.ts
+++ b/apps/admin/src/adminApi.ts
@@ -171,6 +171,51 @@ export type DailyActiveUsersReport = Readonly<{
   rows: ReadonlyArray<DailyActiveUsersRow>;
 }>;
 
+/**
+ * One person who installed at least one catalog deck in the report range.
+ *
+ * `userId` carries the same resolved `actor_id` as `ReviewEventsByDateUser`, so an installer keeps
+ * one identity, one filter entry and one colour across every section.
+ */
+export type CatalogInstallsUser = Readonly<{
+  userId: string;
+  email: string;
+  installCount: number;
+}>;
+
+/**
+ * One deck in the report. The install event carries `catalog.packages.slug` and nothing else about
+ * the deck, so the slug is the whole deck dimension: there is no title and no version number here.
+ */
+export type CatalogInstallsPackage = Readonly<{
+  packageSlug: string;
+  installCount: number;
+}>;
+
+/**
+ * One (UTC date, actor, package slug). `installCount` counts install actions, and `cardCount` sums
+ * the cards those installs added.
+ */
+export type CatalogInstallsRow = Readonly<{
+  date: string;
+  userId: string;
+  email: string;
+  platform: ReviewEventPlatform;
+  packageSlug: string;
+  installCount: number;
+  cardCount: number;
+}>;
+
+export type CatalogInstallsReport = Readonly<{
+  generatedAtUtc: string;
+  from: string;
+  to: string;
+  totalInstalls: number;
+  users: ReadonlyArray<CatalogInstallsUser>;
+  packages: ReadonlyArray<CatalogInstallsPackage>;
+  rows: ReadonlyArray<CatalogInstallsRow>;
+}>;
+
 export class AdminApiError extends Error {
   readonly status: number;
   readonly code: string | null;

--- a/apps/admin/src/charts/chartPrimitives.ts
+++ b/apps/admin/src/charts/chartPrimitives.ts
@@ -1,3 +1,4 @@
+import * as d3 from "d3";
 import {
   reviewEventCohorts,
   reviewEventPlatforms,
@@ -78,6 +79,29 @@ export const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string
   returning: "var(--accent)",
   new: "#2e6f95",
 };
+
+export type PackageColorScale = d3.ScaleOrdinal<string, string, string>;
+
+const packageColorPalette: ReadonlyArray<string> = [...d3.schemeTableau10, ...d3.schemeSet2];
+
+// The scale outlives the render that reads it, and the `implicit` default of `d3.scaleOrdinal`
+// appends an unknown deck to the domain and hands back the next palette colour, so that deck's
+// colour would depend on which render asked for it first. An explicit unknown value prevents that.
+const unknownPackageColor = "#8c8c8c";
+
+/**
+ * Catalog decks are an open-ended set the dashboard only learns from the loaded range, so unlike the
+ * fixed platform colours these are positional over the deduplicated, sorted slugs. Build the scale
+ * from the decks of the loaded report rather than of the filtered one, or narrowing a filter shifts
+ * the colour of every deck sorted after the one it removed.
+ */
+export function getPackageColorScale(packageSlugs: ReadonlyArray<string>): PackageColorScale {
+  const sortedPackageSlugs = Array.from(new Set(packageSlugs))
+    .sort((leftSlug, rightSlug) => leftSlug.localeCompare(rightSlug));
+
+  return d3.scaleOrdinal<string, string>(sortedPackageSlugs, packageColorPalette)
+    .unknown(unknownPackageColor);
+}
 
 export function getPlatformColor(platform: string): string {
   if (reviewEventPlatforms.includes(platform as ReviewEventPlatform) === false) {

--- a/apps/admin/src/charts/chartRenderers.ts
+++ b/apps/admin/src/charts/chartRenderers.ts
@@ -20,6 +20,7 @@ import {
   type ChartUser,
   type GroupedChartRectEntry,
   type MatrixChartEntry,
+  type PackageColorScale,
   type StackedChartRectEntry,
   type UniqueUserCohortKey,
 } from "./chartPrimitives";
@@ -58,6 +59,21 @@ type UniqueUserCohortChartParams = Readonly<{
   tickDates: ReadonlyArray<string>;
   cohortMatrix: ReadonlyArray<MatrixChartEntry>;
   peakDailyUniqueUsers: number;
+  yAxisLabel: string;
+  xAxisLabel: string;
+  buildTooltipMetricsHtml: (entry: StackedChartRectEntry) => string;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+type KeyedStackedBarChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  matrix: ReadonlyArray<MatrixChartEntry>;
+  keys: ReadonlyArray<string>;
+  getKeyColor: (key: string) => string;
+  getKeyLabel: (key: string) => string;
+  peakStackedValue: number;
   yAxisLabel: string;
   xAxisLabel: string;
   buildTooltipMetricsHtml: (entry: StackedChartRectEntry) => string;
@@ -185,6 +201,20 @@ export type RenderPlatformReviewEventsChartParams = Readonly<{
   platformReviewEventsMatrix: ReadonlyArray<MatrixChartEntry>;
   totalPlatformReviewEventsByDate: ReadonlyMap<string, number>;
   peakDailyPlatformReviewEvents: number;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+export type RenderCatalogInstallsByPackageChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  packageInstallsMatrix: ReadonlyArray<MatrixChartEntry>;
+  packageSlugs: ReadonlyArray<string>;
+  packageColorScale: PackageColorScale;
+  totalInstallsByDate: ReadonlyMap<string, number>;
+  /** Cards added per `${date}:${packageSlug}`, which is the granularity of one stack segment. */
+  cardCountByDateAndPackageSlug: ReadonlyMap<string, number>;
+  peakDailyInstalls: number;
   tooltipHandlers: ChartTooltipHandlers;
 }>;
 
@@ -621,12 +651,12 @@ export function renderDailyActiveUsersByPlatformChart(params: RenderDailyActiveU
   });
 }
 
-export function renderPlatformReviewEventsChart(params: RenderPlatformReviewEventsChartParams): void {
+function renderKeyedStackedBarChart(params: KeyedStackedBarChartParams): void {
   const svg = d3.select(params.svgElement);
   const x = createDateScale(params.dates);
   const innerHeight = getInnerHeight(stackedChartHeight);
   const y = d3.scaleLinear()
-    .domain([0, Math.max(1, params.peakDailyPlatformReviewEvents)])
+    .domain([0, Math.max(1, params.peakStackedValue)])
     .nice()
     .range([innerHeight, 0]);
   const group = renderChartFrame(svg, {
@@ -634,18 +664,18 @@ export function renderPlatformReviewEventsChart(params: RenderPlatformReviewEven
     x,
     y,
     tickDates: params.tickDates,
-    yAxisLabel: "Review events",
-    xAxisLabel: "Review date",
+    yAxisLabel: params.yAxisLabel,
+    xAxisLabel: params.xAxisLabel,
   });
   const series = d3.stack<MatrixChartEntry>()
-    .keys(reviewEventPlatforms)
-    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.platformReviewEventsMatrix);
+    .keys(params.keys)
+    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.matrix);
 
   group.selectAll(".series")
     .data(series)
     .join("g")
     .attr("class", "series")
-    .attr("fill", (segment) => getPlatformColor(segment.key))
+    .attr("fill", (segment) => params.getKeyColor(segment.key))
     .selectAll("rect")
     .data((segment) => segment.map((entry) => ({
       key: segment.key,
@@ -665,13 +695,56 @@ export function renderPlatformReviewEventsChart(params: RenderPlatformReviewEven
       params.tooltipHandlers.showTooltip(
         [
           `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-          `<p class="tooltip-subtitle">${escapeHtml(platformLabels[entry.key as ReviewEventPlatform])}</p>`,
-          `<div class="tooltip-metric"><span>Review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
-          `<div class="tooltip-metric"><span>All platforms on this date</span><strong>${numberFormatter(params.totalPlatformReviewEventsByDate.get(entry.date) ?? 0)}</strong></div>`,
+          `<p class="tooltip-subtitle">${escapeHtml(params.getKeyLabel(entry.key))}</p>`,
+          params.buildTooltipMetricsHtml(entry),
         ].join(""),
         event.clientX,
         event.clientY,
       );
     })
     .on("mouseleave", params.tooltipHandlers.hideTooltip);
+}
+
+export function renderPlatformReviewEventsChart(params: RenderPlatformReviewEventsChartParams): void {
+  renderKeyedStackedBarChart({
+    svgElement: params.svgElement,
+    dates: params.dates,
+    tickDates: params.tickDates,
+    matrix: params.platformReviewEventsMatrix,
+    keys: reviewEventPlatforms,
+    getKeyColor: getPlatformColor,
+    getKeyLabel: (key) => platformLabels[key as ReviewEventPlatform],
+    peakStackedValue: params.peakDailyPlatformReviewEvents,
+    yAxisLabel: "Review events",
+    xAxisLabel: "Review date",
+    buildTooltipMetricsHtml: (entry) => [
+      `<div class="tooltip-metric"><span>Review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>All platforms on this date</span><strong>${numberFormatter(params.totalPlatformReviewEventsByDate.get(entry.date) ?? 0)}</strong></div>`,
+    ].join(""),
+    tooltipHandlers: params.tooltipHandlers,
+  });
+}
+
+// Stacked by deck rather than by person: the section answers which decks were installed, and who
+// installed them is already the shared user filter's and the tooltip's job on the per-user charts.
+export function renderCatalogInstallsByPackageChart(params: RenderCatalogInstallsByPackageChartParams): void {
+  renderKeyedStackedBarChart({
+    svgElement: params.svgElement,
+    dates: params.dates,
+    tickDates: params.tickDates,
+    matrix: params.packageInstallsMatrix,
+    keys: params.packageSlugs,
+    getKeyColor: params.packageColorScale,
+    // The deck dimension is the package slug: no catalog table is read, so no deck title exists here.
+    getKeyLabel: (key) => key,
+    peakStackedValue: params.peakDailyInstalls,
+    yAxisLabel: "Installs",
+    xAxisLabel: "Install date",
+    buildTooltipMetricsHtml: (entry) => [
+      `<div class="tooltip-metric"><span>Installs of this deck</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+      `<div class="tooltip-metric"><span>All decks on this date</span><strong>${numberFormatter(params.totalInstallsByDate.get(entry.date) ?? 0)}</strong></div>`,
+      `<div class="tooltip-metric"><span>Cards added</span><strong>${numberFormatter(params.cardCountByDateAndPackageSlug.get(`${entry.date}:${entry.key}`) ?? 0)}</strong></div>`,
+    ].join(""),
+    tooltipHandlers: params.tooltipHandlers,
+  });
 }

--- a/apps/admin/src/dashboard/AdminDashboard.tsx
+++ b/apps/admin/src/dashboard/AdminDashboard.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import {
   reviewEventCohorts,
   reviewEventPlatforms,
+  type CatalogInstallsReport,
+  type CatalogInstallsUser,
   type DailyActiveUsersReport,
   type DailyActiveUsersUser,
   type ReviewEventCohort,
@@ -9,7 +11,10 @@ import {
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUser,
 } from "../adminApi";
+import { getPackageColorScale } from "../charts/chartPrimitives";
 import { formatDateRangeLabel } from "../charts/formatting";
+import { CatalogInstallsSection } from "../reports/catalogInstalls/CatalogInstallsSection";
+import { filterCatalogInstallsReport } from "../reports/catalogInstalls/query";
 import { DailyActiveUsersSection } from "../reports/dailyActiveUsers/DailyActiveUsersSection";
 import { filterDailyActiveUsersReport } from "../reports/dailyActiveUsers/query";
 import { ReviewActivitySection } from "../reports/reviewEventsByDate/ReviewActivitySection";
@@ -29,27 +34,29 @@ import { getStableUserColorDomain, getUserColorScale } from "./userColors";
 
 /**
  * The people the shared user filter and the shared colour scale have to cover: everyone with review
- * events, everyone with community activity, and everyone who opened the app. A person present in
- * more than one section appears once. An active user with no review events in range carries a zero
- * review total, which is what the filter list already shows for a community-only user.
+ * events, everyone with community activity, everyone who opened the app, and everyone who installed
+ * a catalog deck. A person present in more than one section appears once. A user with no review
+ * events in range carries a zero review total, which is what the filter list already shows for a
+ * community-only user.
  */
 function buildUserFilterOptionUsers(
   reviewUsers: ReadonlyArray<ReviewEventsByDateUser>,
   communityOnlyUsers: ReadonlyArray<ReviewEventsByDateUser>,
   activeUsers: ReadonlyArray<DailyActiveUsersUser>,
+  installerUsers: ReadonlyArray<CatalogInstallsUser>,
 ): ReadonlyArray<ReviewEventsByDateUser> {
   const usersByUserId = new Map<string, ReviewEventsByDateUser>(
     [...reviewUsers, ...communityOnlyUsers].map((user) => [user.userId, user]),
   );
 
-  for (const activeUser of activeUsers) {
-    if (usersByUserId.has(activeUser.userId)) {
+  for (const user of [...activeUsers, ...installerUsers]) {
+    if (usersByUserId.has(user.userId)) {
       continue;
     }
 
-    usersByUserId.set(activeUser.userId, {
-      userId: activeUser.userId,
-      email: activeUser.email,
+    usersByUserId.set(user.userId, {
+      userId: user.userId,
+      email: user.email,
       totalReviewEvents: 0,
     });
   }
@@ -115,6 +122,7 @@ export function AdminDashboard(
   props: Readonly<{
     report: ReviewEventsByDateReport;
     dailyActiveUsersReport: DailyActiveUsersReport;
+    catalogInstallsReport: CatalogInstallsReport;
     adminEmail: string;
     defaultRange: ReviewEventsByDateRange;
     isReportLoading: boolean;
@@ -211,6 +219,23 @@ export function AdminDashboard(
     }),
     [props.dailyActiveUsersReport, selectedCohorts, selectedPlatforms, selectedUserIds],
   );
+  // The cohort split comes from the unfiltered daily active users report, so narrowing a filter
+  // cannot change which day an installer counts as new on.
+  const filteredCatalogInstallsReport = useMemo(
+    () => filterCatalogInstallsReport(props.catalogInstallsReport, {
+      selectedUserIds,
+      selectedCohorts,
+      selectedPlatforms,
+      firstActiveDateByUserId: props.dailyActiveUsersReport.firstActiveDateByUserId,
+    }),
+    [
+      props.catalogInstallsReport,
+      props.dailyActiveUsersReport.firstActiveDateByUserId,
+      selectedCohorts,
+      selectedPlatforms,
+      selectedUserIds,
+    ],
+  );
   const selectedUserIdSet = useMemo(
     () => new Set(selectedUserIds),
     [selectedUserIds],
@@ -228,8 +253,14 @@ export function AdminDashboard(
       props.report.users,
       props.report.communityOnlyUsers,
       props.dailyActiveUsersReport.users,
+      props.catalogInstallsReport.users,
     ),
-    [props.dailyActiveUsersReport.users, props.report.communityOnlyUsers, props.report.users],
+    [
+      props.catalogInstallsReport.users,
+      props.dailyActiveUsersReport.users,
+      props.report.communityOnlyUsers,
+      props.report.users,
+    ],
   );
   // Every selectable person, so an active-user chip selected from the daily active users chart still
   // resolves to a label even when that person has no review events.
@@ -248,8 +279,22 @@ export function AdminDashboard(
       ...props.report.users,
       ...props.report.communityOnlyUsers,
       ...props.dailyActiveUsersReport.users,
+      ...props.catalogInstallsReport.users,
     ])),
-    [props.dailyActiveUsersReport.users, props.report.communityOnlyUsers, props.report.users],
+    [
+      props.catalogInstallsReport.users,
+      props.dailyActiveUsersReport.users,
+      props.report.communityOnlyUsers,
+      props.report.users,
+    ],
+  );
+  // Built from the loaded report rather than the filtered one, for the same reason the user colour
+  // domain is: a deck must not change colour because a filter removed another deck.
+  const packageColorScale = useMemo(
+    () => getPackageColorScale(
+      props.catalogInstallsReport.packages.map((catalogPackage) => catalogPackage.packageSlug),
+    ),
+    [props.catalogInstallsReport.packages],
   );
   const activeUserFilters = useMemo(
     () => buildActiveUserFilters(selectedUserIds, reportUserById),
@@ -330,6 +375,12 @@ export function AdminDashboard(
         isReportLoading={props.isReportLoading}
         userColorScale={userColorScale}
         onUserFilterApply={handleChartUserFilterApply}
+      />
+
+      <CatalogInstallsSection
+        filteredReport={filteredCatalogInstallsReport}
+        generatedAtUtc={props.catalogInstallsReport.generatedAtUtc}
+        packageColorScale={packageColorScale}
       />
 
       <ReviewActivitySection

--- a/apps/admin/src/reports/catalogInstalls/CatalogInstallsSection.tsx
+++ b/apps/admin/src/reports/catalogInstalls/CatalogInstallsSection.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useRef, type JSX } from "react";
+import * as d3 from "d3";
+import type { CatalogInstallsReport } from "../../adminApi";
+import { ChartTooltip, useChartTooltip } from "../../charts/ChartTooltip";
+import {
+  createTickDates,
+  type MatrixChartEntry,
+  type PackageColorScale,
+} from "../../charts/chartPrimitives";
+import { renderCatalogInstallsByPackageChart } from "../../charts/chartRenderers";
+import { formatGeneratedAt } from "../../charts/formatting";
+import { buildRequestedDateRange } from "../reportValues";
+import { catalogInstallsReportLabel } from "./query";
+
+type CatalogInstallsChartModel = Readonly<{
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  packageSlugs: ReadonlyArray<string>;
+  packageInstallsMatrix: ReadonlyArray<MatrixChartEntry>;
+  totalInstallsByDate: ReadonlyMap<string, number>;
+  cardCountByDateAndPackageSlug: ReadonlyMap<string, number>;
+  peakDailyInstalls: number;
+}>;
+
+type CatalogInstallsSummaryCard = Readonly<{
+  label: string;
+  value: string;
+}>;
+
+/**
+ * The keys are catalog-chosen slugs, and `constructor` is a legal one, so a plain object would
+ * answer that lookup with a function inherited from `Object.prototype` instead of `undefined`.
+ */
+function createInstallCountsByPackageSlug(): Record<string, number> {
+  return Object.create(null) as Record<string, number>;
+}
+
+function buildCatalogInstallsChartModel(report: CatalogInstallsReport): CatalogInstallsChartModel {
+  const dates = buildRequestedDateRange(report.from, report.to, catalogInstallsReportLabel);
+  const installsByDate = new Map<string, Record<string, number>>();
+  const totalInstallsByDate = new Map<string, number>();
+  const cardCountByDateAndPackageSlug = new Map<string, number>();
+
+  for (const row of report.rows) {
+    const currentValues = installsByDate.get(row.date) ?? createInstallCountsByPackageSlug();
+    currentValues[row.packageSlug] = (currentValues[row.packageSlug] ?? 0) + row.installCount;
+    installsByDate.set(row.date, currentValues);
+    totalInstallsByDate.set(row.date, (totalInstallsByDate.get(row.date) ?? 0) + row.installCount);
+
+    const cardCountKey = `${row.date}:${row.packageSlug}`;
+    cardCountByDateAndPackageSlug.set(
+      cardCountKey,
+      (cardCountByDateAndPackageSlug.get(cardCountKey) ?? 0) + row.cardCount,
+    );
+  }
+
+  return {
+    dates,
+    tickDates: createTickDates(dates),
+    // Already ordered by installs, so the most installed deck sits at the bottom of the stack.
+    packageSlugs: report.packages.map((catalogPackage) => catalogPackage.packageSlug),
+    packageInstallsMatrix: dates.map((date) => ({
+      date,
+      valuesByKey: installsByDate.get(date) ?? createInstallCountsByPackageSlug(),
+    })),
+    totalInstallsByDate,
+    cardCountByDateAndPackageSlug,
+    peakDailyInstalls: d3.max(dates, (date) => totalInstallsByDate.get(date) ?? 0) ?? 0,
+  };
+}
+
+function buildCatalogInstallsSummaryCards(
+  report: CatalogInstallsReport,
+  peakDailyInstalls: number,
+): ReadonlyArray<CatalogInstallsSummaryCard> {
+  return [
+    { label: "Total Installs", value: report.totalInstalls.toLocaleString("en-US") },
+    { label: "Unique Installers", value: report.users.length.toLocaleString("en-US") },
+    { label: "Decks Installed", value: report.packages.length.toLocaleString("en-US") },
+    { label: "Peak Daily Installs", value: peakDailyInstalls.toLocaleString("en-US") },
+  ];
+}
+
+export function CatalogInstallsSection(
+  props: Readonly<{
+    filteredReport: CatalogInstallsReport;
+    generatedAtUtc: string;
+    packageColorScale: PackageColorScale;
+  }>,
+): JSX.Element {
+  const packageInstallsChartRef = useRef<SVGSVGElement | null>(null);
+  const { tooltipState, tooltipHandlers } = useChartTooltip();
+  const chartModel = useMemo(
+    () => buildCatalogInstallsChartModel(props.filteredReport),
+    [props.filteredReport],
+  );
+  const summaryCards = useMemo(
+    () => buildCatalogInstallsSummaryCards(props.filteredReport, chartModel.peakDailyInstalls),
+    [chartModel.peakDailyInstalls, props.filteredReport],
+  );
+
+  useEffect(() => {
+    const packageInstallsSvgElement = packageInstallsChartRef.current;
+    if (packageInstallsSvgElement === null) {
+      return;
+    }
+
+    renderCatalogInstallsByPackageChart({
+      svgElement: packageInstallsSvgElement,
+      dates: chartModel.dates,
+      tickDates: chartModel.tickDates,
+      packageInstallsMatrix: chartModel.packageInstallsMatrix,
+      packageSlugs: chartModel.packageSlugs,
+      packageColorScale: props.packageColorScale,
+      totalInstallsByDate: chartModel.totalInstallsByDate,
+      cardCountByDateAndPackageSlug: chartModel.cardCountByDateAndPackageSlug,
+      peakDailyInstalls: chartModel.peakDailyInstalls,
+      tooltipHandlers,
+    });
+  }, [chartModel, props.packageColorScale, tooltipHandlers]);
+
+  return (
+    <section className="dashboard-section">
+      <header className="dashboard-section-header">
+        <h2>Catalog deck installs</h2>
+        <p className="dashboard-section-description">
+          One install action by one person, from the <code>catalog_deck_installed</code> event. Installs of the delisted <code>test</code> fixture deck and installs by active admins are excluded, which leaves almost nothing on production history so far. The event carries no platform, so every install sits in the <strong>Unresolved</strong> bucket and picking any device platform empties this section. Dates are grouped in <strong>UTC</strong>.
+        </p>
+      </header>
+
+      <section className="summary-grid">
+        {summaryCards.map((card) => (
+          <article key={card.label} className="metric-card">
+            <p className="metric-label">{card.label}</p>
+            <p className="metric-value">{card.value}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="chart-column">
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Catalog deck installs per day &mdash; stacked by deck</span>
+            <div className="chart-meta-right">
+              <span>Generated {formatGeneratedAt(props.generatedAtUtc)}</span>
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={packageInstallsChartRef} />
+          </div>
+        </div>
+      </section>
+
+      <ChartTooltip {...tooltipState} />
+    </section>
+  );
+}

--- a/apps/admin/src/reports/catalogInstalls/query.ts
+++ b/apps/admin/src/reports/catalogInstalls/query.ts
@@ -1,0 +1,345 @@
+import { reviewEventCohorts, reviewEventPlatforms, runAdminQuery } from "../../adminApi";
+import type {
+  AdminQueryResultSet,
+  AdminQueryValue,
+  CatalogInstallsPackage,
+  CatalogInstallsReport,
+  CatalogInstallsRow,
+  CatalogInstallsUser,
+  ReviewEventCohort,
+  ReviewEventPlatform,
+} from "../../adminApi";
+import type { AdminAppConfig } from "../../config";
+import { escapeSqlStringLiteral } from "../../sql";
+import {
+  assertIsString,
+  assertPlatform,
+  assertValidDateRange,
+  toInteger,
+} from "../reportValues";
+
+export const catalogInstallsReportLabel = "Catalog deck installs report";
+
+type CatalogInstallsQueryRow = Readonly<{
+  install_date: string;
+  user_id: string;
+  email: string;
+  platform: ReviewEventPlatform;
+  package_slug: string;
+  install_count: string | number;
+  card_count: string | number;
+}>;
+
+export type CatalogInstallsFilterState = Readonly<{
+  selectedUserIds: ReadonlyArray<string>;
+  selectedCohorts: ReadonlyArray<ReviewEventCohort>;
+  selectedPlatforms: ReadonlyArray<ReviewEventPlatform>;
+  /**
+   * `DailyActiveUsersReport.firstActiveDateByUserId`, so new versus returning is defined in exactly
+   * one place instead of being recomputed from installs.
+   */
+  firstActiveDateByUserId: ReadonlyMap<string, string>;
+}>;
+
+type CatalogInstallsAggregateFields = Readonly<Pick<
+  CatalogInstallsReport,
+  "totalInstalls" | "users" | "packages"
+>>;
+
+type CatalogInstallsRowFilter = Readonly<{
+  selectedUserIds: ReadonlySet<string>;
+  selectedCohorts: ReadonlySet<ReviewEventCohort>;
+  selectedPlatforms: ReadonlySet<ReviewEventPlatform>;
+  firstActiveDateByUserId: ReadonlyMap<string, string>;
+  keepsUnknownCohort: boolean;
+}>;
+
+function toCatalogInstallsQueryRow(
+  resultSetRow: Readonly<Record<string, AdminQueryValue>>,
+): CatalogInstallsQueryRow {
+  return {
+    install_date: assertIsString(resultSetRow.install_date ?? null, catalogInstallsReportLabel, "install_date"),
+    user_id: assertIsString(resultSetRow.user_id ?? null, catalogInstallsReportLabel, "user_id"),
+    email: assertIsString(resultSetRow.email ?? null, catalogInstallsReportLabel, "email"),
+    platform: assertPlatform(resultSetRow.platform ?? null, catalogInstallsReportLabel, "platform"),
+    package_slug: assertIsString(resultSetRow.package_slug ?? null, catalogInstallsReportLabel, "package_slug"),
+    install_count: toInteger(resultSetRow.install_count ?? null, catalogInstallsReportLabel, "install_count"),
+    card_count: toInteger(resultSetRow.card_count ?? null, catalogInstallsReportLabel, "card_count"),
+  };
+}
+
+function buildCatalogInstallsUsers(
+  rows: ReadonlyArray<CatalogInstallsRow>,
+): ReadonlyArray<CatalogInstallsUser> {
+  const usersByUserId = new Map<string, CatalogInstallsUser>();
+
+  for (const row of rows) {
+    const existingUser = usersByUserId.get(row.userId);
+    usersByUserId.set(row.userId, {
+      userId: row.userId,
+      email: existingUser?.email ?? row.email,
+      installCount: (existingUser?.installCount ?? 0) + row.installCount,
+    });
+  }
+
+  return Array.from(usersByUserId.values()).sort((left, right) => {
+    if (right.installCount !== left.installCount) {
+      return right.installCount - left.installCount;
+    }
+
+    const leftLabel = left.email === "(no email)" ? left.userId : left.email;
+    const rightLabel = right.email === "(no email)" ? right.userId : right.email;
+    return leftLabel.localeCompare(rightLabel);
+  });
+}
+
+/** Ordered by installs, so the chart stacks the most installed deck at the bottom of every column. */
+function buildCatalogInstallsPackages(
+  rows: ReadonlyArray<CatalogInstallsRow>,
+): ReadonlyArray<CatalogInstallsPackage> {
+  const installCountsByPackageSlug = new Map<string, number>();
+
+  for (const row of rows) {
+    installCountsByPackageSlug.set(
+      row.packageSlug,
+      (installCountsByPackageSlug.get(row.packageSlug) ?? 0) + row.installCount,
+    );
+  }
+
+  return Array.from(installCountsByPackageSlug.entries())
+    .map(([packageSlug, installCount]) => ({ packageSlug, installCount }))
+    .sort((left, right) => {
+      if (right.installCount !== left.installCount) {
+        return right.installCount - left.installCount;
+      }
+
+      return left.packageSlug.localeCompare(right.packageSlug);
+    });
+}
+
+function buildCatalogInstallsAggregateFields(
+  rows: ReadonlyArray<CatalogInstallsRow>,
+): CatalogInstallsAggregateFields {
+  return {
+    totalInstalls: rows.reduce((total, row) => total + row.installCount, 0),
+    users: buildCatalogInstallsUsers(rows),
+    packages: buildCatalogInstallsPackages(rows),
+  };
+}
+
+function buildCatalogInstallsReport(
+  resultSet: AdminQueryResultSet,
+  executedAtUtc: string,
+  from: string,
+  to: string,
+): CatalogInstallsReport {
+  const rows = resultSet.rows
+    .map(toCatalogInstallsQueryRow)
+    .map((row) => ({
+      date: row.install_date,
+      userId: row.user_id,
+      email: row.email,
+      platform: row.platform,
+      packageSlug: row.package_slug,
+      installCount: toInteger(row.install_count, catalogInstallsReportLabel, "install_count"),
+      cardCount: toInteger(row.card_count, catalogInstallsReportLabel, "card_count"),
+    }));
+
+  return {
+    generatedAtUtc: executedAtUtc,
+    from,
+    to,
+    ...buildCatalogInstallsAggregateFields(rows),
+    rows,
+  };
+}
+
+/**
+ * The cohort of one install, read from the daily active users report instead of recomputed here.
+ *
+ * `null` means the installer has no `app_opened` day inside the loaded range, so that report knows
+ * of no first active day to compare this install against and the row belongs to neither cohort. It
+ * is then kept only while the cohort filter still selects every cohort, which is the state the
+ * filter row treats as "no cohort filter"; any narrowing drops the row rather than guessing a side
+ * for it.
+ */
+function getCatalogInstallsRowCohort(
+  row: CatalogInstallsRow,
+  firstActiveDateByUserId: ReadonlyMap<string, string>,
+): ReviewEventCohort | null {
+  const firstActiveDate = firstActiveDateByUserId.get(row.userId);
+  if (firstActiveDate === undefined) {
+    return null;
+  }
+
+  return firstActiveDate === row.date ? "new" : "returning";
+}
+
+function isUnfilteredCatalogInstallsReport(filters: CatalogInstallsFilterState): boolean {
+  return filters.selectedUserIds.length === 0
+    && filters.selectedCohorts.length === reviewEventCohorts.length
+    && filters.selectedPlatforms.length === reviewEventPlatforms.length;
+}
+
+function shouldIncludeCatalogInstallsRow(
+  row: CatalogInstallsRow,
+  rowFilter: CatalogInstallsRowFilter,
+): boolean {
+  if (rowFilter.selectedUserIds.size > 0 && rowFilter.selectedUserIds.has(row.userId) === false) {
+    return false;
+  }
+
+  const cohort = getCatalogInstallsRowCohort(row, rowFilter.firstActiveDateByUserId);
+  if (cohort === null) {
+    if (rowFilter.keepsUnknownCohort === false) {
+      return false;
+    }
+  } else if (rowFilter.selectedCohorts.has(cohort) === false) {
+    return false;
+  }
+
+  return rowFilter.selectedPlatforms.has(row.platform);
+}
+
+export function filterCatalogInstallsReport(
+  report: CatalogInstallsReport,
+  filters: CatalogInstallsFilterState,
+): CatalogInstallsReport {
+  if (isUnfilteredCatalogInstallsReport(filters)) {
+    return report;
+  }
+
+  const rowFilter: CatalogInstallsRowFilter = {
+    selectedUserIds: new Set(filters.selectedUserIds),
+    selectedCohorts: new Set(filters.selectedCohorts),
+    selectedPlatforms: new Set(filters.selectedPlatforms),
+    firstActiveDateByUserId: filters.firstActiveDateByUserId,
+    keepsUnknownCohort: filters.selectedCohorts.length === reviewEventCohorts.length,
+  };
+  const rows = report.rows.filter((row) => shouldIncludeCatalogInstallsRow(row, rowFilter));
+
+  return {
+    ...report,
+    ...buildCatalogInstallsAggregateFields(rows),
+    rows,
+  };
+}
+
+// Per-actor catalog deck installs for the admin "Catalog deck installs" section. One install action
+// by one person is one event, and one row is one (UTC date, actor, package slug).
+//
+// The shape mirrors `buildReviewEventsByDateSql`: the `org.user_settings` email join folded with
+// `pg_catalog.lower` because `actor_id` renders canonical lowercase hex while
+// `org.user_settings.user_id` is an unconstrained TEXT primary key, the `%@example.com` exclusion
+// restated inline because this package cannot import
+// `exampleComEmailExclusionSqlFragments` from `apps/backend/src/globalMetrics/reporting.ts`, and
+// grouping by `actor_id` so a guest and the account that guest became are one person. Unlike that
+// query this CTE is bounded on both sides, because new versus returning is read from the daily
+// active users report rather than recomputed from a first-install day here.
+//
+// EVERYTHING THIS SECTION NEEDS IS ON THE EVENT. `catalog_deck_installed` is server-only and carries
+// `package_slug` and `card_count` (`apps/backend/src/productAnalytics/catalog.ts`), emitted after the
+// install transaction commits and keyed by `(workspace_id, install_id)` so an idempotent replay
+// cannot double count (`apps/backend/src/catalog/distribution/install/index.ts`). No catalog table is
+// read, so there are no deck titles or version numbers here and the deck dimension is the slug.
+//
+// TWO EXCLUSIONS, AND THEY ARE WHY THIS SECTION IS NEARLY EMPTY ON PRODUCTION HISTORY.
+//   * The delisted test fixture is dropped by slug `'test'` only, the fixture
+//     `db/migrations/0111_delist_catalog_test_fixture.sql` delisted. Package status is not read,
+//     because that needs a `catalog` grant this report deliberately does not take.
+//   * Installs by active admins are dropped. `auth.admin_users.email` is already lower/btrim
+//     normalized by its own CHECK constraint, so only the `org.user_settings` side is folded, and
+//     `revoked_at IS NULL` is what an active grant means. `reporting_readonly` reads that column pair
+//     through `db/migrations/0125_reporting_readonly_admin_users.sql`; without that grant deployed
+//     the whole query fails as HTTP 500 `INTERNAL_ERROR` rather than as a readable permission error.
+// Almost every install in production history is an admin install, so a near-empty chart is the
+// intended default rather than a defect.
+//
+// PLATFORM IS ALWAYS `unattributed`. The producer writes NULL on purpose - the install names no
+// server-stored replica or guest session row, and the request headers that do name a platform are a
+// client claim - and the `0120` backfill wrote none either. The bucket is still derived with the same
+// CASE as every other report rather than invented, so the section obeys the shared platform filter,
+// which means selecting any device platform empties it.
+export function buildCatalogInstallsSql(from: string, to: string): string {
+  assertValidDateRange({ from, to }, catalogInstallsReportLabel);
+
+  return [
+    // The range predicate is on the raw `occurred_at` column rather than on its UTC date so
+    // `idx_product_events_event_name_occurred_at` stays usable as an (event_name, occurred_at) range
+    // scan.
+    "WITH deck_installs AS (",
+    "  SELECT",
+    "    resolved.actor_id::text AS actor_id,",
+    "    (resolved.occurred_at AT TIME ZONE 'UTC')::date AS install_date,",
+    "    CASE",
+    "      WHEN resolved.platform IN ('web', 'android', 'ios', 'agent') THEN resolved.platform",
+    "      ELSE 'unattributed'",
+    "    END AS platform,",
+    "    COALESCE(NULLIF(btrim(user_settings.email), ''), '(no email)') AS email,",
+    "    resolved.event_properties ->> 'package_slug' AS package_slug,",
+    "    (resolved.event_properties ->> 'card_count')::int AS card_count",
+    "  FROM analytics.product_events_resolved AS resolved",
+    "  LEFT JOIN org.user_settings AS user_settings",
+    "    ON pg_catalog.lower(user_settings.user_id) = resolved.actor_id::text",
+    "  WHERE resolved.event_name = 'catalog_deck_installed'",
+    "    AND resolved.occurred_at >= (",
+    `      (${escapeSqlStringLiteral(from)}::date)::timestamp AT TIME ZONE 'UTC'`,
+    "    )",
+    "    AND resolved.occurred_at < (",
+    `      (${escapeSqlStringLiteral(to)}::date + INTERVAL '1 day')::timestamp AT TIME ZONE 'UTC'`,
+    "    )",
+    "    AND resolved.event_properties ->> 'package_slug' <> 'test'",
+    "    AND (",
+    "      user_settings.email IS NULL",
+    "      OR LOWER(btrim(user_settings.email)) NOT LIKE '%@example.com'",
+    "    )",
+    "    AND NOT EXISTS (",
+    "      SELECT 1",
+    "      FROM auth.admin_users AS admin_users",
+    "      WHERE admin_users.email = LOWER(btrim(user_settings.email))",
+    "        AND admin_users.revoked_at IS NULL",
+    "    )",
+    ")",
+    "SELECT",
+    "  to_char(deck_installs.install_date, 'YYYY-MM-DD') AS install_date,",
+    // Emitted under the name the SPA row shape already uses. The value is the resolved actor.
+    "  deck_installs.actor_id AS user_id,",
+    "  deck_installs.email,",
+    "  deck_installs.platform,",
+    "  deck_installs.package_slug,",
+    "  COUNT(*)::int AS install_count,",
+    // The cards those installs added, summed because one person can install one deck more than once
+    // on a day and a later version can carry a different card count.
+    "  SUM(deck_installs.card_count)::int AS card_count",
+    "FROM deck_installs",
+    "GROUP BY",
+    "  deck_installs.install_date,",
+    "  deck_installs.actor_id,",
+    "  deck_installs.email,",
+    "  deck_installs.platform,",
+    "  deck_installs.package_slug",
+    "ORDER BY",
+    "  deck_installs.install_date ASC,",
+    "  install_count DESC,",
+    "  deck_installs.actor_id ASC,",
+    "  deck_installs.package_slug ASC",
+  ].join("\n");
+}
+
+export async function loadCatalogInstallsReport(
+  config: AdminAppConfig,
+  from: string,
+  to: string,
+): Promise<CatalogInstallsReport> {
+  const response = await runAdminQuery(config, buildCatalogInstallsSql(from, to));
+  if (response.resultSets.length !== 1) {
+    throw new Error(`${catalogInstallsReportLabel} must return exactly one result set. Got ${response.resultSets.length}.`);
+  }
+
+  const resultSet = response.resultSets[0];
+  if (resultSet === undefined) {
+    throw new Error(`${catalogInstallsReportLabel} result set is missing.`);
+  }
+
+  return buildCatalogInstallsReport(resultSet, response.executedAtUtc, from, to);
+}

--- a/docs/admin-app.md
+++ b/docs/admin-app.md
@@ -9,9 +9,10 @@ Supported browser entrypoints:
 
 ## Scope
 
-The dashboard carries two report sections, in page order:
+The dashboard carries three report sections, in page order:
 
 - `daily-active-users`
+- `catalog-deck-installs`
 - `review-events-by-date`
 
 The admin app is a separate React + TypeScript + Vite package. It does not reuse the web app runtime storage or sync code.
@@ -76,6 +77,20 @@ Attribution contract for `daily-active-users`:
 - reconstructed and live rows are deliberately not distinguished anywhere in the UI
 - new versus returning is the actor's first `app_opened` day over all history, which is this section's own cohort definition; `review-events-by-date` keeps using the first review day
 - all four shared filters apply: date range reloads the section server-side, and user, cohort and platform are applied client-side
+
+Attribution contract for `catalog-deck-installs`:
+
+- the section answers how many catalog decks were installed on each calendar day and which decks those were; one install action by one person is one event, from `catalog_deck_installed`
+- the event is server-emitted after the install transaction commits and keyed by `(workspace_id, install_id)`, so an idempotent replay of the same install cannot count twice
+- everything the section needs is on the event, so no `catalog` or `sync` table is read; the deck dimension is `package_slug` and there are no deck titles or version numbers here
+- identity works exactly as in `review-events-by-date`: grouped by `actor_id`, the same case-folded `org.user_settings` email join, and the same `%@example.com` exclusion
+- two further exclusions are deliberate: the delisted test fixture, narrowly by `package_slug` `'test'` and never by package status, which would need a `catalog` grant this report does not take; and installs by active admins, joined from `auth.admin_users` on the folded `org.user_settings` email with `revoked_at IS NULL`
+- almost every install in production history is an admin install, so a nearly empty chart is the intended default rather than a defect; the `auth.admin_users` column grant it needs is `db/migrations/0125_reporting_readonly_admin_users.sql`, and without it deployed the section fails as HTTP 500 `INTERNAL_ERROR` rather than as a readable permission error
+- platform is always `unattributed`: the producer writes NULL on purpose, because the install names no server-stored replica or guest session row and the request headers that do name a platform are a client claim, and `db/migrations/0120_backfill_product_analytics_server_facts.sql` wrote none either; the bucket is still derived with the same CASE as every other report, so picking any device platform empties this section
+- new versus returning is not recomputed here: the section reads `daily-active-users`' per-actor first `app_opened` day, so the cohort definition lives in one place
+- that lookup only covers actors with an `app_opened` day inside the loaded range, so an installer without one is in neither cohort and is dropped as soon as the cohort filter narrows, rather than being guessed into `new` or `returning`
+- all four shared filters apply: date range reloads the section server-side, and user, cohort and platform are applied client-side
+- the section carries one chart, installs per UTC day stacked by deck, plus summary tiles
 
 Current v1 attribution contract for `review-events-by-date`:
 
@@ -171,7 +186,11 @@ The admin frontend fails fast on any other non-local hostname. Do not serve the 
 - the default date filter starts on the first app open, review, friend invite, or friendship day and ends on today
 - date, user, new/returning cohort, and platform filters open as popups from the compact filter row
 - the dashboard does not show a persistent email or user list outside the user filter popup
-- the daily active users section renders above `Review activity`, with its new-vs-returning, platform, and stacked-by-user charts and no summary tiles
+- the daily active users section renders above `Catalog deck installs`, with its new-vs-returning, platform, and stacked-by-user charts and no summary tiles
+- `Catalog deck installs` renders between `Daily active users` and `Review activity`, with its summary tiles and its one installs-per-day chart stacked by deck
+- the catalog installs chart is empty or nearly empty on production data, because installs of the `test` fixture deck and installs by active admins are excluded on purpose
+- selecting any device platform empties the catalog installs section while the other sections keep their data
+- hovering a catalog installs segment names the deck slug and shows installs of that deck, all decks on that date, and cards added
 - unique-users, stacked-by-user, platform-users, platform-events, friend-invite-links, and friend-connections charts all render
 - a person keeps the same colour in the daily active users charts and the review charts
 - narrowing the date filter reloads all charts, and Reset all restores the default range and all local filters


### PR DESCRIPTION
Catalog installs were only visible by reading `sync.catalog_package_install_idempotency` by hand. They have been the `catalog_deck_installed` product-analytics event since the pipeline landed, and migration `0120` reconstructed the whole history from that same ledger, so the dashboard can report them directly — no new table, no backend change, and no grant on the `catalog` schema.

A `Catalog deck installs` section renders between `Daily active users` and `Review activity`: installs per UTC day stacked by deck, plus tiles for total installs, unique installers, decks installed and the peak day. The event's id is derived from `(workspace_id, install_id)`, so an idempotent replay conflicts instead of double counting, and one row is one real install action.

Two exclusions live in the SQL rather than behind a UI toggle. The delisted test fixture is dropped by its own `package_slug`, which needs no schema grant. Installs made by an active admin are dropped through `auth.admin_users`, which migration `0125` granted `reporting_readonly` in an earlier PR. Almost every install in production history is an admin install, so the chart is nearly empty by design — that is the intended default, not a defect.

The server writes no platform on this event on purpose, so every install lands in the `unattributed` bucket and selecting a device platform empties the section. Deck is identified by `package_slug`; titles and version numbers are not on the event and are not worth a schema grant.

Cohort is not recomputed here. The section reads the per-actor first-active date the daily active users report already exposes, so the new-versus-returning definition lives in exactly one place. That map only covers actors with an `app_opened` day inside the requested range, so an installer it cannot resolve is dropped by any narrowed cohort filter rather than guessed into `new` or `returning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)