### PR TITLE
Correct the one legacy catalog language tag

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,6 +71,13 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0129_correct_legacy_catalog_language_tag.sql",
+    expectedMigrationCount: 131,
+    testFiles: Object.freeze([
+      "src/catalog/authoring/versions/legacyLanguageTagCorrection.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0128_catalog_educational_alignment.sql",
     expectedMigrationCount: 130,
     testFiles: Object.freeze([

--- a/apps/backend/scripts/postgresIntegrations/migrations.mjs
+++ b/apps/backend/scripts/postgresIntegrations/migrations.mjs
@@ -372,6 +372,82 @@ async function seedMigration0103LegacyChatRun(client) {
   );
 }
 
+async function seedMigration0129LegacyCatalogLanguageTag(client) {
+  const authorId = "12900000-0000-4000-8000-000000000001";
+  const packageId = "12900000-0000-4000-8000-000000000002";
+  const packageVersions = [
+    { packageVersionId: "12900000-0000-4000-8000-000000000003", languageTags: ["en-us"] },
+    { packageVersionId: "12900000-0000-4000-8000-000000000004", languageTags: ["en-us"] },
+    { packageVersionId: "12900000-0000-4000-8000-000000000005", languageTags: ["en-us"] },
+    { packageVersionId: "12900000-0000-4000-8000-000000000006", languageTags: ["en"] },
+  ];
+  const packageSlug = "us-citizenship-test";
+  const packageTitle = "Migration 0129 legacy language tag";
+  const packageSummary = "Package seeded so migration 0129 has rows to correct.";
+  const packageDescription =
+    "Catalog package whose early published versions carry the legacy en-us tag.";
+  const adminEmail = "migration-0129-legacy-language-tag@example.test";
+  const timestamp = "2026-08-05T00:00:00.000Z";
+
+  await client.query(
+    `INSERT INTO catalog.authors (
+       author_id, slug, display_name
+     ) VALUES ($1, $2, $3)`,
+    [authorId, "migration-0129-legacy-language-tag", packageTitle],
+  );
+  await client.query(
+    `INSERT INTO catalog.packages (
+       package_id, author_id, slug, title, summary, description,
+       language_tags, license, status, published_at
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6, ARRAY['en']::TEXT[], 'CC0-1.0', 'published', $7
+     )`,
+    [
+      packageId,
+      authorId,
+      packageSlug,
+      packageTitle,
+      packageSummary,
+      packageDescription,
+      timestamp,
+    ],
+  );
+  // Published versions are inserted directly. Both triggers that block this shape -
+  // package_versions_published_immutable and package_versions_status_transition - are
+  // BEFORE UPDATE, so only an update path has to walk the draft/submitted/approved
+  // lifecycle. The shape mirrors production: versions 1 to 3 carry ARRAY['en-us'] and
+  // are what makes migration 0129 take its DISABLE TRIGGER path in CI instead of first
+  // executing it against production, while the already-correct published version 4 must
+  // survive untouched, which is what separates the migration's exact-array WHERE from a
+  // package-wide one. Version 4 stays published on purpose: that is production's shape,
+  // and a draft, submitted or approved row would sit under
+  // idx_package_versions_one_review_candidate.
+  for (const [index, packageVersion] of packageVersions.entries()) {
+    await client.query(
+      `INSERT INTO catalog.package_versions (
+         package_version_id, package_id, version_number, status, slug, title,
+         summary, description, language_tags, license, created_by_admin_email,
+         published_at
+       ) VALUES (
+         $1, $2, $3, 'published', $4, $5, $6, $7, $8::TEXT[],
+         'CC0-1.0', $9, $10
+       )`,
+      [
+        packageVersion.packageVersionId,
+        packageId,
+        index + 1,
+        packageSlug,
+        packageTitle,
+        packageSummary,
+        packageDescription,
+        packageVersion.languageTags,
+        adminEmail,
+        timestamp,
+      ],
+    );
+  }
+}
+
 async function createExpectedMigrationRoles(
   client,
   fileName,
@@ -518,6 +594,16 @@ async function applySingleMigration(
           await client.query("BEGIN");
           transactionStarted = true;
           await seedMigration0103LegacyChatRun(client);
+          await client.query("COMMIT");
+          transactionStarted = false;
+        }
+        if (
+          fileName
+          === "0129_correct_legacy_catalog_language_tag.sql"
+        ) {
+          await client.query("BEGIN");
+          transactionStarted = true;
+          await seedMigration0129LegacyCatalogLanguageTag(client);
           await client.query("COMMIT");
           transactionStarted = false;
         }

--- a/apps/backend/src/catalog/authoring/versions/legacyLanguageTagCorrection.postgres.integration.ts
+++ b/apps/backend/src/catalog/authoring/versions/legacyLanguageTagCorrection.postgres.integration.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+
+type PackageVersionLanguageTagRow = Readonly<{
+  package_version_id: string;
+  version_number: number;
+  language_tags: readonly string[];
+  created_at: Date;
+  updated_at: Date;
+}>;
+
+const legacyPackageSlug = "us-citizenship-test";
+const untouchedVersionNumber = 4;
+
+function requireTestDatabaseAdminUrl(): string {
+  const databaseUrl = process.env.TEST_DATABASE_ADMIN_URL?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error(
+      "TEST_DATABASE_ADMIN_URL is required for the legacy catalog language tag integration test.",
+    );
+  }
+
+  return databaseUrl;
+}
+
+function isPublishedVersionImmutable(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && error.code === "23514"
+    && error.message.includes("Published catalog package versions are immutable");
+}
+
+// Migration 0129 is the only migration in this repository that disables a trigger. The postgres
+// integration runner seeds production's shape - three published ARRAY['en-us'] versions plus the
+// already-correct published version 4 - so the DISABLE TRIGGER, the UPDATE and the ENABLE TRIGGER
+// are parsed and executed against a real PostgreSQL before the production release runs them. Only
+// a real database can prove that the guard the migration turns off is armed again afterwards.
+//
+// The exact-array WHERE is not what this test proves. A package-wide WHERE is rejected by the
+// migration's own updated_count <> expected_version_count abort in
+// db/migrations/0129_correct_legacy_catalog_language_tag.sql, which fails the migration run before
+// this file executes, and language_tags alone could not tell the two apart afterwards: every
+// version reads ARRAY['en'] either way. What this test can observe is that version 4 was never
+// written at all. package_versions_set_updated_at stamps updated_at on every row the UPDATE
+// touches, and the seed and the migration commit in separate transactions, so the corrected
+// versions end with updated_at past created_at while version 4 keeps the two equal.
+test("migration 0129 normalizes the legacy catalog language tag and rearms the published version guard", async () => {
+  const pool = new pg.Pool({
+    connectionString: requireTestDatabaseAdminUrl(),
+    application_name: "catalog-legacy-language-tag-integration",
+  });
+
+  try {
+    const versions = await pool.query<PackageVersionLanguageTagRow>(
+      [
+        "SELECT package_versions.package_version_id, package_versions.version_number,",
+        "package_versions.language_tags, package_versions.created_at,",
+        "package_versions.updated_at",
+        "FROM catalog.package_versions AS package_versions",
+        "JOIN catalog.packages AS packages",
+        "ON packages.package_id = package_versions.package_id",
+        "WHERE packages.slug = $1",
+        "ORDER BY package_versions.version_number",
+      ].join(" "),
+      [legacyPackageSlug],
+    );
+    assert.deepEqual(
+      versions.rows.map((version) => version.version_number),
+      [1, 2, 3, 4],
+    );
+    for (const version of versions.rows) {
+      assert.deepEqual(version.language_tags, ["en"]);
+      if (version.version_number === untouchedVersionNumber) {
+        assert.equal(
+          version.updated_at.getTime(),
+          version.created_at.getTime(),
+          `Version ${version.version_number} was written by the migration but must not be.`,
+        );
+        continue;
+      }
+      assert.ok(
+        version.updated_at.getTime() > version.created_at.getTime(),
+        `Version ${version.version_number} was not stamped by package_versions_set_updated_at.`,
+      );
+    }
+
+    const correctedVersion = versions.rows[0];
+    await assert.rejects(
+      pool.query(
+        "UPDATE catalog.package_versions SET title = $2 WHERE package_version_id = $1",
+        [correctedVersion?.package_version_id, "Rejected title edit"],
+      ),
+      isPublishedVersionImmutable,
+    );
+  } finally {
+    await pool.end();
+  }
+});

--- a/db/migrations/0129_correct_legacy_catalog_language_tag.sql
+++ b/db/migrations/0129_correct_legacy_catalog_language_tag.sql
@@ -1,0 +1,216 @@
+-- Migration status: Current / one-time data correction.
+-- Introduces: the normalization of the last catalog language tag that is not a supported audience
+--   locale. Package slug 'us-citizenship-test' still carries language_tags = ARRAY['en-us'] on its
+--   published versions 1, 2 and 3; this sets those three rows to ARRAY['en']. No new database
+--   object of any kind, and no schema change.
+-- Schemas touched/read explicitly: catalog, pg_catalog.
+--
+--
+-- WHY
+--
+-- apps/backend/src/catalog/types.ts fixes the audience locales a package may declare to ar, de, en,
+-- es, hi, ja, ru and zh, and apps/backend/src/routes/catalog/admin.ts rejects anything else on the
+-- admin write path. These three rows predate that rule. Measured across every published package
+-- version in the live public snapshot the tag histogram is en 97, ru 9, es 8, ja 8, zh 8, hi 5,
+-- ar 4, de 4 and en-us 3, so en-us is the only value outside the eight, and that artifact holds no
+-- collections, so nothing else needs repair. The marketing website is about to apply the same rule
+-- to every languageTags value it reads out of the snapshot; left as they are, these rows would make
+-- it reject real production data.
+--
+-- en-us and en name the same audience, so this is a normalization and not a change of meaning. The
+-- package's latest version, 4, and the mutable catalog.packages draft row already carry
+-- ARRAY['en'], so nothing changes for the version anyone installs today.
+--
+--
+-- HOW THE IMMUTABILITY GUARD IS SATISFIED
+--
+-- language_tags is one of the columns catalog.prevent_published_package_version_update() enumerates
+-- by name, so a plain UPDATE of a published row raises 23514. This migration disables exactly one
+-- trigger, package_versions_published_immutable, for the length of its own UPDATE and re-enables it
+-- in the same transaction:
+--
+--   * The guard function is never redefined, so the set of columns it protects afterwards is the
+--     same set it protects now, by construction. That is why this file does not follow 0113's
+--     CREATE OR REPLACE: restating the definition here would silently drop from the guard any
+--     column a migration merged in the meantime had added to it.
+--   * ALTER TABLE ... DISABLE TRIGGER takes SHARE ROW EXCLUSIVE on catalog.package_versions, which
+--     conflicts with the ROW EXCLUSIVE every INSERT, UPDATE and DELETE needs. The lock is held
+--     until this migration commits, so no other session can write the table while the guard is off,
+--     and the catalog change is itself transactional, so no other session ever observes the trigger
+--     disabled.
+--   * Every failure path below raises, and all three runners apply one file as one transaction -
+--     scripts/deploy/migrate.sh with psql --single-transaction, the migration Lambda with the
+--     BEGIN/COMMIT in apps/backend/src/database/migrationRunner.ts, and the postgres-integration
+--     runner with the BEGIN/COMMIT in apps/backend/scripts/postgresIntegrations/migrations.mjs - so
+--     an abort rolls the ALTER TABLE back with everything else. There is no path that leaves the
+--     guard disabled.
+--   * The trigger's enabled state is asserted to be the plain enabled one ('O') before it is
+--     disabled, which is what makes the restore exact: a replica-only or always-fire configuration
+--     aborts here instead of being silently rewritten into a plain one. The same assertion after
+--     ENABLE TRIGGER cannot fail by construction and is kept only as a self-documenting check that
+--     the statement above restores the state the pre-flight demanded.
+--   * The other two triggers on the table stay enabled throughout. package_versions_set_updated_at
+--     therefore stamps updated_at on the three rows, and their updatedAt in the public snapshot
+--     moves to this migration's timestamp: the repair is recorded rather than hidden.
+--     package_versions_status_transition is BEFORE UPDATE OF status and does not fire, because the
+--     statement below never mentions that column.
+--
+--
+-- WHAT IS DELIBERATELY NOT TOUCHED
+--
+-- language_tags is audience metadata and is not part of the install contract, so no installed card,
+-- media asset or workspace changes here. The durable install payloads in
+-- sync.catalog_package_install_idempotency keep their own frozen copy of languageTags, and keep
+-- en-us on purpose: they record what a completed install actually delivered, their schema in
+-- apps/backend/src/catalog/distribution/install/replay.ts accepts any string there and never
+-- compares that field against catalog.package_versions, so rewriting them would rewrite the history
+-- of finished installs for no gain. 0113 had to strip topicTags from those same payloads only
+-- because its strict schema no longer had a field to hold the value.
+--
+-- The correction is scoped to this one package rather than to every row that holds en-us anywhere,
+-- because a draft or delisted row elsewhere reaches no public surface and must not be able to abort
+-- a release. The delisted 'und' fixture from 0105/0107 is left alone for the same reason: every
+-- public projection excludes it with delisted_at IS NULL.
+--
+--
+-- RE-RUN AND ENVIRONMENT SAFETY
+--
+-- The file is a no-op wherever there is nothing to correct - a database without the package, which
+-- is every fresh and non-production one except the postgres-integration database described below,
+-- and a database whose rows already read ARRAY['en'] - and in both cases it leaves the trigger
+-- untouched and says so with a notice the migration runner logs. That second no-op is proved
+-- rather than assumed: because the UPDATE matches the whole array, a row holding en-us beside a
+-- companion tag would satisfy neither branch's premise and would leave the artifact carrying the
+-- value this migration exists to remove, so the branch first asserts that no version of the package
+-- carries en-us at all and aborts the release when one does. Where there is something to correct it
+-- must be exactly three rows, matched on the exact current value and never on the slug alone; any
+-- other count aborts the release rather than guessing.
+--
+-- Because this is the repository's first migration-level DISABLE TRIGGER, the correcting path is
+-- not left to run for the first time in production. seedMigration0129LegacyCatalogLanguageTag in
+-- apps/backend/scripts/postgresIntegrations/migrations.mjs inserts the package immediately before
+-- this file runs there, in production's shape: the three published ARRAY['en-us'] versions plus the
+-- already-correct version 4, so the rehearsal exercises the exact-array WHERE rather than a
+-- package-wide one. apps/backend/scripts/postgresIntegrations/boundaries.mjs declares that boundary
+-- and names the test that reads the result,
+-- apps/backend/src/catalog/authoring/versions/legacyLanguageTagCorrection.postgres.integration.ts.
+
+DO $migration$
+DECLARE
+  target_package_slug CONSTANT TEXT := 'us-citizenship-test';
+  legacy_language_tags CONSTANT TEXT[] := ARRAY['en-us']::TEXT[];
+  corrected_language_tags CONSTANT TEXT[] := ARRAY['en']::TEXT[];
+  expected_version_count CONSTANT BIGINT := 3;
+  target_package_id UUID;
+  legacy_version_count BIGINT;
+  guard_trigger_enabled "char";
+  updated_count INTEGER;
+BEGIN
+  SELECT packages.package_id
+  INTO target_package_id
+  FROM catalog.packages AS packages
+  WHERE packages.slug = target_package_slug;
+
+  IF NOT FOUND THEN
+    RAISE NOTICE 'Legacy catalog language tag correction skipped: no package with slug %', target_package_slug;
+    RETURN;
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO legacy_version_count
+  FROM catalog.package_versions AS package_versions
+  WHERE package_versions.package_id = target_package_id
+    AND package_versions.language_tags = legacy_language_tags;
+
+  IF legacy_version_count = 0 THEN
+    -- A whole-array match cannot tell "already corrected" from "en-us survives beside another tag",
+    -- so the absence of the tag itself is what makes this branch a no-op rather than a silent skip.
+    IF EXISTS (
+      SELECT 1
+      FROM catalog.package_versions AS package_versions
+      WHERE package_versions.package_id = target_package_id
+        AND legacy_language_tags[1] = ANY(package_versions.language_tags)
+    ) THEN
+      RAISE EXCEPTION 'Legacy catalog language tag % survives on package slug % in a shape this migration cannot repair: it corrects only versions whose language_tags equal %, package_id=%',
+        legacy_language_tags[1],
+        target_package_slug,
+        legacy_language_tags,
+        target_package_id
+        USING ERRCODE = '23514';
+    END IF;
+
+    RAISE NOTICE 'Legacy catalog language tag correction skipped: package slug % holds no version with language_tags %',
+      target_package_slug,
+      legacy_language_tags;
+    RETURN;
+  END IF;
+
+  IF legacy_version_count <> expected_version_count THEN
+    RAISE EXCEPTION 'Legacy catalog language tag correction expected % versions with language_tags %, found %: package_slug=% package_id=%',
+      expected_version_count,
+      legacy_language_tags,
+      legacy_version_count,
+      target_package_slug,
+      target_package_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  -- The trigger name cannot be a parameter of ALTER TABLE, so it is spelled out here and in the two
+  -- statements below; all three must name the same trigger created by 0083.
+  SELECT triggers.tgenabled
+  INTO guard_trigger_enabled
+  FROM pg_catalog.pg_trigger AS triggers
+  WHERE triggers.tgrelid = 'catalog.package_versions'::pg_catalog.regclass
+    AND triggers.tgname = 'package_versions_published_immutable'
+    AND triggers.tgfoid = 'catalog.prevent_published_package_version_update()'::pg_catalog.regprocedure;
+
+  IF NOT FOUND OR guard_trigger_enabled <> 'O' THEN
+    RAISE EXCEPTION 'Published catalog package version guard is not in the enabled state this migration can restore: trigger=package_versions_published_immutable found=% tgenabled=%',
+      FOUND,
+      guard_trigger_enabled
+      USING ERRCODE = '23514';
+  END IF;
+
+  ALTER TABLE catalog.package_versions
+    DISABLE TRIGGER package_versions_published_immutable;
+
+  UPDATE catalog.package_versions AS package_versions
+  SET language_tags = corrected_language_tags
+  WHERE package_versions.package_id = target_package_id
+    AND package_versions.language_tags = legacy_language_tags;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count <> expected_version_count THEN
+    RAISE EXCEPTION 'Legacy catalog language tag correction updated % versions instead of %: package_slug=% package_id=%',
+      updated_count,
+      expected_version_count,
+      target_package_slug,
+      target_package_id
+      USING ERRCODE = '40001';
+  END IF;
+
+  ALTER TABLE catalog.package_versions
+    ENABLE TRIGGER package_versions_published_immutable;
+
+  SELECT triggers.tgenabled
+  INTO guard_trigger_enabled
+  FROM pg_catalog.pg_trigger AS triggers
+  WHERE triggers.tgrelid = 'catalog.package_versions'::pg_catalog.regclass
+    AND triggers.tgname = 'package_versions_published_immutable'
+    AND triggers.tgfoid = 'catalog.prevent_published_package_version_update()'::pg_catalog.regprocedure;
+
+  IF NOT FOUND OR guard_trigger_enabled <> 'O' THEN
+    RAISE EXCEPTION 'Published catalog package version guard was not restored: trigger=package_versions_published_immutable found=% tgenabled=%',
+      FOUND,
+      guard_trigger_enabled
+      USING ERRCODE = '23514';
+  END IF;
+
+  RAISE NOTICE 'Legacy catalog language tag corrected from % to % on % versions: package_slug=% package_id=%',
+    legacy_language_tags,
+    corrected_language_tags,
+    updated_count,
+    target_package_slug,
+    target_package_id;
+END;
+$migration$;


### PR DESCRIPTION
The catalog now constrains `languageTags` to the eight supported audience locales on write, and the marketing website is about to apply the same rule everywhere it reads them. One value predates that rule: `us-citizenship-test` versions 1, 2 and 3 carry `en-us`, while its latest version and its draft row already carry `en`. Across every published version in the public artifact that is the only tag outside the eight locales, on exactly three rows.

`en-us` and `en` name the same audience, and `language_tags` is audience metadata rather than part of the install contract, so this is a normalization: nothing anyone installed changes.

## Why it disables a trigger

`language_tags` is one of the columns `catalog.prevent_published_package_version_update()` protects, so a plain `UPDATE` on a published row raises `23514`.

The migration disables that one trigger by name for the duration of the update and re-enables it, rather than taking migration `0113`'s route of redefining the guard function. Restating an eighteen-column predicate is exactly how a silently narrowed guard would land, and it would drop any column another migration had since added; disabling by name cannot narrow the guard at all. The whole migration is a single `DO` block and every runner applies one file in one transaction, so any failure rolls the trigger state back with everything else. The trigger's enabled state is asserted before the disable, matched on both trigger name and function, so a `replica` or `always` configuration could never be silently rewritten into a plain one.

## Why it is rehearsed

Every postgres-integration boundary stopped at `0128`, so nothing would have executed this file before production — and plpgsql defers parsing a block's statements until they first run, so even a bare boundary on an empty database would have validated only the early return. The disable, the update and the re-enable would have been parsed and executed for the first time against production.

A seed hook now reproduces production's four-version shape — three legacy rows plus the already-correct version 4 — and a boundary runs it against a real `postgres:18`. The test asserts the corrected values, that the guard was rearmed (a title edit still raises `23514`), and that version 4 was never written, which the `package_versions_set_updated_at` stamp makes observable.

## Safety

Re-running is a no-op, and a database without the package is a no-op. If the package holds the legacy tag in a shape the exact-array match cannot repair, the migration aborts rather than passing silently. The `UPDATE` matches the exact array value, never the slug alone, and a mis-scoped predicate would trip the row-count assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)