### PR TITLE
Resolve deck review filters to the workspace's tag spellings

### DIFF
--- a/apps/backend/src/agent/reviews.postgres.integration.ts
+++ b/apps/backend/src/agent/reviews.postgres.integration.ts
@@ -244,7 +244,7 @@ test("agent reviews select, filter, and schedule cards the way the first-party c
     );
 
     await t.test(
-      "tags match any of, a deck resolves to its tags, and both empty inputs keep their asymmetry",
+      "tags match any of, a deck resolves its tags to stored spellings, and both empty inputs keep their asymmetry",
       async () => {
         await tombstoneEveryCard();
         const alpha = await makeCard(["alpha"], "2026-02-01T00:00:00.000Z");
@@ -270,6 +270,15 @@ test("agent reviews select, filter, and schedule cards the way the first-party c
           {
             name: "Everything",
             filterDefinition: { version: 2, tags: [] },
+          },
+          { ...deckMetadata, lastOperationId: randomUUID() },
+        );
+        const upperBetaAndStaleDeck = await createDeck(
+          userId,
+          workspaceId,
+          {
+            name: "Beta upper and stale",
+            filterDefinition: { version: 2, tags: ["BeTa", "absent"] },
           },
           { ...deckMetadata, lastOperationId: randomUUID() },
         );
@@ -302,6 +311,16 @@ test("agent reviews select, filter, and schedule cards the way the first-party c
           await firstCardId({ kind: "deck", deckId: betaDeck.deckId }),
           beta.cardId,
         );
+        // A deck resolves its tags to the workspace's spellings, so a casing no card stores still
+        // reviews that deck's cards, while a name no card carries drops out instead of refusing the
+        // deck or widening it back to the workspace.
+        assert.equal(
+          await firstCardId({
+            kind: "deck",
+            deckId: upperBetaAndStaleDeck.deckId,
+          }),
+          beta.cardId,
+        );
         assert.equal(
           await firstCardId({ kind: "deck", deckId: everythingDeck.deckId }),
           alpha.cardId,
@@ -323,6 +342,13 @@ test("agent reviews select, filter, and schedule cards the way the first-party c
         assert.equal(
           (await post("next", { tags: ["alpha", "beta"] })).status,
           400,
+        );
+        // The workspace saved the same name into this deck, so it is dropped rather than refused,
+        // and the deck matches no card: the untagged card the next assertion reaches shows the
+        // queue stayed narrowed rather than widening back to the workspace.
+        assert.equal(
+          await firstCardId({ kind: "deck", deckId: betaDeck.deckId }),
+          null,
         );
         assert.equal(
           await firstCardId({ kind: "deck", deckId: everythingDeck.deckId }),

--- a/apps/backend/src/agent/reviews.ts
+++ b/apps/backend/src/agent/reviews.ts
@@ -67,21 +67,24 @@ function describeUnresolvedTags(unresolvedTags: ReadonlyArray<string>): string {
   return remaining > 0 ? `${named} and ${remaining} more` : named;
 }
 
-/** Replaces the requested names with the spellings the workspace's cards store for them, since the
- * queue query matches those spellings byte for byte. A caller has no tag picker to constrain it, so
- * a name no card carries is refused here instead of reaching the queue as a predicate that cannot
- * match, which reads back as nothing to review. */
-async function resolveRequestedTags(
+/** The spellings the workspace's cards store for the given names, beside the names nothing stored
+ * matched, since the queue query matches stored spellings byte for byte. */
+async function resolveTagsToStoredSpellings(
   context: AgentReviewContext,
   requestedTags: ReadonlyArray<string>,
-): Promise<ReadonlyArray<string>> {
+): Promise<
+  Readonly<{
+    storedTags: ReadonlyArray<string>;
+    unresolvedTags: ReadonlyArray<string>;
+  }>
+> {
   // Keys a requested name the way listWorkspaceTagsMatchingKeys keys a stored one: NFC, then
-  // lowercase, the contract having trimmed it on the same code points that function's btrim
-  // strips. Case folding is the one axis left diverging: Postgres lower() under the RDS
-  // en_US.UTF-8 ctype collapses more than V8 does, mapping U+0130 to "i" and every sigma to the
-  // medial one. Both directions of that are accepted because both stay case-only: "İstanbul" and
-  // "ΟΔΟΣ" are refused even where a card carries them, while "istanbul" and "οδοσ" resolve to
-  // those same cards.
+  // lowercase, the request contract and normalizeDeckTags having trimmed it on the same code
+  // points that function's btrim strips. Case folding is the one axis left diverging: Postgres
+  // lower() under the RDS en_US.UTF-8 ctype collapses more than V8 does, mapping U+0130 to "i" and
+  // every sigma to the medial one. Both directions of that are accepted because both stay
+  // case-only: "İstanbul" and "ΟΔΟΣ" resolve to nothing even where a card carries them, while
+  // "istanbul" and "οδοσ" resolve to those same cards.
   const requestedByKey = new Map(
     requestedTags.map(
       (tag) => [tag.normalize("NFC").toLowerCase(), tag] as const,
@@ -93,25 +96,38 @@ async function resolveRequestedTags(
     [...requestedByKey.keys()],
   );
   const resolvedKeys = new Set(storedTags.map((stored) => stored.tagKey));
-  const unresolved = [...requestedByKey]
-    .filter(([key]) => !resolvedKeys.has(key))
-    .map(([, tag]) => `"${tag}"`);
-  if (unresolved.length > 0) {
+  return {
+    storedTags: storedTags.map((stored) => stored.tag),
+    unresolvedTags: [...requestedByKey]
+      .filter(([key]) => !resolvedKeys.has(key))
+      .map(([, tag]) => tag),
+  };
+}
+
+/** A caller has no tag picker to constrain it, so a name no card carries is refused here instead of
+ * reaching the queue as a predicate that cannot match, which reads back as nothing to review. */
+async function resolveRequestedTags(
+  context: AgentReviewContext,
+  requestedTags: ReadonlyArray<string>,
+): Promise<ReadonlyArray<string>> {
+  const resolved = await resolveTagsToStoredSpellings(context, requestedTags);
+  if (resolved.unresolvedTags.length > 0) {
+    const named = describeUnresolvedTags(
+      resolved.unresolvedTags.map((tag) => `"${tag}"`),
+    );
     throw new HttpError(
       400,
-      `This workspace has no cards tagged ${describeUnresolvedTags(unresolved)}. Tag names are matched case-insensitively, so there is nothing to review under this filter.`,
+      `This workspace has no cards tagged ${named}. Tag names are matched case-insensitively, so there is nothing to review under this filter.`,
       "REVIEW_INPUT_INVALID",
     );
   }
 
-  return storedTags.map((stored) => stored.tag);
+  return resolved.storedTags;
 }
 
 /** Resolves the requested filter to the tag list the card query must match, or null for every card.
  * A deck carries no cards: content.decks.filter_definition is a saved tag filter, and an empty one
- * selects the whole workspace, while an explicitly empty tags request selects nothing. A deck's
- * saved tags go to the query as they are and match stored spellings byte for byte, so the deck
- * branch can skip cards the clients treat as part of that deck; resolving them is separate work. */
+ * selects the whole workspace, while an explicitly empty tags request selects nothing. */
 async function resolveReviewFilterTags(
   context: AgentReviewContext,
   filter: AgentReviewCardFilter,
@@ -127,9 +143,19 @@ async function resolveReviewFilterTags(
   }
 
   const deck = await getDeck(context.userId, context.workspaceId, filter.deckId);
-  return deck.filterDefinition.tags.length === 0
-    ? null
-    : deck.filterDefinition.tags;
+  if (deck.filterDefinition.tags.length === 0) {
+    return null;
+  }
+
+  // An unmatched name is not refused the way a caller-typed one is: a renamed or deleted tag would
+  // otherwise turn every deck saved under the old name into a hard 400. Every saved name must keep
+  // reaching the query, an invariant no test pins: an unmatched one still matches a card that
+  // stores it byte for byte, and contributes nothing otherwise, so the deck never widens.
+  const resolved = await resolveTagsToStoredSpellings(
+    context,
+    deck.filterDefinition.tags,
+  );
+  return [...new Set([...deck.filterDefinition.tags, ...resolved.storedTags])];
 }
 
 const recentlyReviewedWindow =

--- a/docs/conversational-reviews.md
+++ b/docs/conversational-reviews.md
@@ -51,10 +51,10 @@ deck / N tags filter:
   workspace does not use is a `400` rather than an empty queue. An explicitly
   empty array matches no card.
 - `deckId`: a saved deck. A deck holds no cards; `content.decks.filter_definition`
-  is a stored tag filter whose tags go to the queue as stored and are matched
-  exactly, so a deck tag the workspace no longer uses is an empty queue rather
-  than a `400`. A deck with no tags matches every card. An unknown `deckId` is a
-  `404`.
+  is a stored tag filter whose tags resolve case-insensitively to the
+  workspace's spellings, like `tags`. A deck tag the workspace no longer uses is
+  dropped rather than refused, so a deck whose tags are all unused matches no
+  card. A deck with no tags matches every card. An unknown `deckId` is a `404`.
 
 They are mutually exclusive, because no client combines a deck with tags. Supplying
 both is a `400`. Nothing due stays `card: null`.


### PR DESCRIPTION
A deck in this repository is a saved tag filter, not a container. Its saved tags went to the review queue unresolved and were matched byte for byte, so a deck saved as `Math` missed cards stored as `math` or `MATH` — while every client decides deck membership on a normalized key. `next_review_card` with a `deckId` could therefore skip cards the apps show in that deck, and answer `card: null` for a deck that is not empty, with nothing to signal it.

This predates the tag-filter change that shipped yesterday; it was found by that change's review and deliberately carved out rather than fixed in a sixth round of an unrelated patch.

Deck tags now resolve through the same helper `tags` uses. The saved spellings travel **alongside** what they resolved to rather than being replaced by it: case folding differs between Postgres `lower()` and V8 `toLowerCase()` for a few names — `İ`, a word-final `Σ` — that cards do store byte for byte, and replacing the saved spelling would have turned exactly those decks into empty queues. A raw saved name can only ever overlap a card storing it byte for byte, and every such card is one all three clients already place in that deck, so keeping it adds no over-match.

The two filters keep different failure semantics on purpose:

- a caller-typed tag that resolves to nothing is a `400`, because the caller typed it and an error is the honest answer;
- a deck's saved tag that resolves to nothing is kept and simply matches nothing, because refusing it would turn every deck saved under a since-renamed tag into a hard error in the agent client.

Only a deck saved with no tags selects the whole workspace. A deck whose tags all fail to resolve matches no card — those are deliberately opposite paths, and the early return that widens runs before resolution so the two cannot be conflated.

The existing tag/deck subtest was extended in place rather than duplicated: one deck now carries a resolving tag and a stale one, so a single assertion separates three things at once — that the differently-cased tag resolved, that the stale tag did not refuse the deck, and that the deck did not widen.

One thing deliberately not added: an assertion pinning the saved-spelling half of the union. Its discriminating power would depend on the CI Postgres container's ctype rather than on this code, so it could pass vacuously and read as coverage it does not provide. The invariant is stated in the code instead, and says outright that no test pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
