### PR TITLE
Recover a throttled live attach on iOS and Android

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatLiveRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatLiveRemoteService.kt
@@ -33,6 +33,10 @@ const val aiChatLiveStreamReadFailedCode: String = "ai_live_stream_read_failed"
 
 private const val aiChatLiveClientPlatform: String = "android"
 
+private const val aiChatLiveAttachThrottleStatusCode: Int = 429
+
+private const val aiChatMaximumLiveAttachRetryAfterMs: Long = 4_000L
+
 // Identifies this app process on every live attach, including resumes. The backend ends an older
 // attach only when the same id attaches again, so a per-request id would supersede the connection
 // that is opening.
@@ -44,6 +48,16 @@ class AiChatLiveStreamException(
     val code: String,
     cause: Throwable
 ) : IOException(message, cause)
+
+/**
+ * A pre-handler Lambda throttle rejects a live attach with a bare HTTP 429 before our handler runs,
+ * so the response carries no application error code. The session owner retries that with backoff
+ * instead of failing the run; a 429 that carries one of our codes stays a product-level refusal.
+ */
+class AiChatLiveAttachThrottledException(
+    val remoteError: AiChatRemoteException,
+    val retryAfterMs: Long?
+) : IOException(remoteError.message, remoteError)
 
 /**
  * Owns the low-level live SSE transport for Android AI chat.
@@ -245,12 +259,22 @@ class AiChatLiveRemoteService private constructor(
             call.awaitOkHttpResponse().use { response ->
                 if (response.isSuccessful.not()) {
                     val responseBody = readAiChatResponseBody(response = response)
-                    throw readAiChatRemoteErrorResponse(
+                    val remoteError = readAiChatRemoteErrorResponse(
                         response = response,
                         responseBody = responseBody,
                         observability = observability,
                         observationVersions = observationVersions
                     )
+                    if (
+                        remoteError.statusCode == aiChatLiveAttachThrottleStatusCode
+                        && remoteError.code.isNullOrBlank()
+                    ) {
+                        throw AiChatLiveAttachThrottledException(
+                            remoteError = remoteError,
+                            retryAfterMs = readLiveAttachRetryAfterMs(response = response)
+                        )
+                    }
+                    throw remoteError
                 }
 
                 val requestId = readAiChatRequestIdHeader(response = response)
@@ -341,6 +365,16 @@ class AiChatLiveRemoteService private constructor(
         } finally {
             cancellationHandle.dispose()
         }
+    }
+
+    private fun readLiveAttachRetryAfterMs(response: Response): Long? {
+        val retryAfterHeader = response.header(name = "Retry-After")
+        val retryAfterSeconds = retryAfterHeader?.trim()?.toLongOrNull() ?: return null
+        if (retryAfterSeconds < 0) {
+            return null
+        }
+
+        return minOf(retryAfterSeconds, aiChatMaximumLiveAttachRetryAfterMs / 1_000L) * 1_000L
     }
 
     private fun readAiChatResponseBody(response: Response): String? {

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/live/AiChatLiveStreamCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/live/AiChatLiveStreamCoordinator.kt
@@ -1,6 +1,8 @@
 package com.flashcardsopensourceapp.feature.ai.runtime.coordinators.live
 
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.data.local.ai.diagnostics.AiChatDiagnosticsLogger
+import com.flashcardsopensourceapp.data.local.ai.remote.AiChatLiveAttachThrottledException
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatLiveStreamException
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.ai.remote.aiChatLiveStreamEndedBeforeTerminalCode
@@ -32,6 +34,7 @@ import com.flashcardsopensourceapp.feature.ai.runtime.observability.makeAiErrorA
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.makeAiUserFacingErrorPresentation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -39,6 +42,29 @@ import kotlinx.coroutines.launch
 private enum class AiLiveAttachDisposition {
     PENDING,
     TERMINAL_EVENT_SEEN
+}
+
+private val liveAttachThrottleRecoveryDelaysMs: List<Long> = listOf(500L, 1_000L, 2_000L, 4_000L)
+
+private const val maximumLiveAttachThrottleRecoveryDelayMs: Long = 4_000L
+
+/**
+ * Backoff before retrying a live attach the backend throttled, or null when the failure must surface.
+ */
+private fun liveAttachThrottleRecoveryDelayMs(
+    throttledError: AiChatLiveAttachThrottledException,
+    attemptCount: Int
+): Long? {
+    val fallbackDelayMs = liveAttachThrottleRecoveryDelaysMs.getOrNull(index = attemptCount) ?: return null
+    val requestedDelayMs = throttledError.retryAfterMs ?: fallbackDelayMs
+    return minOf(maxOf(fallbackDelayMs, requestedDelayMs), maximumLiveAttachThrottleRecoveryDelayMs)
+}
+
+/**
+ * Whether the composer still owns a live run, so this coordinator must keep its attach alive.
+ */
+private fun isLiveAiComposerPhase(composerPhase: AiComposerPhase): Boolean {
+    return composerPhase == AiComposerPhase.RUNNING || composerPhase == AiComposerPhase.STOPPING
 }
 
 internal class AiChatLiveStreamCoordinator(
@@ -153,80 +179,123 @@ internal class AiChatLiveStreamCoordinator(
         var liveJob: Job? = null
         liveJob = context.scope.launch {
             var liveAttachDisposition = AiLiveAttachDisposition.PENDING
+            var throttleAttemptCount = 0
             context.runtimeStateMutable.update { state ->
                 state.copy(isLiveAttached = true)
             }
             context.persistCurrentState()
             try {
-                context.aiChatRepository.attachLiveRun(
-                    workspaceId = workspaceId,
-                    sessionId = sessionId,
-                    runId = runId,
-                    liveStream = liveStream,
-                    afterCursor = afterCursor,
-                    resumeDiagnostics = resumeDiagnostics
-                ).collect { event ->
-                    if (event is AiChatLiveEvent.RunTerminal) {
-                        liveAttachDisposition = AiLiveAttachDisposition.TERMINAL_EVENT_SEEN
-                    }
-                    applyLiveEvent(event = event)
-                }
-                if (
-                    liveAttachDisposition == AiLiveAttachDisposition.PENDING
-                    && context.isScreenVisible
-                ) {
-                    reconcileUnexpectedLiveStreamDetach(
-                        workspaceId = workspaceId,
-                        sessionId = sessionId
-                    )
-                }
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                if (isUnexpectedLiveStreamDetach(error = error)) {
-                    if (context.isScreenVisible) {
-                        reconcileUnexpectedLiveStreamDetach(
+                while (true) {
+                    try {
+                        context.aiChatRepository.attachLiveRun(
                             workspaceId = workspaceId,
-                            sessionId = sessionId
+                            sessionId = sessionId,
+                            runId = runId,
+                            liveStream = liveStream,
+                            afterCursor = afterCursor,
+                            resumeDiagnostics = resumeDiagnostics
+                        ).collect { event ->
+                            if (event is AiChatLiveEvent.RunTerminal) {
+                                liveAttachDisposition = AiLiveAttachDisposition.TERMINAL_EVENT_SEEN
+                            }
+                            throttleAttemptCount = 0
+                            applyLiveEvent(event = event)
+                        }
+                        if (
+                            liveAttachDisposition == AiLiveAttachDisposition.PENDING
+                            && context.isScreenVisible
+                        ) {
+                            reconcileUnexpectedLiveStreamDetach(
+                                workspaceId = workspaceId,
+                                sessionId = sessionId
+                            )
+                        }
+                        break
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Exception) {
+                        val throttledError = error as? AiChatLiveAttachThrottledException
+                        if (throttledError != null) {
+                            val throttleRecoveryDelayMs = liveAttachThrottleRecoveryDelayMs(
+                                throttledError = throttledError,
+                                attemptCount = throttleAttemptCount
+                            )
+                            if (throttleRecoveryDelayMs != null) {
+                                throttleAttemptCount += 1
+                                AiChatDiagnosticsLogger.warn(
+                                    event = "ai_live_attach_throttled",
+                                    fields = listOf(
+                                        "sessionId" to sessionId,
+                                        "runId" to runId,
+                                        "attempt" to throttleAttemptCount.toString(),
+                                        "delayMs" to throttleRecoveryDelayMs.toString(),
+                                        "requestId" to throttledError.remoteError.requestId
+                                    )
+                                )
+                                delay(timeMillis = throttleRecoveryDelayMs)
+                                // A stop finalizes the conversation without cancelling this job, so
+                                // give up quietly instead of alerting over an already idle run.
+                                val stateAfterBackoff = context.runtimeStateMutable.value
+                                if (
+                                    stateAfterBackoff.activeRun?.runId != runId
+                                    || isLiveAiComposerPhase(
+                                        composerPhase = stateAfterBackoff.composerPhase
+                                    ).not()
+                                    || context.isScreenVisible.not()
+                                ) {
+                                    break
+                                }
+                                continue
+                            }
+                        }
+                        if (isUnexpectedLiveStreamDetach(error = error)) {
+                            if (context.isScreenVisible) {
+                                reconcileUnexpectedLiveStreamDetach(
+                                    workspaceId = workspaceId,
+                                    sessionId = sessionId
+                                )
+                            }
+                            break
+                        }
+                        val surfacedError = throttledError?.remoteError ?: error
+                        val issueDisposition = aiChatFailureIssueDisposition(error = surfacedError)
+                        val technicalErrorAlreadyObserved = captureLiveStreamCrashIfNeeded(
+                            error = surfacedError,
+                            issueDisposition = issueDisposition,
+                            workspaceId = workspaceId,
+                            sessionId = sessionId,
+                            runId = runId
                         )
-                    }
-                    return@launch
-                }
-                val issueDisposition = aiChatFailureIssueDisposition(error = error)
-                val technicalErrorAlreadyObserved = captureLiveStreamCrashIfNeeded(
-                    error = error,
-                    issueDisposition = issueDisposition,
-                    workspaceId = workspaceId,
-                    sessionId = sessionId,
-                    runId = runId
-                )
-                val presentation = makeAiUserFacingErrorPresentation(
-                    error = error,
-                    surface = AiErrorSurface.CHAT,
-                    configuration = context.currentServerConfiguration(),
-                    textProvider = context.textProvider
-                )
-                context.runtimeStateMutable.update { state ->
-                    state.copy(
-                        activeRun = null,
-                        isLiveAttached = false,
-                        composerPhase = AiComposerPhase.IDLE,
-                        repairStatus = null,
-                        activeAlert = makeAiErrorAlert(
-                            presentation = presentation,
-                            technicalErrorAlreadyObserved = technicalErrorAlreadyObserved,
+                        val presentation = makeAiUserFacingErrorPresentation(
+                            error = surfacedError,
+                            surface = AiErrorSurface.CHAT,
+                            configuration = context.currentServerConfiguration(),
                             textProvider = context.textProvider
-                        ),
-                        errorMessage = ""
-                    )
+                        )
+                        context.runtimeStateMutable.update { state ->
+                            state.copy(
+                                activeRun = null,
+                                isLiveAttached = false,
+                                composerPhase = AiComposerPhase.IDLE,
+                                repairStatus = null,
+                                activeAlert = makeAiErrorAlert(
+                                    presentation = presentation,
+                                    technicalErrorAlreadyObserved = technicalErrorAlreadyObserved,
+                                    textProvider = context.textProvider
+                                ),
+                                errorMessage = ""
+                            )
+                        }
+                        context.persistCurrentState()
+                        break
+                    }
                 }
-                context.persistCurrentState()
             } finally {
                 if (context.activeLiveJob === liveJob) {
                     context.activeLiveJob = null
                 }
                 context.runtimeStateMutable.update { state ->
-                    if (state.composerPhase == AiComposerPhase.RUNNING || state.composerPhase == AiComposerPhase.STOPPING) {
+                    if (isLiveAiComposerPhase(composerPhase = state.composerPhase)) {
                         state
                     } else {
                         state.copy(isLiveAttached = false)

--- a/apps/ios/Flashcards/Flashcards/AI/Live/AIChatLiveStreamErrors.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Live/AIChatLiveStreamErrors.swift
@@ -35,6 +35,43 @@ enum AIChatLiveStreamError: LocalizedError {
     }
 }
 
+private let aiChatLiveAttachThrottleRecoveryDelaysNanoseconds: [UInt64] = [
+    500_000_000,
+    1_000_000_000,
+    2_000_000_000,
+    4_000_000_000
+]
+
+private let aiChatMaximumLiveAttachThrottleRecoveryDelayNanoseconds: UInt64 = 4_000_000_000
+
+/**
+ * Backoff before retrying a live attach the backend rejected, or nil when the failure must surface.
+ * Only a bare HTTP 429 is retried: a pre-handler Lambda throttle rejects the attach before our
+ * handler runs, so it carries no application error code. A 429 that carries one of our codes is a
+ * product-level refusal and keeps failing.
+ */
+func aiChatLiveAttachThrottleRecoveryDelayNanoseconds(
+    error: Error,
+    attemptCount: Int
+) -> UInt64? {
+    guard let liveStreamError = error as? AIChatLiveStreamError,
+          case .invalidStatusCode(let httpStatusCode, let errorDetails, _, _) = liveStreamError,
+          httpStatusCode == 429,
+          errorDetails.code?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
+          attemptCount >= 0,
+          attemptCount < aiChatLiveAttachThrottleRecoveryDelaysNanoseconds.count
+    else {
+        return nil
+    }
+
+    let fallbackDelayNanoseconds = aiChatLiveAttachThrottleRecoveryDelaysNanoseconds[attemptCount]
+    let requestedDelayNanoseconds = errorDetails.retryAfterDelayNanoseconds ?? fallbackDelayNanoseconds
+    return min(
+        max(fallbackDelayNanoseconds, requestedDelayNanoseconds),
+        aiChatMaximumLiveAttachThrottleRecoveryDelayNanoseconds
+    )
+}
+
 func makeAIChatLiveStreamURL(
     liveUrl: String,
     sessionId: String,

--- a/apps/ios/Flashcards/Flashcards/AI/Live/AIChatLiveStreamTaskDelegate.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Live/AIChatLiveStreamTaskDelegate.swift
@@ -157,7 +157,10 @@ final class AIChatLiveStreamTaskDelegate: NSObject, URLSessionDataDelegate, @unc
             let requestId = extractAIChatLiveRequestId(httpResponse: httpResponse)
             let errorDetails = decodeCloudApiErrorDetails(
                 data: self.responseBody,
-                requestId: requestId
+                requestId: requestId,
+                retryAfterDelayNanoseconds: cloudRetryAfterDelayNanoseconds(
+                    value: httpResponse.value(forHTTPHeaderField: "Retry-After")
+                )
             )
             self.finish(throwing: AIChatLiveStreamError.invalidStatusCode(
                 httpStatusCode: httpResponse.statusCode,

--- a/apps/ios/Flashcards/Flashcards/AI/Runtime/AIChatSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Runtime/AIChatSessionRuntime.swift
@@ -137,45 +137,74 @@ actor AIChatSessionRuntime {
     ) {
         detach()
         activeLiveTask = Task {
-            logAIChatRuntimeEvent(
-                action: "ai_live_attach",
-                metadata: [
-                    "sessionId": sessionId,
-                    "runId": runId,
-                    "afterCursor": afterCursor ?? "-"
-                ]
-                .merging(
-                    resumeAttemptDiagnostics.map { ["resumeAttempt": $0.headerValue] } ?? [:]
-                ) { _, newValue in newValue }
-            )
-            do {
-                let termination = try await self.consumeLiveStream(
-                    liveStream: liveStream,
-                    sessionId: sessionId,
-                    runId: runId,
-                    afterCursor: afterCursor,
-                    configurationMode: configurationMode,
-                    resumeAttemptDiagnostics: resumeAttemptDiagnostics,
-                    eventHandler: eventHandler
-                )
-                await completionHandler(termination)
-            } catch is CancellationError {
-            } catch {
+            // The retry budget belongs to this attach only, so a cancelled previous attach that
+            // resumes late cannot spend or reset it.
+            var throttleAttemptCount = 0
+            while Task.isCancelled == false {
                 logAIChatRuntimeEvent(
-                    action: "ai_live_error",
-                    metadata: aiChatRuntimeErrorMetadata(
+                    action: "ai_live_attach",
+                    metadata: [
+                        "sessionId": sessionId,
+                        "runId": runId,
+                        "afterCursor": afterCursor ?? "-"
+                    ]
+                    .merging(
+                        resumeAttemptDiagnostics.map { ["resumeAttempt": $0.headerValue] } ?? [:]
+                    ) { _, newValue in newValue }
+                )
+                var throttleRecoveryDelayNanoseconds: UInt64?
+                do {
+                    let termination = try await self.consumeLiveStream(
+                        liveStream: liveStream,
+                        sessionId: sessionId,
+                        runId: runId,
+                        afterCursor: afterCursor,
+                        configurationMode: configurationMode,
+                        resumeAttemptDiagnostics: resumeAttemptDiagnostics,
+                        eventHandler: eventHandler,
+                        onLiveEventDelivered: { throttleAttemptCount = 0 }
+                    )
+                    await completionHandler(termination)
+                } catch is CancellationError {
+                } catch {
+                    let errorMetadata = aiChatRuntimeErrorMetadata(
                         error: error,
                         sessionId: sessionId,
                         runId: runId,
                         afterCursor: afterCursor,
                         resumeAttemptDiagnostics: resumeAttemptDiagnostics
                     )
-                )
-                await completionHandler(.failed(
-                    message: Flashcards.errorMessage(error: error),
-                    requestId: aiChatLiveErrorRequestId(error),
-                    clientRequestId: aiChatLiveErrorClientRequestId(error)
-                ))
+                    if let recoveryDelayNanoseconds = aiChatLiveAttachThrottleRecoveryDelayNanoseconds(
+                        error: error,
+                        attemptCount: throttleAttemptCount
+                    ) {
+                        throttleAttemptCount += 1
+                        throttleRecoveryDelayNanoseconds = recoveryDelayNanoseconds
+                        logAIChatRuntimeEvent(
+                            action: "ai_live_attach_throttled",
+                            metadata: errorMetadata
+                        )
+                    } else {
+                        logAIChatRuntimeEvent(
+                            action: "ai_live_error",
+                            metadata: errorMetadata
+                        )
+                        await completionHandler(.failed(
+                            message: Flashcards.errorMessage(error: error),
+                            requestId: aiChatLiveErrorRequestId(error),
+                            clientRequestId: aiChatLiveErrorClientRequestId(error)
+                        ))
+                    }
+                }
+
+                guard let throttleRecoveryDelayNanoseconds else {
+                    break
+                }
+                do {
+                    try await Task.sleep(nanoseconds: throttleRecoveryDelayNanoseconds)
+                } catch {
+                    break
+                }
             }
             logAIChatRuntimeEvent(
                 action: "ai_live_detach",
@@ -200,7 +229,8 @@ actor AIChatSessionRuntime {
         afterCursor: String?,
         configurationMode: CloudServiceConfigurationMode,
         resumeAttemptDiagnostics: AIChatResumeAttemptDiagnostics?,
-        eventHandler: @escaping @Sendable (AIChatLiveEvent) async -> Void
+        eventHandler: @escaping @Sendable (AIChatLiveEvent) async -> Void,
+        onLiveEventDelivered: () -> Void
     ) async throws -> AIChatLiveAttachTermination {
         if runId.isEmpty {
             throw AIChatLiveStreamSetupError.missingRunId(
@@ -236,6 +266,7 @@ actor AIChatSessionRuntime {
                 liveRequestId = aiChatLiveEventMetadata(liveEvent).requestId ?? liveRequestId
             }
 
+            onLiveEventDelivered()
             await eventHandler(event)
 
             switch event {

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Observability/AIChatStore+LifecycleLogging.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Observability/AIChatStore+LifecycleLogging.swift
@@ -180,6 +180,7 @@ private func aiChatStoreLiveEventIsWarning(_ action: AILiveLifecycleAction) -> B
             .finish,
             .finishError,
             .attach,
+            .attachThrottled,
             .detach,
             .error,
             .eventParseFailed,

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -460,6 +460,7 @@ enum AILiveLifecycleAction: String, Sendable {
     case finish = "ai_live_finish"
     case finishError = "ai_live_finish_error"
     case attach = "ai_live_attach"
+    case attachThrottled = "ai_live_attach_throttled"
     case error = "ai_live_error"
     case detach = "ai_live_detach"
     case eventHandleStart = "ai_live_event_handle_start"


### PR DESCRIPTION
## Why

A pre-handler Lambda throttle answers a chat live attach with a bare `429` and none of our error codes. Web has retried that since 2026-09-02; iOS and Android surfaced it as a failed AI chat. On 2026-09-07 that state lasted about ten minutes, and in one 15-minute window only 3 attaches got through against 37 rejections.

## What

Both mobile clients now mirror the web contract:

- delays `500, 1000, 2000, 4000` ms, at most four retries
- `Retry-After` honored, clamped to 4 s
- budget reset once the stream delivers an event
- a `429` carrying one of our error codes stays a product-level refusal and still fails

The retry lives where cancellation is already guaranteed — inside the runtime actor's single `activeLiveTask` on iOS, and inside the single `activeLiveJob` on Android. Break-before-make is unchanged: a retry never opens an attach while another is live, and a detach or run change kills a pending backoff instead of attaching late.

## The Android liveness guard

The loop now keeps the live job alive for up to 7.5 s, and `finalizeStoppedConversation()` is the one stop path that does not cancel it. Without a guard, a Stop tapped during a throttle window would exhaust the budget and write a chat-failed alert over an already idle conversation — the exact surface this change exists to remove.

So Android re-checks after each backoff that the run is still the active one, the composer phase is still live, and the screen is visible. That check and the `finally` block now share one liveness helper so they cannot drift; `RUNNING` and `STOPPING` both count as live, matching what `finally` already meant.

iOS needs no equivalent because every stop path calls `runtime.detach()` before any phase transition, which cancels the task and makes the pending `Task.sleep` throw.

## Notes

`Retry-After` is accepted as integer seconds only, the only form the backend emits. The captured live authorization envelope is reused across retries; its TTL is 10 minutes against roughly 7.5 s of backoff.

Nothing in this repository compiles iOS before merge by design, so the Swift changes get their first compiler in Xcode Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)