### PR TITLE
Fix OpenAI response stream backpressure

### DIFF
--- a/apps/backend/src/chat/openai/loop/loop.providerEvents.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.providerEvents.test.ts
@@ -288,7 +288,7 @@ test("startOpenAILoopWithDeps retries a callIndex > 1 overflow once with the red
     },
     getObservedOpenAIClient: () => ({
       responses: {
-        stream: () => {
+        create: async () => {
           streamCallCount += 1;
           if (streamCallCount === 1) {
             return createResponseStream(

--- a/apps/backend/src/chat/openai/loop/loop.testSupport.ts
+++ b/apps/backend/src/chat/openai/loop/loop.testSupport.ts
@@ -317,7 +317,9 @@ export function createSdkAbortedResponseStream(
 }
 
 export function createDependencies(
-  streamFactory: (request: OpenAI.Responses.ResponseCreateParams) => OpenAIResponseStream,
+  streamFactory: (
+    request: OpenAI.Responses.ResponseCreateParamsStreaming,
+  ) => OpenAIResponseStream,
   runOneToolCall: (
     params: Parameters<OpenAILoopDependencies["runOneToolCall"]>[0],
   ) => Promise<TestToolCallResult>,
@@ -327,7 +329,9 @@ export function createDependencies(
     buildChatCompletionInputWithBudget: async () => [],
     getObservedOpenAIClient: () => ({
       responses: {
-        stream: (request: OpenAI.Responses.ResponseCreateParams) => streamFactory(request),
+        create: async (
+          request: OpenAI.Responses.ResponseCreateParamsStreaming,
+        ): Promise<OpenAIResponseStream> => streamFactory(request),
       },
     } as unknown as OpenAI),
     runOneToolCall: async (params) => {

--- a/apps/backend/src/chat/openai/loop/modelCall.ts
+++ b/apps/backend/src/chat/openai/loop/modelCall.ts
@@ -217,8 +217,8 @@ export async function runOneModelCallWithPhase(
 ): Promise<ModelCallResult> {
   params.onExecutionPhaseChanged?.("model");
   try {
-    const stream: ResponseStreamWithOptionalFinalResponse = params.client.responses.stream(
-      params.request,
+    const stream: ResponseStreamWithOptionalFinalResponse = await params.client.responses.create(
+      { ...params.request, stream: true },
       { signal: params.signal },
     );
     return await collectResponseStream({


### PR DESCRIPTION
## Summary

- Consume the raw Responses API stream so durable event handling applies backpressure directly instead of lagging behind the SDK helper's bounded event iterator.
- Update the affected loop client fakes to use the awaited `responses.create({ stream: true })` contract.

## Why

A valid production chat run failed after successful provider and SQL activity with `Event stream iterator buffer limit exceeded (4096 events or 8388608 bytes); consume events as they arrive.` The existing collector deliberately awaits durable event persistence, so the eager `ResponseStream` helper could outpace its detached iterator. The raw SDK stream is single-consumer and pull-based while preserving the existing terminal-event, abort, tool-call, and diagnostics behavior.

## Validation

- Fresh full static review: no P0–P4 findings.
- Local project checks were not run; the repository's cloud PR checks own executable validation.
