### PR TITLE
Normalize streamed OpenAI completed responses

### DIFF
--- a/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
@@ -27,6 +27,7 @@ import {
   collectEvents,
   createAbortedResponseStream,
   createAssistantMessageItem,
+  createCompletedResponseStream,
   createDependencies,
   createFunctionCallAddedEvent,
   createFunctionCallItem,
@@ -540,11 +541,12 @@ test("startOpenAILoopWithDeps reports phase transitions for model and tool execu
   assert.deepEqual(phases, ["idle", "model", "idle", "tool", "idle", "idle"]);
 });
 
-test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit summary call", async () => {
+test("startOpenAILoopWithDeps completes a raw tool-limit summary and reports model phase transitions", async () => {
   let streamCallCount = 0;
   let toolCallCount = 0;
   const phases: Array<string> = [];
   const requests: Array<OpenAI.Responses.ResponseCreateParams> = [];
+  const { sink, events } = collectEvents();
 
   const result = await startOpenAILoopWithDeps(
     createParams({
@@ -552,7 +554,7 @@ test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit
         phases.push(phase);
       },
     }),
-    async (): Promise<void> => undefined,
+    sink,
     createDependencies(
       (request) => {
         requests.push(request);
@@ -564,9 +566,8 @@ test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit
           );
         }
 
-        return createResponseStream(
-          [],
-          createResponse([createAssistantMessageItem("summary")], "summary"),
+        return createCompletedResponseStream(
+          createResponse([createAssistantMessageItem("summary")], undefined),
         );
       },
       async () => {
@@ -583,6 +584,41 @@ test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit
   assert.equal(result.terminationReason, "completed");
   assert.equal(streamCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1);
   assert.equal(toolCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS);
+  assert.deepEqual(events.slice(-2), [
+    {
+      type: "delta",
+      text: "summary",
+      itemId: "tool-limit-summary",
+      responseIndex: CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS,
+      outputIndex: 0,
+      contentIndex: 0,
+      sequenceNumber: 0,
+    },
+    { type: "done" },
+  ]);
+  assert.equal(result.openaiItems.length, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS * 2 + 1);
+  assert.deepEqual(result.openaiItems[0], {
+    type: "function_call",
+    call_id: "call-1",
+    name: "sql",
+    arguments: "{\"sql\":\"select 1\"}",
+    status: "completed",
+  });
+  assert.deepEqual(result.openaiItems.at(-2), {
+    type: "function_call_output",
+    call_id: `call-${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}`,
+    output: `{\"call\":${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}}`,
+  });
+  assert.deepEqual(result.openaiItems.at(-1), {
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{
+      type: "output_text",
+      text: "summary",
+      annotations: [],
+    }],
+  });
   assert.deepEqual(
     requests.map((request) => request.safety_identifier),
     Array.from(

--- a/apps/backend/src/chat/openai/loop/loop.testSupport.ts
+++ b/apps/backend/src/chat/openai/loop/loop.testSupport.ts
@@ -86,7 +86,7 @@ export function createAssistantMessageItem(
 
 export function createResponse(
   output: ReadonlyArray<OpenAI.Responses.ResponseOutputItem>,
-  outputText: string,
+  outputText: string | undefined,
 ): OpenAI.Responses.Response {
   return {
     id: "response-1",
@@ -99,7 +99,7 @@ export function createResponse(
     max_output_tokens: null,
     model: "gpt-5.6-terra",
     output: [...output],
-    output_text: outputText,
+    ...(outputText === undefined ? {} : { output_text: outputText }),
     parallel_tool_calls: false,
     temperature: 1,
     tool_choice: "auto",
@@ -215,6 +215,16 @@ export function createTerminalEventStream(
       yield event;
     },
   };
+}
+
+export function createCompletedResponseStream(
+  response: OpenAI.Responses.Response,
+): OpenAIResponseStream {
+  return createTerminalEventStream({
+    type: "response.completed",
+    response,
+    sequence_number: 1,
+  } as OpenAI.Responses.ResponseCompletedEvent);
 }
 
 export function createStreamWithoutCompletedResponse(): OpenAIResponseStream {

--- a/apps/backend/src/chat/openai/loop/responseStream.ts
+++ b/apps/backend/src/chat/openai/loop/responseStream.ts
@@ -236,6 +236,31 @@ async function getFinalResponseFromStream(
   });
 }
 
+function deriveAssistantOutputText(response: OpenAI.Responses.Response): string {
+  return response.output.flatMap((item) => {
+    if (item.type !== "message" || item.role !== "assistant") {
+      return [];
+    }
+
+    return item.content.flatMap((content) => (
+      content.type === "output_text" ? [content.text] : []
+    ));
+  }).join("");
+}
+
+function normalizeFinalResponse(
+  response: OpenAI.Responses.Response,
+): OpenAI.Responses.Response {
+  if (typeof response.output_text === "string") {
+    return response;
+  }
+
+  return {
+    ...response,
+    output_text: deriveAssistantOutputText(response),
+  };
+}
+
 export async function collectResponseStream(
   params: CollectResponseStreamParams,
 ): Promise<ModelCallResult> {
@@ -391,11 +416,13 @@ export async function collectResponseStream(
     }
   }
 
-  const finalResponse = await getFinalResponseFromStream(
-    params.stream,
-    completedResponse,
-    params.signal,
-    toStreamDiagnostics(streamCounters, streamedText.length),
+  const finalResponse = normalizeFinalResponse(
+    await getFinalResponseFromStream(
+      params.stream,
+      completedResponse,
+      params.signal,
+      toStreamDiagnostics(streamCounters, streamedText.length),
+    ),
   );
   return {
     finalResponse,


### PR DESCRIPTION
## Summary

- Normalize raw OpenAI completed responses when the SDK-only `output_text` convenience field is absent.
- Preserve ordered assistant text while excluding reasoning, tool calls, and refusals.
- Exercise the existing tool-limit summary flow with a production-shaped completed response.

## Validation

- Local project checks were intentionally not run; GitHub Actions owns executable validation.

## Sentry

- Fixes `FLASHCARDS-BACKEND-1A`.
