### PR TITLE
Remove dead in-table card editor assets

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -1008,9 +1008,6 @@ const arCatalog: TranslationCatalog = {
       trigger: "فلترة",
       triggerWithCount: "فلترة ({{count}})",
     },
-    loading: {
-      open: "فتح",
-    },
     loadingMore: "جارٍ تحميل مزيد من البطاقات...",
     search: {
       label: "بحث",
@@ -1022,7 +1019,6 @@ const arCatalog: TranslationCatalog = {
       due: "مستحق",
       front: "الأمام",
       lapses: "الإخفاقات",
-      open: "فتح",
       reps: "المراجعات",
       tags: "الوسوم",
       updated: "تم التحديث",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -1008,9 +1008,6 @@ const deCatalog: TranslationCatalog = {
       trigger: "Filtern",
       triggerWithCount: "Filtern ({{count}})",
     },
-    loading: {
-      open: "Öffnen",
-    },
     loadingMore: "Weitere Karten werden geladen...",
     search: {
       label: "Suchen",
@@ -1022,7 +1019,6 @@ const deCatalog: TranslationCatalog = {
       due: "Fällig",
       front: "Vorderseite",
       lapses: "Fehlversuche",
-      open: "Öffnen",
       reps: "Wiederholungen",
       tags: "Tags",
       updated: "Aktualisiert",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -1006,9 +1006,6 @@ const enCatalog = {
       trigger: "Filter",
       triggerWithCount: "Filter ({{count}})",
     },
-    loading: {
-      open: "Open",
-    },
     loadingMore: "Loading more cards...",
     search: {
       label: "Search",
@@ -1020,7 +1017,6 @@ const enCatalog = {
       due: "Due",
       front: "Front",
       lapses: "Lapses",
-      open: "Open",
       reps: "Reps",
       tags: "Tags",
       updated: "Updated",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -1008,9 +1008,6 @@ const esEsCatalog: TranslationCatalog = {
       trigger: "Filtrar",
       triggerWithCount: "Filtrar ({{count}})",
     },
-    loading: {
-      open: "Abrir",
-    },
     loadingMore: "Cargando más tarjetas...",
     search: {
       label: "Buscar",
@@ -1022,7 +1019,6 @@ const esEsCatalog: TranslationCatalog = {
       due: "Pendiente",
       front: "Frente",
       lapses: "Fallos",
-      open: "Abrir",
       reps: "Repasos",
       tags: "Etiquetas",
       updated: "Actualizado",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -1008,9 +1008,6 @@ const esMxCatalog: TranslationCatalog = {
       trigger: "Filtrar",
       triggerWithCount: "Filtrar ({{count}})",
     },
-    loading: {
-      open: "Abrir",
-    },
     loadingMore: "Cargando más tarjetas...",
     search: {
       label: "Buscar",
@@ -1022,7 +1019,6 @@ const esMxCatalog: TranslationCatalog = {
       due: "Pendiente",
       front: "Frente",
       lapses: "Fallos",
-      open: "Abrir",
       reps: "Repasos",
       tags: "Etiquetas",
       updated: "Actualizado",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -1008,9 +1008,6 @@ const hiCatalog: TranslationCatalog = {
       trigger: "फ़िल्टर",
       triggerWithCount: "फ़िल्टर ({{count}})",
     },
-    loading: {
-      open: "खोलें",
-    },
     loadingMore: "और कार्ड लोड हो रहे हैं...",
     search: {
       label: "खोजें",
@@ -1022,7 +1019,6 @@ const hiCatalog: TranslationCatalog = {
       due: "बाकी",
       front: "सामने",
       lapses: "चूक",
-      open: "खोलें",
       reps: "रिव्यू",
       tags: "टैग",
       updated: "अपडेट किया गया",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -1008,9 +1008,6 @@ export const jaCatalog = {
       trigger: "絞り込み",
       triggerWithCount: "絞り込み（{{count}}）",
     },
-    loading: {
-      open: "開く",
-    },
     loadingMore: "さらにカードを読み込んでいます...",
     search: {
       label: "検索",
@@ -1022,7 +1019,6 @@ export const jaCatalog = {
       due: "期限",
       front: "表面",
       lapses: "失敗",
-      open: "開く",
       reps: "復習回数",
       tags: "タグ",
       updated: "更新日時",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -1008,9 +1008,6 @@ export const ruCatalog = {
       trigger: "Фильтр",
       triggerWithCount: "Фильтр ({{count}})",
     },
-    loading: {
-      open: "Открыть",
-    },
     loadingMore: "Загрузка дополнительных карточек...",
     search: {
       label: "Поиск",
@@ -1022,7 +1019,6 @@ export const ruCatalog = {
       due: "Срок",
       front: "Лицевая сторона",
       lapses: "Ошибки",
-      open: "Открыть",
       reps: "Повторы",
       tags: "Теги",
       updated: "Обновлено",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -1008,9 +1008,6 @@ export const zhHansCatalog = {
       trigger: "筛选",
       triggerWithCount: "筛选（{{count}}）",
     },
-    loading: {
-      open: "打开",
-    },
     loadingMore: "正在加载更多卡片...",
     search: {
       label: "搜索",
@@ -1022,7 +1019,6 @@ export const zhHansCatalog = {
       due: "到期",
       front: "正面",
       lapses: "失误",
-      open: "打开",
       reps: "复习次数",
       tags: "标签",
       updated: "更新时间",

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -364,7 +364,6 @@ export type WebAppOperation =
   | "card_delete"
   | "cards_list_load"
   | "cards_page_load"
-  | "cards_inline_save"
   | "review_data_load"
   | "review_submit"
   | "review_rollback_lookup"

--- a/apps/web/src/screens/cards/form/CardFormTagsField.tsx
+++ b/apps/web/src/screens/cards/form/CardFormTagsField.tsx
@@ -154,7 +154,7 @@ export const CardFormTagsField = forwardRef<CardFormTagsFieldHandle, CardFormTag
     setIsOpen(true);
   }
 
-  const triggerClassName = `settings-input card-form-tags-trigger${disabled ? " cards-cell-disabled" : ""}`;
+  const triggerClassName = "settings-input card-form-tags-trigger";
 
   return (
     <>

--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -301,74 +301,9 @@
   overflow-wrap: anywhere;
 }
 
-.drilldown-editable {
-  cursor: pointer;
-}
-
-.drilldown-editable:hover {
-  color: var(--text);
-}
-
-.drilldown-editable-select::after {
-  content: " \25BE";
-  color: var(--text-tertiary);
-  font-size: 10px;
-  opacity: 0;
-}
-
-.drilldown-editable-select:hover::after {
-  opacity: 1;
-}
-
-.cell-editor-overlay {
-  z-index: 200;
-  display: flex;
-  min-width: 0;
-  min-height: 42px;
-  font-size: 16px;
-  font-family: inherit;
-  line-height: 1.5;
-  background: var(--surface);
-  color: var(--text);
-  border: 0;
-  border-radius: var(--radius-sm);
-  outline: 2px solid var(--text);
-  outline-offset: 2px;
-  box-shadow: none;
-  box-sizing: border-box;
-  overflow: hidden;
-}
-
-.cell-editor-overlay-multiline {
-  min-height: 120px;
-}
-
-.cell-editor-field {
-  flex: 1 1 auto;
-  width: 100%;
-  min-width: 0;
-  min-height: 42px;
-  padding: 10px 12px;
-  border: 0;
-  border-radius: inherit;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  line-height: inherit;
-  outline: none;
-  box-sizing: border-box;
-}
-
-.cell-editor-field-multiline {
-  min-height: 120px;
-  white-space: pre-wrap;
-  resize: vertical;
-}
-
 .cell-select-overlay {
   --cell-select-overlay-padding: 6px;
   --cell-select-overlay-radius: var(--radius-md);
-  --cell-select-overlay-inner-radius: calc(var(--cell-select-overlay-radius) / 2);
   z-index: 200;
   display: flex;
   flex-direction: column;
@@ -384,55 +319,6 @@
 
 .cell-select-overlay .tag-input-field {
   font-size: 16px;
-}
-
-.cell-select-search {
-  width: 100%;
-  min-height: 42px;
-  border: none;
-  border-bottom: 1px solid var(--divider);
-  background: transparent;
-  color: var(--text);
-  padding: 0 12px;
-  outline: none;
-  box-sizing: border-box;
-}
-
-.cell-select-search:focus {
-  outline: 2px solid var(--text);
-  outline-offset: -2px;
-}
-
-.cell-select-options {
-  flex: 1;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding: 6px;
-}
-
-.cell-select-option {
-  width: 100%;
-  min-height: 38px;
-  padding: 8px 10px;
-  border: none;
-  border-radius: var(--cell-select-overlay-inner-radius);
-  background: transparent;
-  color: var(--text);
-  font-family: inherit;
-  font-size: 14px;
-  text-align: start;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.cell-select-option:hover,
-.cell-select-option-highlight {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.cell-select-option-active {
-  color: var(--accent-strong);
-  background: var(--accent-soft);
 }
 
 .deck-list {


### PR DESCRIPTION
Follow-up cleanup after #1709, which removed the in-table card editors (`CardsTableEditors.tsx`) and left behind assets that only that file used. Pure dead-code removal: no rendering or behaviour changes.

Removed:

- `apps/web/src/styles/features/cards.css` — `.drilldown-editable`, `.drilldown-editable:hover`, `.cell-editor-overlay`, `.cell-editor-overlay-multiline`, `.cell-editor-field`, `.cell-editor-field-multiline`, plus the `--cell-select-overlay-inner-radius` custom property whose only consumer went with them. Also `.drilldown-editable-select`, `.cell-select-search`, `.cell-select-options` and the `.cell-select-option*` rules, which had already been dead before #1709. `.cell-select-overlay` stays: it is still used by `CardFormTagsField.tsx`.
- All nine locale catalogs — the orphaned `cardsScreen.table.open` key and the whole `cardsScreen.loading` object, whose only member was `open`. The shape change is identical across the nine because `TranslationCatalog` derives from the `en` catalog. The sibling `cardsScreen.loadingMore` is still in use and untouched.
- `apps/web/src/observability/webObservability.ts` — the `cards_inline_save` member of `WebAppOperation`, whose only emitter was the deleted `handleInlineSave`.
- `apps/web/src/screens/cards/form/CardFormTagsField.tsx` — the dead `cards-cell-disabled` class name, whose rule #1709 deleted. `.card-form-tags-trigger` already sets its own cursor, so the rendered result is unchanged in both the enabled and disabled states.

Every removal was verified with a repo-wide `git grep` over all tracked file types, including prefix searches to rule out dynamically assembled class names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
