### PR TITLE
Advertise the custom-server cloud contract

### DIFF
--- a/apps/backend/src/routes/system/index.ts
+++ b/apps/backend/src/routes/system/index.ts
@@ -68,6 +68,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
     return context.json({
       status: "ok",
       service: "flashcards-open-source-app-backend",
+      cloudContractVersion: 1,
       dbTime: result.rows[0]?.now ?? null,
     });
   });

--- a/docs/backend-web-deployment.md
+++ b/docs/backend-web-deployment.md
@@ -75,6 +75,16 @@ policy. The value must be one exact HTTP(S) origin without credentials, path,
 query, fragment, or wildcard. CDK deployments inject
 `https://app.<baseDomain>` automatically.
 
+### Client compatibility
+
+Before connecting a newer client, deploy the current backend and request
+`GET <API_BASE_URL>/health`. A compatible response returns HTTP `200` and
+includes an integer `cloudContractVersion`. This version identifies the
+supported guest-session and workspace-sync protocol generation; it is not an
+app release version or proof that the database is correct. If the field is
+missing or the client does not support the advertised version, update and
+redeploy the backend before connecting the client.
+
 ## First AWS deploy
 
 Keep the operator config in root `.env`. The important deploy-time values are:


### PR DESCRIPTION
## Summary

- Add an additive cloudContractVersion field to the API health response.
- Document how self-host operators update and verify server compatibility before connecting newer clients.
- Preserve existing health fields and all shipped client behavior.

## Validation

- Independent static review completed with no findings.
- No local project checks were run; GitHub CI owns executable validation.
- iOS compatibility enforcement and guest workspace recovery follow in a separate PR.