### PR TITLE
Match the review queue skeleton height and unify the empty-tags label

### DIFF
--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -875,7 +875,7 @@ export function CardsScreen(): ReactElement {
                     <span className="cards-cell-multiline-display">{card.backText === "" ? t("common.noBackText") : card.backText}</span>
                   </td>
                   <td className="txn-cell cards-col-tags cards-tag-cell">
-                    {card.tags.length === 0 ? <span className="tag-value-empty">—</span> : (
+                    {card.tags.length === 0 ? <span className="tag-value-empty">{t("common.noTags")}</span> : (
                       <span className="tag-value-list">
                         {card.tags.map((tag) => (
                           <span key={tag} className="tag-chip tag-chip-readonly">

--- a/apps/web/src/screens/review/components/ReviewCardTags.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardTags.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { useI18n } from "../../../i18n";
 
-export type ReviewCardTagsProps = Readonly<{
+type ReviewCardTagsProps = Readonly<{
   tags: ReadonlyArray<string>;
 }>;
 

--- a/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
@@ -366,7 +366,11 @@ export function DeckDetailScreen(): ReactElement {
                   {detailState.cards.map((card) => (
                     <article key={card.cardId} className="content-card deck-detail-card">
                       <div className="deck-detail-card-head">
-                        <span className="badge">{formatTagSummary(card.tags, t)}</span>
+                        {card.tags.length === 0 ? (
+                          <span className="tag-value-empty">{t("common.noTags")}</span>
+                        ) : (
+                          <span className="badge">{formatTagSummary(card.tags, t)}</span>
+                        )}
                       </div>
                       <h3 className="panel-subtitle">{card.frontText}</h3>
                       <p className="subtitle">{card.backText === "" ? t("common.noBackText") : card.backText}</p>

--- a/apps/web/src/styles/features/review/review-queue.css
+++ b/apps/web/src/styles/features/review/review-queue.css
@@ -58,7 +58,8 @@
 }
 
 .review-loading-queue-card {
-  min-height: 96px;
+  /* Matches a real single-line .review-queue-card, whose .review-queue-card-tags row is one 30px chip tall. */
+  min-height: 106px;
 }
 
 .review-queue-card:hover {


### PR DESCRIPTION
Follow-ups left over from #1710, which turned the review card's tags and status into matching chips.

The queue's tag row became a 30px chip row, so a real `.review-queue-card` is now 105.7px tall while `.review-loading-queue-card` stayed pinned at 96px — measured on the deployed app, not estimated. On the cold path the list therefore pushed downward when data replaced the skeleton; before the chip change the skeleton was slightly taller and the list settled upward instead. The other loading branch is unaffected: when a `reviewLoadingSnapshot` exists it already renders real queue markup through the same `ReviewCardTags`, so its height always matched.

`DeckDetailScreen` sent the empty-tags case through `formatTagSummary` into a `badge` pill, so a card with no tags showed the localized `common.noTags` string inside a real pill — indistinguishable from a tag literally named "No tags". It now renders as a plain `tag-value-empty` placeholder, matching `CardTagsValue`. Real tags still render exactly as before, as a comma-joined string in the pill; the decks screen is deliberately not converted to chips.

On the cards list the loading-snapshot row already printed the localized string while the real row printed an em dash, so an untagged card's label changed as snapshot data was replaced by real data. Both now print `common.noTags`.

`ReviewCardTagsProps` is no longer exported, since nothing imports it and module-local props types are the convention in that directory.

Accepted tradeoff: one fixed skeleton height cannot match both a tagged card (105.7px) and an untagged one (92.7px). The tagged height is the right target because the seeded demo onboarding card carries a `demo` tag, so untagged-only workspaces are the rare shape.

No new i18n keys; `common.noTags` already exists in all nine catalogs. `formatTagSummary` stays exported for the cards-list loading row and the decks pill. No tests reference the changed markup or the em dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
