### PR TITLE
Run chat-run integration tests on a schema that has the ownership columns

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,6 +71,14 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0127_ai_chat_run_live_attach_ownership.sql",
+    expectedMigrationCount: 129,
+    testFiles: Object.freeze([
+      "src/chat/cardImages/operation.postgres.integration.ts",
+      "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0123_backfill_live_review_answered_platform.sql",
     expectedMigrationCount: 125,
     testFiles: Object.freeze([
@@ -110,11 +118,9 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 109,
     testFiles: Object.freeze([
       "src/cards/managedMedia/generatedImageAppend.postgres.integration.ts",
-      "src/chat/cardImages/operation.postgres.integration.ts",
       "src/chat/cardImages/promotion/jobsLeasing.postgres.integration.ts",
       "src/chat/cardImages/promotion/jobsSettlement.postgres.integration.ts",
       "src/chat/cardImages/promotion/jobsRevocation.postgres.integration.ts",
-      "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
       "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
       "src/sync/freshBootstrap.postgres.integration.ts",
     ]),


### PR DESCRIPTION
## Why

`AWS / Web Release` fails at `Pre-deploy checks` on every commit since #1701, so **nothing deploys**: migration `0127` is not applied and the backend is not updated ([run 34229443845](https://github.com/kirill-markin/flashcards-open-source-app/actions/runs/34229443845)).

`0127` added `live_attach_client_id` and `live_attach_seq` to `ai.chat_runs`, and `CHAT_RUN_COLUMNS_SQL` now names them. The PostgreSQL integration harness replays migrations only up to each test's declared boundary and then runs current backend code against that historical schema, so two tests pinned at `0107` fail with `column "live_attach_client_id" does not exist`.

This is the same failure mode as `e7624f483`, which fixed it for `0119`.

## What

Adds a `0127` boundary and moves exactly the two tests that reach an affected read:

- `src/chat/cardImages/operation.postgres.integration.ts` — `claimChatRun` / `prepareChatRun` via the `../runs` facade
- `src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts` — `claimChatRun`, `prepareChatRun`, `reconcileInactiveClaimedChatRun` via `./lifecycleService`

Per that precedent the set was derived from the read entry points, not from the tests that happened to fail: the nine `*WithExecutor` functions built on `CHAT_RUN_COLUMNS_SQL` plus the ownership claim, walked out through their callers over runtime-value imports only, across all 25 files pinned below `0127`.

The near misses stay where they are, deliberately:

- the card-image promotion tests reach `chat/runs` only through `claimFence`, whose queries use an explicit five-column list
- `freshBootstrap` reaches `chat/runs` only through an `import type`, erased at runtime
- `aiChatInitiatingAuthClassification` imports no backend module, drives `ai.chat_runs` with raw SQL that never enumerates the table, and `0107` is the point of its coverage

`expectedMigrationCount` is `129`, not `127`: it counts sorted `.sql` files at or before the boundary, and `0028` and `0069` each have two.

## Scope

Only `boundaries.mjs`. No production code, no migration, no change to `CHAT_RUN_COLUMNS_SQL`.

## Verification limit

These boundaries run only in pre-deploy on `main`, so this cannot be shown green before merge; PR checks do not execute them. The proof is the release run after merge, which is being watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)