### PR TITLE
End a chat live attach superseded by the same client

### DIFF
--- a/apps/backend/src/chat/live/index.ts
+++ b/apps/backend/src/chat/live/index.ts
@@ -22,6 +22,7 @@ import {
   type ChatLiveLifecycleDetails,
 } from "../../observability/sentry";
 import {
+  claimChatLiveAttachOwnership,
   getChatRunSnapshot,
   getRecoveredChatSessionSnapshot,
   type ChatRunSnapshot,
@@ -50,9 +51,16 @@ const MAX_CONNECTION_DURATION_MS = 9 * 60 * 1000;
 type ChatLiveStreamDependencies = Readonly<{
   getRecoveredChatSessionSnapshot: typeof getRecoveredChatSessionSnapshot;
   getChatRunSnapshot: typeof getChatRunSnapshot;
+  claimChatLiveAttachOwnership: typeof claimChatLiveAttachOwnership;
   listChatMessagesAfterCursor: typeof listChatMessagesAfterCursor;
   listChatMessagesLatest: typeof listChatMessagesLatest;
   waitForNextPollInterval: typeof waitForNextPollInterval;
+}>;
+
+// The attach this connection owns, present only when the client identified its runtime.
+type LiveAttachOwnership = Readonly<{
+  clientId: string;
+  seq: number;
 }>;
 
 export type ChatLiveStreamResult = Readonly<{
@@ -83,6 +91,7 @@ type BacklogReplayState = Readonly<{
 const defaultChatLiveStreamDependencies: ChatLiveStreamDependencies = {
   getRecoveredChatSessionSnapshot,
   getChatRunSnapshot,
+  claimChatLiveAttachOwnership,
   listChatMessagesAfterCursor,
   listChatMessagesLatest,
   waitForNextPollInterval,
@@ -132,6 +141,7 @@ function buildChatLiveLifecycleDetails(
       afterCursor: params.afterCursor ?? null,
       clientRequestId: params.clientRequestId ?? null,
       resumeAttemptId: params.resumeAttemptId ?? null,
+      liveAttachClientId: params.liveAttachClientId ?? null,
       clientPlatform: params.clientPlatform ?? null,
       clientVersion: params.clientVersion ?? null,
       connectionDurationMs: payload.connectionDurationMs,
@@ -150,6 +160,7 @@ function buildChatLiveLifecycleDetails(
     afterCursor: params.afterCursor ?? null,
     clientRequestId: params.clientRequestId ?? null,
     resumeAttemptId: params.resumeAttemptId ?? null,
+    liveAttachClientId: params.liveAttachClientId ?? null,
     clientPlatform: params.clientPlatform ?? null,
     clientVersion: params.clientVersion ?? null,
     connectionDurationMs: payload.connectionDurationMs,
@@ -214,6 +225,17 @@ function cursorOrNull(lastEmittedCursor: number): string | null {
 
 function isOpenRunStatus(status: ChatRunSnapshot["status"]): boolean {
   return status === "queued" || status === "running";
+}
+
+// Only the same client instance can supersede this attach. Two tabs or two devices on one run would
+// otherwise terminate each other and reconnect in a loop.
+function isSupersededAttach(
+  run: ChatRunSnapshot,
+  ownership: LiveAttachOwnership | null,
+): boolean {
+  return ownership !== null
+    && run.liveAttachClientId === ownership.clientId
+    && run.liveAttachSeq > ownership.seq;
 }
 
 function findAssistantMessageByItemId(
@@ -603,6 +625,19 @@ export async function runLiveStreamWithDependencies(
       return buildLiveStreamResult();
     }
 
+    const liveAttachClientId = params.liveAttachClientId;
+    const liveAttachOwnership: LiveAttachOwnership | null = liveAttachClientId === undefined
+      ? null
+      : {
+        clientId: liveAttachClientId,
+        seq: await dependencies.claimChatLiveAttachOwnership(
+          params.userId,
+          params.workspaceId,
+          params.runId,
+          liveAttachClientId,
+        ),
+      };
+
     const backlogState = await replayBacklogEvents(
       params,
       initialRun.assistantItemId,
@@ -645,6 +680,14 @@ export async function runLiveStreamWithDependencies(
       if (run === null || run.sessionId !== params.sessionId) {
         emitTerminal(buildResetRequiredPayload(lastDeliveredCursor, initialRun.assistantItemId));
         terminationReason = "missing_run";
+        break;
+      }
+
+      // The same client instance attached again, so this container is redundant and released here.
+      // A client that already abandoned this connection locally simply ignores the reset.
+      if (isSupersededAttach(run, liveAttachOwnership)) {
+        emitTerminal(buildResetRequiredPayload(lastDeliveredCursor, run.assistantItemId));
+        terminationReason = "superseded_attach";
         break;
       }
 

--- a/apps/backend/src/chat/live/request.ts
+++ b/apps/backend/src/chat/live/request.ts
@@ -30,6 +30,10 @@ export type LiveStreamParams = Readonly<{
   requestId?: string;
   clientRequestId?: string;
   resumeAttemptId?: string;
+  // The client runtime that opened this attach. Clients released before the header existed send
+  // nothing, and a value that is not a UUID is dropped on read; an attach without it is never
+  // superseded.
+  liveAttachClientId?: string;
   clientPlatform?: string;
   clientVersion?: string;
 }>;
@@ -52,7 +56,9 @@ const defaultHandleLiveRequestDependencies: HandleLiveRequestDependencies = {
   assertChatLiveRunAccessFn: assertChatLiveRunAccess,
 };
 
-const chatRequestIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// Shape required of the two headers read through readOptionalUuidHeader: X-Chat-Request-Id and
+// X-Chat-Live-Client-Id.
+const uuidHeaderPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function readOptionalHeader(headers: Headers | Record<string, string | undefined>, name: string): string | undefined {
   if (headers instanceof Headers) {
@@ -71,20 +77,27 @@ function readOptionalHeader(headers: Headers | Record<string, string | undefined
   return undefined;
 }
 
-export function readOptionalChatRequestIdHeader(
+function readOptionalUuidHeader(
   headers: Headers | Record<string, string | undefined>,
+  name: string,
 ): string | undefined {
-  const value = readOptionalHeader(headers, "X-Chat-Request-Id");
+  const value = readOptionalHeader(headers, name);
   if (value === undefined) {
     return undefined;
   }
 
   const trimmedValue = value.trim();
-  if (trimmedValue === "" || !chatRequestIdPattern.test(trimmedValue)) {
+  if (trimmedValue === "" || !uuidHeaderPattern.test(trimmedValue)) {
     return undefined;
   }
 
   return trimmedValue;
+}
+
+export function readOptionalChatRequestIdHeader(
+  headers: Headers | Record<string, string | undefined>,
+): string | undefined {
+  return readOptionalUuidHeader(headers, "X-Chat-Request-Id");
 }
 
 /**
@@ -140,6 +153,7 @@ export async function handleLiveRequest(
       traceContext: verifiedLiveAuth.traceContext ?? null,
       ...(clientRequestId === undefined ? {} : { clientRequestId }),
       resumeAttemptId: readOptionalHeader(headers, "X-Chat-Resume-Attempt-Id"),
+      liveAttachClientId: readOptionalUuidHeader(headers, "X-Chat-Live-Client-Id"),
       clientPlatform: readOptionalHeader(headers, "X-Client-Platform"),
       clientVersion: readOptionalHeader(headers, "X-Client-Version"),
     };
@@ -199,6 +213,7 @@ export async function handleLiveRequest(
     traceContext: null,
     ...(clientRequestId === undefined ? {} : { clientRequestId }),
     resumeAttemptId: readOptionalHeader(headers, "X-Chat-Resume-Attempt-Id"),
+    liveAttachClientId: readOptionalUuidHeader(headers, "X-Chat-Live-Client-Id"),
     clientPlatform: readOptionalHeader(headers, "X-Client-Platform"),
     clientVersion: readOptionalHeader(headers, "X-Client-Version"),
   };

--- a/apps/backend/src/chat/runs.ts
+++ b/apps/backend/src/chat/runs.ts
@@ -24,6 +24,7 @@ export {
 export type { ChatRunClaimFenceParams, ChatRunClaimState } from "./runs/claimFence";
 
 export {
+  claimChatLiveAttachOwnership,
   getChatRunSnapshot,
   getRecoveredChatSessionSnapshot,
   getRecoveredPaginatedSession,

--- a/apps/backend/src/chat/runs/lifecycleService.test.ts
+++ b/apps/backend/src/chat/runs/lifecycleService.test.ts
@@ -66,6 +66,8 @@ function createRunRow(
     finished_at: null,
     last_error_message: null,
     initiating_auth_is_signed_in: false,
+    live_attach_client_id: null,
+    live_attach_seq: "0",
     ...overrides,
   };
 }

--- a/apps/backend/src/chat/runs/readService.ts
+++ b/apps/backend/src/chat/runs/readService.ts
@@ -3,6 +3,7 @@ import {
   recoverStaleRunWithExecutor,
 } from "./finalization";
 import {
+  claimChatLiveAttachOwnershipWithExecutor,
   selectChatRunWithExecutor,
   selectSessionForUpdateWithExecutor,
 } from "./repository";
@@ -22,6 +23,15 @@ function toEpochMillisOrNull(value: string | null): number | null {
   }
 
   return new Date(value).getTime();
+}
+
+function toLiveAttachSeq(value: string): number {
+  const liveAttachSeq = Number(value);
+  if (!Number.isSafeInteger(liveAttachSeq) || liveAttachSeq < 0) {
+    throw new RangeError(`Chat run live attach sequence is not a non-negative safe integer: ${value}`);
+  }
+
+  return liveAttachSeq;
 }
 
 /**
@@ -105,6 +115,27 @@ export async function getChatRunSnapshot(
       startedAt: toEpochMillisOrNull(run.started_at),
       finishedAt: toEpochMillisOrNull(run.finished_at),
       lastErrorMessage: run.last_error_message,
+      liveAttachClientId: run.live_attach_client_id,
+      liveAttachSeq: toLiveAttachSeq(run.live_attach_seq),
     };
   });
+}
+
+/**
+ * Makes this attach the owning live SSE connection for the run and returns the sequence it owns.
+ * A later attach from the same client instance supersedes it by taking a greater sequence.
+ */
+export async function claimChatLiveAttachOwnership(
+  userId: string,
+  workspaceId: string,
+  runId: string,
+  liveAttachClientId: string,
+): Promise<number> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) =>
+    toLiveAttachSeq(await claimChatLiveAttachOwnershipWithExecutor(
+      executor,
+      { userId, workspaceId },
+      runId,
+      liveAttachClientId,
+    )));
 }

--- a/apps/backend/src/chat/runs/repository.ts
+++ b/apps/backend/src/chat/runs/repository.ts
@@ -48,6 +48,13 @@ export type ChatRunRow = Readonly<{
   finished_at: string | null;
   last_error_message: string | null;
   initiating_auth_is_signed_in: boolean;
+  live_attach_client_id: string | null;
+  // BIGINT, which node-postgres hands back as a string.
+  live_attach_seq: string;
+}>;
+
+export type ChatLiveAttachOwnershipRow = Readonly<{
+  live_attach_seq: string;
 }>;
 
 export type ChatRunClaimRow = Readonly<{
@@ -139,7 +146,9 @@ const CHAT_RUN_COLUMNS_SQL = `
     started_at,
     finished_at,
     last_error_message,
-    initiating_auth_is_signed_in
+    initiating_auth_is_signed_in,
+    live_attach_client_id,
+    live_attach_seq
 `;
 
 const SELECT_CHAT_RUN_SQL = `
@@ -244,6 +253,15 @@ const UPDATE_CHAT_RUN_POLICY_SNAPSHOT_SQL = `
   WHERE run_id = $1
   RETURNING
 ${CHAT_RUN_COLUMNS_SQL}
+`;
+
+// Deliberately leaves updated_at alone: attaching to a run observes it, it does not progress it.
+const CLAIM_CHAT_LIVE_ATTACH_OWNERSHIP_SQL = `
+  UPDATE ai.chat_runs
+  SET live_attach_client_id = $2,
+      live_attach_seq = live_attach_seq + 1
+  WHERE run_id = $1
+  RETURNING live_attach_seq
 `;
 
 const SELECT_SESSION_FOR_UPDATE_SQL = `
@@ -590,6 +608,27 @@ export async function selectChatRunClaimForUpdateWithExecutor(
       [runId],
     );
     return rows[0] ?? null;
+  });
+}
+
+export async function claimChatLiveAttachOwnershipWithExecutor(
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  runId: string,
+  liveAttachClientId: string,
+): Promise<string> {
+  return withScopedExecutor(executor, scope, async () => {
+    const rows = await executeQuery<ChatLiveAttachOwnershipRow>(
+      executor,
+      CLAIM_CHAT_LIVE_ATTACH_OWNERSHIP_SQL,
+      [runId, liveAttachClientId],
+    );
+    const row = rows[0];
+    if (row === undefined) {
+      throw new ChatRunRowNotFoundError("live attach ownership claim");
+    }
+
+    return row.live_attach_seq;
   });
 }
 

--- a/apps/backend/src/chat/runs/types.ts
+++ b/apps/backend/src/chat/runs/types.ts
@@ -95,6 +95,8 @@ export type ChatRunSnapshot = Readonly<{
   startedAt: number | null;
   finishedAt: number | null;
   lastErrorMessage: string | null;
+  liveAttachClientId: string | null;
+  liveAttachSeq: number;
 }>;
 
 export type RecoveredPaginatedSession = Readonly<{

--- a/apps/backend/src/chat/tests/live/errors.test.ts
+++ b/apps/backend/src/chat/tests/live/errors.test.ts
@@ -117,6 +117,7 @@ test("handleLiveRequest uses the authoritative Cognito profile for downstream ac
     {
       "X-Chat-Resume-Attempt-Id": "resume-1",
       "X-Chat-Request-Id": "11111111-2222-4333-8444-555555555555",
+      "X-Chat-Live-Client-Id": "77777777-8888-4999-8aaa-bbbbbbbbbbbb",
       "X-Client-Platform": "web",
       "X-Client-Version": "web-test",
     },
@@ -179,6 +180,7 @@ test("handleLiveRequest uses the authoritative Cognito profile for downstream ac
     workspaceId: EXPLICIT_WORKSPACE_ID,
     clientRequestId: "11111111-2222-4333-8444-555555555555",
     resumeAttemptId: "resume-1",
+    liveAttachClientId: "77777777-8888-4999-8aaa-bbbbbbbbbbbb",
     clientPlatform: "web",
     clientVersion: "web-test",
     traceContext: null,

--- a/apps/backend/src/chat/tests/live/resume.test.ts
+++ b/apps/backend/src/chat/tests/live/resume.test.ts
@@ -47,7 +47,14 @@ function createRunSnapshot(
     startedAt: 1,
     finishedAt: params.status === "queued" || params.status === "running" ? null : 2,
     lastErrorMessage: params.lastErrorMessage,
+    liveAttachClientId: null,
+    liveAttachSeq: 0,
   };
+}
+
+// These attaches send no X-Chat-Live-Client-Id, so no ownership may ever be claimed for them.
+async function refuseLiveAttachOwnershipClaim(): Promise<number> {
+  throw new Error("Live attach ownership was claimed for an attach without a live client id.");
 }
 
 function createRunningSessionSnapshot(
@@ -168,6 +175,7 @@ test("resume replay emits terminal assistant backlog after afterCursor", async (
         assistantItemId: "assistant-1",
         lastErrorMessage: null,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createRunningSessionSnapshot(),
       listChatMessagesAfterCursor: async (_userId, _workspaceId, _sessionId, afterCursor) =>
         afterCursor === 5
@@ -259,6 +267,7 @@ test("completed live replay emits composer suggestions before the terminal event
         assistantItemId: "assistant-1",
         lastErrorMessage: null,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createRunningSessionSnapshot(composerSuggestions),
       listChatMessagesAfterCursor: async () => [],
       listChatMessagesLatest: async () => ({
@@ -320,6 +329,7 @@ test("interrupted live replay keeps the existing error outcome contract and incl
         assistantItemId: "assistant-1",
         lastErrorMessage: timeoutMessage,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createInterruptedSessionSnapshot(),
       listChatMessagesAfterCursor: async () => [],
       listChatMessagesLatest: async () => ({
@@ -373,6 +383,7 @@ test("resume replay seeds in-progress assistant content and continues live delta
         assistantItemId: "assistant-2",
         lastErrorMessage: null,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createRunningSessionSnapshot(),
       listChatMessagesAfterCursor: async (_userId, _workspaceId, _sessionId, afterCursor) => {
         if (afterCursor === 5) {
@@ -457,6 +468,7 @@ test("terminal replay emits assistant_message_done before run_terminal when the 
             lastErrorMessage: null,
           });
       },
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createRunningSessionSnapshot(),
       listChatMessagesAfterCursor: async (_userId, _workspaceId, _sessionId, afterCursor) => {
         if (afterCursor === 5) {
@@ -558,6 +570,7 @@ test("terminal replay falls back to reset_required when a completed run has only
             lastErrorMessage: null,
           });
       },
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createRunningSessionSnapshot(),
       listChatMessagesAfterCursor: async (_userId, _workspaceId, _sessionId, afterCursor) => {
         if (afterCursor === 5) {
@@ -626,6 +639,7 @@ test("resume replay emits reset_required when backlog contains multiple in-progr
         assistantItemId: "assistant-3",
         lastErrorMessage: null,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createRunningSessionSnapshot(),
       listChatMessagesAfterCursor: async () => [
         makeAssistantMessage({
@@ -693,6 +707,7 @@ test("recovered session read emits terminal events when the attached run finaliz
             lastErrorMessage: null,
           });
       },
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createIdleSessionSnapshot([]),
       listChatMessagesAfterCursor: async (_userId, _workspaceId, _sessionId, afterCursor) => {
         if (afterCursor === 5) {
@@ -778,6 +793,7 @@ test("recovered session read emits reset_required immediately when the attached 
         assistantItemId: "assistant-8",
         lastErrorMessage: null,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => createInterruptedSessionSnapshot(),
       listChatMessagesAfterCursor: async () => [],
       listChatMessagesLatest: async () => ({
@@ -824,6 +840,7 @@ test("poll failures mark the stream result for Sentry flush and keep the termina
         assistantItemId: "assistant-9",
         lastErrorMessage: null,
       }),
+      claimChatLiveAttachOwnership: refuseLiveAttachOwnershipClaim,
       getRecoveredChatSessionSnapshot: async () => {
         throw new Error("session poll failed");
       },

--- a/apps/backend/src/observability/sentry/events/chat.ts
+++ b/apps/backend/src/observability/sentry/events/chat.ts
@@ -72,6 +72,7 @@ export type ChatLiveLifecycleDetails = Readonly<{
   afterCursor: number | null;
   clientRequestId: string | null;
   resumeAttemptId: string | null;
+  liveAttachClientId: string | null;
   clientPlatform: string | null;
   clientVersion: string | null;
   connectionDurationMs: number | null;

--- a/db/migrations/0127_ai_chat_run_live_attach_ownership.sql
+++ b/db/migrations/0127_ai_chat_run_live_attach_ownership.sql
@@ -1,0 +1,26 @@
+-- Migration status: Current / additive.
+-- Introduces: ai.chat_runs.live_attach_client_id and ai.chat_runs.live_attach_seq, the record of
+--   which live SSE attach currently owns a run. A chat-live connection holds a whole Lambda
+--   container for its lifetime, and the Function URL never reports that a browser or app went away,
+--   so a reconnecting client instance used to leave every earlier container attached until the run
+--   finished and could exhaust the reservation on its own. With these columns each identified
+--   attach claims the run, and an earlier attach from the same client instance ends as soon as a
+--   later one claims it.
+-- Schemas touched/read explicitly: ai.
+
+ALTER TABLE ai.chat_runs
+  ADD COLUMN IF NOT EXISTS live_attach_client_id TEXT,
+  ADD COLUMN IF NOT EXISTS live_attach_seq BIGINT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN ai.chat_runs.live_attach_client_id IS
+  'Client instance holding the newest live SSE attach on this run, a UUID from the '
+  'X-Chat-Live-Client-Id request header and only ever compared, never parsed. It names a client '
+  'runtime, not a request and not a device. NULL means no attach ever claimed this run, either '
+  'because the client sent no X-Chat-Live-Client-Id or because the value it sent was dropped on '
+  'read; neither is ever superseded.';
+
+COMMENT ON COLUMN ai.chat_runs.live_attach_seq IS
+  'Counter incremented by each identified live SSE attach on this run. An attach keeps the value '
+  'its own claim returned and ends once the run carries the same live_attach_client_id at a '
+  'strictly greater value. Two different client instances on one run never supersede each other, '
+  'because that would only make them reconnect against one another.';

--- a/infra/aws/lib/lambda-database-capacity.ts
+++ b/infra/aws/lib/lambda-database-capacity.ts
@@ -78,8 +78,8 @@ export const authHandlerReservedConcurrency = 6;
 export const mcpHandlerReservedConcurrency = 4;
 // Production reached the previous cap of 10 on 2026-09-02, with two same-minute throttles and 40
 // throttles through 05:04 UTC. A reservation of 16 gives round headroom above at least 12
-// simultaneous attempts. SSE holds a container for the whole stream, up to 222 s, so concurrency
-// here is set by session duration rather than by requests per second.
+// simultaneous attempts. SSE holds a container for the whole stream, so concurrency here is set by
+// session duration rather than by requests per second.
 export const chatLiveHandlerReservedConcurrency = 16;
 // Observed 1/1/2, sized above the weekly max. A run holds a container up to 720 s, under the shared
 // 15-minute timeout, so the same duration-driven reasoning applies.


### PR DESCRIPTION
## Why

A chat live SSE connection holds a whole Lambda container for its lifetime, and the Lambda Function URL never propagates that the browser or app went away — 548 stream closes in the week of 2026-09-01 produced **zero** `client_disconnect` events. So every client reconnect left the previous container attached until the run finished.

Concurrency on that function is therefore `reconnects × run duration`, not `active users`. 46 of 458 runs carried 2–7 simultaneous connections for one `runId` (`X-Chat-Resume-Attempt-Id` reached 30 and 31 on a single run). That exhausted the 16-slot reservation on 2026-09-02 (40 throttles) and again on 2026-09-07, when 37 attaches were rejected with 429 across about ten minutes — in one 15-minute window only 3 invocations got through against 37 rejections.

Raising the reservation was already tried on 2026-09-02 (10 → 16) and the saturation returned five days later, so this fixes the leak instead.

## What

- `db/migrations/0127`: additive `live_attach_client_id` and `live_attach_seq` on `ai.chat_runs`.
- An attach that identifies its client runtime claims the run; on its next 750 ms poll, an earlier attach from **that same client instance** ends with the existing reset-required terminal event and the new `superseded_attach` termination reason.
- Two different client instances on one run never supersede each other. Doing so would make two tabs reconnect against one another and consume more containers than before.
- Drops the false claim in `lambda-database-capacity.ts` that an SSE stream holds a container for up to 222 s. The real cap is `MAX_CONNECTION_DURATION_MS`, nine minutes.

`chatLiveHandlerReservedConcurrency` deliberately stays at 16.

## Compatibility

Released clients send no `X-Chat-Live-Client-Id`, claim nothing, and behave exactly as they do today. A value that is not a UUID is dropped on read and likewise claims nothing, rather than failing the attach with a new 4xx — the attach path is the one item D is meant to make more recoverable, not less.

No new SSE event type: the existing reset-required terminal payload is reused so the wire contract released clients parse is unchanged.

Clients begin sending the header in #1700.

## Verification note

A separate read-only check confirmed all three clients are break-before-make — web aborts in the first statement of `startLiveStream`, iOS calls `detach()` first in `attachLive`, Android cancels `activeLiveJob` before `scope.launch` — so the superseded connection is never one the user is still watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)