### PR TITLE
Default AI-authored card fronts to short prompts

### DIFF
--- a/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
+++ b/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
@@ -12,7 +12,7 @@ export const SQL_EXECUTE_TOOL_NAME = "sql_execute";
  * answer. Shared so the MCP tools and the in-app AI agent stay on one contract.
  */
 export const FRONT_BACK_CONTRACT =
-  "Card side contract: front_text is only a question or review prompt and must never contain the answer; back_text contains the answer, optionally with a concrete example (prefer a fenced markdown code block when helpful).";
+  "Card side contract: front_text is only a question or review prompt and must never contain the answer; back_text contains the answer, optionally with a concrete example (prefer a fenced markdown code block when helpful). Keep front_text short by default, usually one word, a term, or a brief phrase rather than a full sentence question, while back_text may still be long; write a longer front_text only when the user asks for it or when similar existing cards in the same deck, tag, or topic already use long fronts.";
 
 /**
  * Canonical Markdown and LaTeX authoring contract for every agent surface.

--- a/apps/backend/src/chat/shared.ts
+++ b/apps/backend/src/chat/shared.ts
@@ -34,6 +34,9 @@ function buildCardSideContractSection(): string {
   return joinLines([
     "Card side contract:",
     "- Front side must contain only a question or recall prompt. Never include the answer on the front side.",
+    "- Keep the front short by default: usually one word, a term, or a brief phrase, not a full sentence question.",
+    "- Front brevity does not limit the back side, which may still be long.",
+    "- Write a longer front only when the user asks for it, or when similar existing cards in the same deck, tag, or topic already use long fronts.",
     "- Back side must start with the direct answer.",
     "- When the back side is longer than one short sentence, format it as real Markdown instead of dense plain text.",
     "- Use blank lines between paragraphs on longer back sides so the rendered card stays readable.",


### PR DESCRIPTION
AI-authored fronts were drifting toward full-sentence questions. This adds a short-front default to the card side contract, keeps back sides unconstrained, and leaves explicit escape hatches for long fronts.

## Changes

- `apps/backend/src/chat/shared.ts` — three bullets in the in-app chat card side contract: front short by default (one word, a term, or a brief phrase, not a full sentence question), front brevity does not limit the back, longer front only on user request or when similar cards in the same deck/tag/topic already use long fronts.
- `apps/backend/src/aiTools/toolContract/sqlToolContract.ts` — same rule appended to `FRONT_BACK_CONTRACT`, so the MCP `sql_query` / `sql_execute` tool descriptions and the `GET /v1/agent` discovery payload carry it too.

## Notes

- The existing "Card style alignment" section already tells the model to inspect similar cards and preserve patterns such as one-word fronts, so the already-long-category escape hatch reinforces that rather than fighting it.
- `CLAUDE.md` is deliberately untouched: it states the side contract as mandatory across all clients and APIs, and this is a default with explicit exceptions, not a hard rule.
- Both edits are string-literal only. No test pins the prompt text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)