### PR TITLE
Report the failure that blocked multipart exact resolution

### DIFF
--- a/apps/backend/src/mediaAssets/multipart/atomicWriterPostgresTestSupport.ts
+++ b/apps/backend/src/mediaAssets/multipart/atomicWriterPostgresTestSupport.ts
@@ -133,6 +133,9 @@ export function applicationObservationScope(
   );
 }
 
+// operationBudgetMs has to clear multipartAttemptMinimumSettlementBudgetMs by more than the writer
+// attempt transactions the boundary runs inside it, or acquisition and the first lease renewal fail
+// on that settlement floor instead of reaching the behavior under test.
 export function createApplicationDeadlines(
   operationBudgetMs: number,
   requestBudgetMs: number,

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/atomicWriterLease.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/atomicWriterLease.postgres.integration.ts
@@ -399,7 +399,7 @@ test("foreground exact cleanup retries transient and unknown outcomes and waits 
         persistentInput.workspaceId,
         persistentInput.sessionId,
       );
-    const persistentDeadlines = createApplicationDeadlines(1_200, 2_400);
+    const persistentDeadlines = createApplicationDeadlines(2_000, 4_000);
     const persistentStorageFailure =
       new Error("Persistent foreground storage failure.");
     let persistentResolutionCalls = 0;

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerLease.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerLease.ts
@@ -273,6 +273,14 @@ function isRetryableMultipartResolutionError(error: unknown): boolean {
     || isTransientDatabaseError(error);
 }
 
+// The safe lease expiry is also the database deadline of every exact attempt, so an attempt that
+// runs into it fails on the deadline rather than on whatever keeps resolution from settling.
+function isMultipartResolutionDeadlineError(error: unknown): boolean {
+  return error instanceof DatabaseDeadlineExceededError
+    || hasSqlState(error, "57014")
+    || hasSqlState(error, "55P03");
+}
+
 function calculateMultipartResolutionRetryDelayMs(attempt: number): number {
   return Math.min(
     multipartResolutionRetryMaximumDelayMs,
@@ -361,19 +369,26 @@ export async function resolveMultipartOperationExactlyUntilSafe<Result>(
         );
         return { kind: "resolved", value };
       } catch (error) {
-        lastResolutionError = error;
+        // A deadline failure reports when retrying stopped, never why it kept failing, so it is
+        // only worth reporting while no real resolution failure has been seen.
+        if (
+          !isMultipartResolutionDeadlineError(error)
+          || lastResolutionError === null
+        ) {
+          lastResolutionError = error;
+        }
         if (!isRetryableMultipartResolutionError(error)) {
           await waitForMultipartWriterLeaseExpiry(cleanupDeadline);
           return {
             kind: "safe_lease_expired",
-            resolutionError: error,
+            resolutionError: lastResolutionError,
           };
         }
         const remainingMs = safeLeaseExpiryAtMs - Date.now();
         if (remainingMs <= 0) {
           return {
             kind: "safe_lease_expired",
-            resolutionError: error,
+            resolutionError: lastResolutionError,
           };
         }
         const delayMs = Math.min(


### PR DESCRIPTION
## What broke

`resolveMultipartOperationExactlyUntilSafe` uses the safe writer-lease expiry both as its own loop exit condition and as the database deadline it passes to every exact attempt, and it clamps the last retry delay so that sleep lands exactly on that boundary. When the loop-top clock read passes but the clock crosses before `validateDatabaseDeadline` re-reads it, the attempt fails with `DatabaseDeadlineExceededError` before the operation runs.

That error is not retryable and is not an `HttpError`, so it replaced the resolution failure that had actually blocked every earlier attempt, and `createMultipartCompletionResolutionError` degraded the terminal error to a bare `AggregateError`. The caller lost the `SERVICE_UNAVAILABLE` code and the reported cause named the deadline rather than the transient database failure that kept resolution from settling.

Through the HTTP route the status stays a retryable 503 either way, because `mapMultipartCompletionDeadlineError` remaps the escaping error and the operation deadline signal is always aborted by then. The cost is the wrong error code and a diagnostic that points at the loop's own boundary instead of the real failure.

## What it cost operationally

This is what made the persistent block of `foreground exact cleanup retries transient and unknown outcomes and waits out persistent failure safely` fail intermittently. That test runs in Pre-deploy checks of AWS/Web Release, so a flake there skips Deploy AWS release and every post-deploy smoke, and main stops deploying — most recently on a web-only CSS and TSX pull request.

## The fix

A deadline failure — `DatabaseDeadlineExceededError`, SQLSTATE `57014`, `55P03`, the same triple this file's `mapMultipartCompletionDeadlineError` already groups — no longer overwrites the last real resolution failure. It is still reported when no real resolution failure was ever seen.

A controllable clock was evaluated and rejected rather than skipped: the writer lease is an absolute timestamp stored in Postgres, and its liveness is compared against `clock_timestamp()`, so a Node-side clock cannot control the lease the assertions depend on. Removing the race at its source was the only deterministic option, and it is also the more correct behaviour.

The persistent block also gave two writer-attempt transactions only 200 ms above the production 1000 ms `multipartAttemptMinimumSettlementBudgetMs` floor — a second wall-clock dependency that no clock injection can remove either. Its budgets now match the sibling blocks at 2000/4000, which costs roughly 500 ms of test runtime.

The test's assertions are unchanged. It still proves the storage mutation is not live, that exact resolution was retried, the exact `SERVICE_UNAVAILABLE` plus `AggregateError([storageFailure, TransientDatabaseHttpError])` shape, `live_attempts` 0 with a null reconciliation state, and that the session can still be aborted afterwards.

## Validation

No project checks were run locally, per the repository working agreement. Cloud CI owns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
