### PR TITLE
Constrain catalog language tags to supported audience locales

### DIFF
--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -12,6 +12,22 @@ export const catalogPackageStatuses = [
 
 export type CatalogPackageStatus = (typeof catalogPackageStatuses)[number];
 
+/**
+ * Audience locales a catalog package may declare in `languageTags`. Intentionally mirrors the
+ * marketing website's `src/lib/localeConfig.ts`, which derives a deck's canonical route and its
+ * schema.org `inLanguage` from these tags, and must be changed together with it.
+ */
+export const catalogAudienceLocales = [
+  "ar",
+  "de",
+  "en",
+  "es",
+  "hi",
+  "ja",
+  "ru",
+  "zh",
+] as const;
+
 export type TimestampValue = Date | string;
 
 export type CatalogAuthorRow = Readonly<{

--- a/apps/backend/src/routes/catalog/admin.test.ts
+++ b/apps/backend/src/routes/catalog/admin.test.ts
@@ -170,7 +170,7 @@ function createCatalogPackageInputValidationApp(
   return app;
 }
 
-test("catalog package inputs carry educational alignment, and an omitted field clears it", async () => {
+test("catalog package inputs lowercase language tags, carry educational alignment, and clear an omitted field", async () => {
   const parsedInputs: Array<CreateCatalogPackageDraftInput | UpdateCatalogPackageDraftInput> = [];
   const app = createCatalogPackageInputCaptureApp((input) => {
     parsedInputs.push(input);
@@ -181,7 +181,7 @@ test("catalog package inputs carry educational alignment, and an omitted field c
     title: "Test package",
     summary: "Test summary",
     description: "Test description",
-    languageTags: ["en"],
+    languageTags: ["EN"],
     license: "CC0-1.0",
     contentWarning: null,
   };
@@ -209,6 +209,10 @@ test("catalog package inputs carry educational alignment, and an omitted field c
 
   assert.equal(createResponse.status, 201);
   assert.equal(updateResponse.status, 200);
+  assert.deepEqual(
+    parsedInputs.map((input) => input.languageTags),
+    [["en"], ["en"]],
+  );
   assert.deepEqual(
     parsedInputs.map((input) => [
       input.educationalSubject,
@@ -262,6 +266,51 @@ test("catalog package inputs explicitly reject the removed topicTags field", asy
     assert.deepEqual(await response.json(), {
       error: "topicTags was removed; omit topicTags from catalog package requests.",
       code: "CATALOG_ADMIN_TOPIC_TAGS_REMOVED",
+    });
+  }
+  assert.equal(processingCalls, 0);
+});
+
+test("catalog package inputs reject a language tag outside the supported audience locales", async () => {
+  let processingCalls = 0;
+  const app = createCatalogPackageInputValidationApp(async () => {
+    processingCalls += 1;
+    throw new Error("Unsupported language tag must be rejected before processing");
+  });
+  const sharedPackageInput = {
+    authorId,
+    slug: "test-package",
+    title: "Test package",
+    summary: "Test summary",
+    description: "Test description",
+    languageTags: ["en", "world history"],
+    license: "CC0-1.0",
+    contentWarning: null,
+  };
+  const requests = [
+    {
+      method: "POST",
+      path: "/admin/catalog/packages",
+      body: { packageId, ...sharedPackageInput },
+    },
+    {
+      method: "PUT",
+      path: `/admin/catalog/packages/${packageId}/draft`,
+      body: { ...sharedPackageInput, coverPackageMediaKey: null },
+    },
+  ] as const;
+
+  for (const request of requests) {
+    const response = await app.request(`http://localhost${request.path}`, {
+      method: request.method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request.body),
+    });
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error: "languageTags[1] must be a supported catalog audience locale. "
+        + "tag=world history supported=ar, de, en, es, hi, ja, ru, zh",
+      code: "CATALOG_INVALID_INPUT",
     });
   }
   assert.equal(processingCalls, 0);

--- a/apps/backend/src/routes/catalog/admin.ts
+++ b/apps/backend/src/routes/catalog/admin.ts
@@ -23,6 +23,7 @@ import {
   type CatalogDumpRefreshTrigger,
 } from "../../catalog/distribution/public/publication/dumpRefresh";
 import {
+  catalogAudienceLocales,
   catalogPackageStatuses,
   type AttachCatalogPackageMediaAssetInput,
   type CatalogAuthor,
@@ -99,6 +100,7 @@ type CatalogAdminRoutesOptions = Readonly<{
 
 const catalogAdminMaximumBodyBytes = 2_000_000;
 const catalogStatusSet: ReadonlySet<string> = new Set(catalogPackageStatuses);
+const catalogAudienceLocaleSet: ReadonlySet<string> = new Set(catalogAudienceLocales);
 
 async function parseCatalogAdminJsonBody(request: Request): Promise<Readonly<Record<string, unknown>>> {
   return expectRecord(await parseJsonBodyWithByteLimit(
@@ -163,6 +165,25 @@ function expectStringArray(value: unknown, fieldName: string): ReadonlyArray<str
   }
 
   return value.map((item, index) => expectNonEmptyString(item, `${fieldName}[${index}]`));
+}
+
+/**
+ * Checks membership case-insensitively and returns the lowercased tag, so an uppercase entry such as
+ * `EN` is accepted and every returned value is itself one of `catalogAudienceLocales`.
+ */
+function expectCatalogAudienceLocaleArray(value: unknown, fieldName: string): ReadonlyArray<string> {
+  return expectStringArray(value, fieldName).map((languageTag, index) => {
+    if (catalogAudienceLocaleSet.has(languageTag.toLowerCase()) === false) {
+      throw new HttpError(
+        400,
+        `${fieldName}[${index}] must be a supported catalog audience locale. `
+          + `tag=${languageTag} supported=${catalogAudienceLocales.join(", ")}`,
+        "CATALOG_INVALID_INPUT",
+      );
+    }
+
+    return languageTag.toLowerCase();
+  });
 }
 
 function rejectRemovedTopicTagsField(record: Readonly<Record<string, unknown>>): void {
@@ -236,7 +257,7 @@ function parsePackageCreateInput(record: Readonly<Record<string, unknown>>): Cre
     title: expectNonEmptyString(record.title, "title"),
     summary: expectNonEmptyString(record.summary, "summary"),
     description: expectNonEmptyString(record.description, "description"),
-    languageTags: expectStringArray(record.languageTags, "languageTags"),
+    languageTags: expectCatalogAudienceLocaleArray(record.languageTags, "languageTags"),
     educationalSubject: expectOmittableNonEmptyString(
       record.educationalSubject,
       "educationalSubject",
@@ -263,7 +284,7 @@ function parsePackageUpdateInput(
     title: expectNonEmptyString(record.title, "title"),
     summary: expectNonEmptyString(record.summary, "summary"),
     description: expectNonEmptyString(record.description, "description"),
-    languageTags: expectStringArray(record.languageTags, "languageTags"),
+    languageTags: expectCatalogAudienceLocaleArray(record.languageTags, "languageTags"),
     educationalSubject: expectOmittableNonEmptyString(
       record.educationalSubject,
       "educationalSubject",


### PR DESCRIPTION
The catalog accepted any non-empty string as a `languageTags` entry. That is how topic strings once leaked into the field and reached the marketing website as a page language — a website test at the time literally asserted `inLanguage: ["en", "world history"]`.

The website is about to derive both a deck's canonical route and its schema.org `inLanguage` from these tags, so the contract now enforces what convention alone was carrying.

## What changes

- A single exported `catalogAudienceLocales` constant lists the eight supported audience locales, beside the other closed catalog values. Its comment records that it intentionally mirrors the marketing website's `src/lib/localeConfig.ts` and must change together with it.
- Both catalog package admin input parsers validate every `languageTags` entry against it and raise the existing `CATALOG_INVALID_INPUT` error naming the offending tag.
- Membership is checked case-insensitively and the parser returns the lowercased tag, so its own output is provably one of the eight rather than depending on `normalizeTextArray` in the authoring layer to make that true afterwards. `"EN"` is still accepted and still stored as `"en"`, exactly as before.

## Scope and consequences

No database constraint is added; validation stays at the API boundary where the existing catalog input errors live. Every published deck already uses one of the eight locales, so no existing caller is rejected.

This deliberately couples catalog audience languages to the website's interface locales: adding an audience language now requires adding an interface locale.

No collection parser is touched, because none accepts `languageTags` — `catalog.collections.language_tags` is written only by migrations, and the sole collection admin endpoint is the cover upload. When collection metadata authoring lands it should apply the same rule, which will need the helper exported or moved to a shared parsing module.

The guarantee covers writes. Version creation copies `packages.language_tags` verbatim, and three historical published versions of one deck carry an older tag that cannot be rewritten because that column is protected by the published-version immutability trigger; handling those is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)