### PR TITLE
refactor(catalog): isolate publication and pointer reader

### DIFF
--- a/apps/backend/src/catalog/distribution/public/publication/dumpGeneration.ts
+++ b/apps/backend/src/catalog/distribution/public/publication/dumpGeneration.ts
@@ -1,7 +1,7 @@
-import { unsafeRepeatableReadReadOnlyTransaction } from "../../../database/core";
-import { parsePublicOrigin } from "../../../shared/publicUrls";
-import type { BackendObservationScope } from "../../../observability/sentry";
-import { loadPublicCatalogSnapshotInExecutor } from "./snapshot";
+import { unsafeRepeatableReadReadOnlyTransaction } from "../../../../database/core";
+import { parsePublicOrigin } from "../../../../shared/publicUrls";
+import type { BackendObservationScope } from "../../../../observability/sentry";
+import { loadPublicCatalogSnapshotInExecutor } from "../snapshot";
 import {
   getCatalogDumpStorageConfig,
   writeCatalogDumpToS3,

--- a/apps/backend/src/catalog/distribution/public/publication/dumpRefresh.ts
+++ b/apps/backend/src/catalog/distribution/public/publication/dumpRefresh.ts
@@ -28,7 +28,7 @@ import {
   captureBackendRuntimeException,
   createBackendObservationScope,
   normalizeCaughtError,
-} from "../../../observability/runtime";
+} from "../../../../observability/runtime";
 
 export type CatalogDumpRefreshTrigger = Readonly<{
   route: string;

--- a/apps/backend/src/catalog/distribution/public/publication/dumpStorage.ts
+++ b/apps/backend/src/catalog/distribution/public/publication/dumpStorage.ts
@@ -1,11 +1,10 @@
 import { createHash } from "node:crypto";
-import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import {
   addBackendBreadcrumb,
   type BackendObservationScope,
-} from "../../../observability/sentry";
-import { HttpError } from "../../../shared/errors";
-import type { CatalogPublicSnapshot } from "../../types";
+} from "../../../../observability/sentry";
+import type { CatalogPublicSnapshot } from "../../../types";
 
 export type CatalogDumpStorageConfig = Readonly<{
   bucketName: string;
@@ -20,23 +19,10 @@ export type CatalogDumpWriteResult = Readonly<{
   byteLength: number;
 }>;
 
-/** Alias object naming the immutable artifact `GET /v1/catalog` redirects to. */
-export type CatalogDumpPointer = Readonly<{
-  objectKey: string;
-  url: string;
-  generatedAt: string;
-}>;
-
-export const catalogDumpPointerUnavailableCode = "CATALOG_DUMP_POINTER_UNAVAILABLE";
-
 const maxS3AttemptCount = 3;
 const catalogDumpObjectKeyPrefix = "catalog";
 const latestCatalogDumpObjectKey = `${catalogDumpObjectKeyPrefix}/latest.json`;
 const pointerCatalogDumpObjectKey = `${catalogDumpObjectKeyPrefix}/pointer.json`;
-const immutableCatalogDumpObjectKeyPattern = new RegExp(
-  `^${catalogDumpObjectKeyPrefix}/[0-9a-f]{64}\\.json$`,
-  "u",
-);
 const catalogDumpContentType = "application/json; charset=utf-8";
 export const immutableCatalogDumpCacheControl = "public, max-age=31536000, immutable";
 const revalidatedCatalogDumpCacheControl = "public, max-age=60";
@@ -168,103 +154,6 @@ async function putCatalogDumpObjectWithRetries(params: Readonly<{
     throw new Error(
       `Failed to write the public catalog dump to s3://${params.bucketName}/${params.objectKey}: ${formatCatalogDumpS3ErrorSummary(error)}`,
     );
-  }
-}
-
-function parseCatalogDumpPointerJson(
-  bodyText: string,
-  cdnBaseUrl: string,
-): CatalogDumpPointer {
-  const parsed: unknown = JSON.parse(bodyText);
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new Error("Public catalog dump pointer must be a JSON object.");
-  }
-
-  const { objectKey, url, generatedAt } = parsed as Readonly<{
-    objectKey?: unknown;
-    url?: unknown;
-    generatedAt?: unknown;
-  }>;
-  // The route turns objectKey into a Location header, so it is held to the key
-  // shape the builder writes. Without this a control character in the key would
-  // reach header validation and fail the request as a 500 instead of this 503.
-  if (typeof objectKey !== "string" || !immutableCatalogDumpObjectKeyPattern.test(objectKey)) {
-    throw new Error(
-      `Public catalog dump pointer objectKey does not name an immutable ${catalogDumpObjectKeyPrefix} artifact.`,
-    );
-  }
-  if (typeof generatedAt !== "string" || generatedAt === "") {
-    throw new Error("Public catalog dump pointer is missing generatedAt.");
-  }
-  if (typeof url !== "string" || url === "") {
-    throw new Error("Public catalog dump pointer is missing url.");
-  }
-
-  // The route sends clients to this URL, so a pointer that names anything other
-  // than the configured distribution is treated as unreadable instead of being
-  // turned into an open redirect.
-  if (url !== `${cdnBaseUrl}/${objectKey}`) {
-    throw new Error(
-      `Public catalog dump pointer url does not name an object on ${cdnBaseUrl}.`,
-    );
-  }
-
-  return { objectKey, url, generatedAt };
-}
-
-function createCatalogDumpPointerUnavailableError(
-  config: CatalogDumpStorageConfig | null,
-  error: unknown,
-): HttpError {
-  const location = config === null
-    ? "public catalog dump storage"
-    : `s3://${config.bucketName}/${pointerCatalogDumpObjectKey}`;
-  return new HttpError(
-    503,
-    `Public catalog dump pointer is unavailable from ${location}: ${formatCatalogDumpS3ErrorSummary(error)}`,
-    catalogDumpPointerUnavailableCode,
-  );
-}
-
-/**
- * Reads the alias object naming the current immutable catalog artifact.
- *
- * `GET /v1/catalog` redirects to `url` instead of recomputing the snapshot, so
- * an unreadable pointer has to fail loudly. Recomputing per request is exactly
- * the load the artifact pipeline removed, and reintroducing it as a fallback
- * would bring back the API Gateway timeouts it was built to stop.
- */
-export async function loadCatalogDumpPointerFromS3(
-  observationScope: BackendObservationScope,
-): Promise<CatalogDumpPointer> {
-  let config: CatalogDumpStorageConfig | null = null;
-
-  try {
-    const resolvedConfig = getCatalogDumpStorageConfig();
-    config = resolvedConfig;
-    const response = await runCatalogDumpS3OperationWithRetries({
-      operation: "get_object",
-      observationScope,
-      bucketName: resolvedConfig.bucketName,
-      objectKey: pointerCatalogDumpObjectKey,
-      run: async () => getCatalogDumpS3Client().send(new GetObjectCommand({
-        Bucket: resolvedConfig.bucketName,
-        Key: pointerCatalogDumpObjectKey,
-      })),
-    });
-
-    if (response.Body === undefined) {
-      throw new Error(
-        `S3 returned an empty body for s3://${resolvedConfig.bucketName}/${pointerCatalogDumpObjectKey}`,
-      );
-    }
-
-    return parseCatalogDumpPointerJson(
-      await response.Body.transformToString(),
-      resolvedConfig.cdnBaseUrl,
-    );
-  } catch (error) {
-    throw createCatalogDumpPointerUnavailableError(config, error);
   }
 }
 

--- a/apps/backend/src/catalog/distribution/public/publication/mediaPublication.ts
+++ b/apps/backend/src/catalog/distribution/public/publication/mediaPublication.ts
@@ -24,20 +24,20 @@ import {
   DeleteObjectCommand,
   ListObjectsV2Command,
 } from "@aws-sdk/client-s3";
-import type { DatabaseExecutor } from "../../../database";
-import { getMediaAssetsStorageConfig } from "../../../mediaAssets/storage/config";
-import { buildMediaBlobStorageKey } from "../../../mediaAssets/storageKeys";
+import type { DatabaseExecutor } from "../../../../database";
+import { getMediaAssetsStorageConfig } from "../../../../mediaAssets/storage/config";
+import { buildMediaBlobStorageKey } from "../../../../mediaAssets/storageKeys";
 import {
   addBackendBreadcrumb,
   type BackendObservationScope,
-} from "../../../observability/sentry";
-import { toSafeNumber } from "../../common";
+} from "../../../../observability/sentry";
+import { toSafeNumber } from "../../../common";
 import {
   buildCatalogMediaObjectKey,
   catalogMediaObjectKeyPrefix,
   isCatalogMediaSha256,
   isPublicCatalogMediaDeliverable,
-} from "../../publicMediaDelivery";
+} from "../../../publicMediaDelivery";
 import {
   formatCatalogDumpS3ErrorSummary,
   getCatalogDumpS3Client,

--- a/apps/backend/src/catalog/distribution/public/publication/reader.ts
+++ b/apps/backend/src/catalog/distribution/public/publication/reader.ts
@@ -1,0 +1,123 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import type { BackendObservationScope } from "../../../../observability/sentry";
+import { HttpError } from "../../../../shared/errors";
+import {
+  formatCatalogDumpS3ErrorSummary,
+  getCatalogDumpS3Client,
+  getCatalogDumpStorageConfig,
+  runCatalogDumpS3OperationWithRetries,
+  type CatalogDumpStorageConfig,
+} from "./dumpStorage";
+
+/** Alias object naming the immutable artifact `GET /v1/catalog` redirects to. */
+export type CatalogDumpPointer = Readonly<{
+  objectKey: string;
+  url: string;
+  generatedAt: string;
+}>;
+
+export const catalogDumpPointerUnavailableCode = "CATALOG_DUMP_POINTER_UNAVAILABLE";
+
+const catalogDumpObjectKeyPrefix = "catalog";
+const pointerCatalogDumpObjectKey = `${catalogDumpObjectKeyPrefix}/pointer.json`;
+const immutableCatalogDumpObjectKeyPattern = new RegExp(
+  `^${catalogDumpObjectKeyPrefix}/[0-9a-f]{64}\\.json$`,
+  "u",
+);
+
+function parseCatalogDumpPointerJson(
+  bodyText: string,
+  cdnBaseUrl: string,
+): CatalogDumpPointer {
+  const parsed: unknown = JSON.parse(bodyText);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Public catalog dump pointer must be a JSON object.");
+  }
+
+  const { objectKey, url, generatedAt } = parsed as Readonly<{
+    objectKey?: unknown;
+    url?: unknown;
+    generatedAt?: unknown;
+  }>;
+  // The route turns objectKey into a Location header, so it is held to the key
+  // shape the builder writes. Without this a control character in the key would
+  // reach header validation and fail the request as a 500 instead of this 503.
+  if (typeof objectKey !== "string" || !immutableCatalogDumpObjectKeyPattern.test(objectKey)) {
+    throw new Error(
+      `Public catalog dump pointer objectKey does not name an immutable ${catalogDumpObjectKeyPrefix} artifact.`,
+    );
+  }
+  if (typeof generatedAt !== "string" || generatedAt === "") {
+    throw new Error("Public catalog dump pointer is missing generatedAt.");
+  }
+  if (typeof url !== "string" || url === "") {
+    throw new Error("Public catalog dump pointer is missing url.");
+  }
+
+  // The route sends clients to this URL, so a pointer that names anything other
+  // than the configured distribution is treated as unreadable instead of being
+  // turned into an open redirect.
+  if (url !== `${cdnBaseUrl}/${objectKey}`) {
+    throw new Error(
+      `Public catalog dump pointer url does not name an object on ${cdnBaseUrl}.`,
+    );
+  }
+
+  return { objectKey, url, generatedAt };
+}
+
+function createCatalogDumpPointerUnavailableError(
+  config: CatalogDumpStorageConfig | null,
+  error: unknown,
+): HttpError {
+  const location = config === null
+    ? "public catalog dump storage"
+    : `s3://${config.bucketName}/${pointerCatalogDumpObjectKey}`;
+  return new HttpError(
+    503,
+    `Public catalog dump pointer is unavailable from ${location}: ${formatCatalogDumpS3ErrorSummary(error)}`,
+    catalogDumpPointerUnavailableCode,
+  );
+}
+
+/**
+ * Reads the alias object naming the current immutable catalog artifact.
+ *
+ * `GET /v1/catalog` redirects to `url` instead of recomputing the snapshot, so
+ * an unreadable pointer has to fail loudly. Recomputing per request is exactly
+ * the load the artifact pipeline removed, and reintroducing it as a fallback
+ * would bring back the API Gateway timeouts it was built to stop.
+ */
+export async function loadCatalogDumpPointerFromS3(
+  observationScope: BackendObservationScope,
+): Promise<CatalogDumpPointer> {
+  let config: CatalogDumpStorageConfig | null = null;
+
+  try {
+    const resolvedConfig = getCatalogDumpStorageConfig();
+    config = resolvedConfig;
+    const response = await runCatalogDumpS3OperationWithRetries({
+      operation: "get_object",
+      observationScope,
+      bucketName: resolvedConfig.bucketName,
+      objectKey: pointerCatalogDumpObjectKey,
+      run: async () => getCatalogDumpS3Client().send(new GetObjectCommand({
+        Bucket: resolvedConfig.bucketName,
+        Key: pointerCatalogDumpObjectKey,
+      })),
+    });
+
+    if (response.Body === undefined) {
+      throw new Error(
+        `S3 returned an empty body for s3://${resolvedConfig.bucketName}/${pointerCatalogDumpObjectKey}`,
+      );
+    }
+
+    return parseCatalogDumpPointerJson(
+      await response.Body.transformToString(),
+      resolvedConfig.cdnBaseUrl,
+    );
+  } catch (error) {
+    throw createCatalogDumpPointerUnavailableError(config, error);
+  }
+}

--- a/apps/backend/src/catalog/publicMediaDelivery.ts
+++ b/apps/backend/src/catalog/publicMediaDelivery.ts
@@ -2,7 +2,7 @@
  * What the public catalog may deliver, and where the delivered object lives.
  *
  * The predicate and the object key belong together: the reconcile in
- * `distribution/public/mediaPublication.ts` publishes exactly the blobs this
+ * `distribution/public/publication/mediaPublication.ts` publishes exactly the blobs this
  * predicate accepts, so a reader may only point at the CDN for an asset the
  * same predicate accepts. The builders live in this dependency-free module
  * rather than beside the reconcile so the read paths can address a published

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-catalog-dump.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-catalog-dump.ts
@@ -23,13 +23,13 @@ type CatalogDumpResponse = Readonly<{
 }>;
 
 type CatalogDumpRuntime = Readonly<{
-  generateAndWriteCatalogDump: typeof import("../../catalog/distribution/public/dumpGeneration").generateAndWriteCatalogDump;
+  generateAndWriteCatalogDump: typeof import("../../catalog/distribution/public/publication/dumpGeneration").generateAndWriteCatalogDump;
 }>;
 
 let catalogDumpRuntimePromise: Promise<CatalogDumpRuntime> | null = null;
 
 async function createCatalogDumpRuntime(): Promise<CatalogDumpRuntime> {
-  const { generateAndWriteCatalogDump } = await import("../../catalog/distribution/public/dumpGeneration");
+  const { generateAndWriteCatalogDump } = await import("../../catalog/distribution/public/publication/dumpGeneration");
   return {
     generateAndWriteCatalogDump,
   };

--- a/apps/backend/src/routes/catalog/admin.ts
+++ b/apps/backend/src/routes/catalog/admin.ts
@@ -21,7 +21,7 @@ import {
 import {
   refreshPublicCatalogDump,
   type CatalogDumpRefreshTrigger,
-} from "../../catalog/distribution/public/dumpRefresh";
+} from "../../catalog/distribution/public/publication/dumpRefresh";
 import {
   catalogPackageStatuses,
   type AttachCatalogPackageMediaAssetInput,

--- a/apps/backend/src/routes/catalog/adminImageIngestion.ts
+++ b/apps/backend/src/routes/catalog/adminImageIngestion.ts
@@ -17,7 +17,7 @@ import { normalizePackageMediaKey } from "../../catalog/common";
 import {
   refreshPublicCatalogDump,
   type CatalogDumpRefreshTrigger,
-} from "../../catalog/distribution/public/dumpRefresh";
+} from "../../catalog/distribution/public/publication/dumpRefresh";
 import type {
   CatalogCollectionCover,
   CatalogPackageMediaAsset,

--- a/apps/backend/src/routes/catalog/public.ts
+++ b/apps/backend/src/routes/catalog/public.ts
@@ -13,12 +13,12 @@ import {
   normalizeSlug,
 } from "../../catalog/common";
 // Narrow path on purpose: the catalog barrels must not start carrying the dump
-// storage module into Lambdas that never touch the artifact bucket.
+// reader into Lambdas that never touch the artifact bucket.
 import {
   catalogDumpPointerUnavailableCode,
   loadCatalogDumpPointerFromS3,
   type CatalogDumpPointer,
-} from "../../catalog/distribution/public/dumpStorage";
+} from "../../catalog/distribution/public/publication/reader";
 import {
   buildCatalogMediaCdnUrl,
   getPublicCatalogMediaDeliveryIssue,
@@ -201,7 +201,7 @@ function createCatalogPublicScope(
  * That accessor also requires `CATALOG_DUMP_S3_BUCKET_NAME`, which the media and
  * browse routes never read. `GET /catalog` does read it: its
  * `loadCatalogDumpPointerFromS3` in
- * apps/backend/src/catalog/distribution/public/dumpStorage.ts calls
+ * apps/backend/src/catalog/distribution/public/publication/reader.ts calls
  * `getCatalogDumpStorageConfig()` to resolve the bucket the pointer object is
  * fetched from, so the variable stays required on `BackendHandler` in
  * infra/aws/lib/gateways/api-gateway.ts. Resolving the whole config here would

--- a/infra/aws/lib/catalog-dump.ts
+++ b/infra/aws/lib/catalog-dump.ts
@@ -46,7 +46,7 @@ export const catalogDumpPointerObjectKey = `${catalogDumpObjectKeyPrefix}/pointe
 /**
  * Prefix of the dump bucket the builder publishes public catalog media blobs to.
  * Must stay in sync with `catalogMediaObjectKeyPrefix` in
- * `apps/backend/src/catalog/distribution/public/mediaPublication.ts`.
+ * `apps/backend/src/catalog/distribution/public/publication/mediaPublication.ts`.
  */
 const catalogDumpMediaObjectKeyPrefix = `${catalogDumpObjectKeyPrefix}/media/`;
 


### PR DESCRIPTION
Public catalog browsing and artifact publication shared one flat module group. Give publication its own directory and separate narrow generation, refresh, and pointer-reader entrypoints, keeping the direct-image Lambda's lightweight import boundary intact.

Preserve catalog URLs, snapshot/media ordering, S3 keys, retry behavior, and lazy worker loading. Independent static review found no issues; executable validation runs in cloud CI.
