### PR TITLE
Require this commit's newest migration in the release check

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -384,7 +384,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0123_backfill_live_review_answered_platform.sql
+            --require-latest-migration
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -95,14 +95,14 @@ test("shared worker has exact permanent-prefix access and no public route", () =
 });
 
 test("release disables cleanup until the latest migration is confirmed", () => {
-  for (const { relativePath, requiredMigration } of [
+  for (const { relativePath, requireMigrationArgument } of [
     {
       relativePath: "../../.github/workflows/aws-web-release.yml",
-      requiredMigration: "0123_backfill_live_review_answered_platform.sql",
+      requireMigrationArgument: "--require-latest-migration",
     },
     {
       relativePath: "../../scripts/deploy/bootstrap.sh",
-      requiredMigration: "0110_collection_cover_media.sql",
+      requireMigrationArgument: "--require-migration 0110_collection_cover_media.sql",
     },
   ]) {
     const source = readSource(relativePath);
@@ -112,9 +112,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
     const cleanupDisabled = source.indexOf(
       "mediaBlobCleanupEnabled=false",
     );
-    const migration = source.indexOf(
-      `--require-migration ${requiredMigration}`,
-    );
+    const migration = source.indexOf(requireMigrationArgument);
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",
     );

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -207,9 +207,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const disabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
-  const requiredMigration = workflow.indexOf(
-    "--require-migration 0123_backfill_live_review_answered_platform.sql",
-  );
+  const requiredMigration = workflow.indexOf("--require-latest-migration");
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
   );

--- a/scripts/deploy/migrate-aws.sh
+++ b/scripts/deploy/migrate-aws.sh
@@ -1,20 +1,72 @@
 #!/usr/bin/env bash
 # Run database migrations through the AWS migration Lambda inside the VPC.
+#
+# --require-migration <file>   fail unless that db/migrations file is installed.
+# --require-latest-migration   fail unless the newest db/migrations file in this
+#                              checkout is installed; the name is resolved here,
+#                              so the release never pins a stale file.
+# Without either flag the script only reports what the Lambda did.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MIGRATIONS_DIR="${ROOT_DIR}/db/migrations"
 
 STACK_NAME="FlashcardsOpenSourceApp"
 FUNCTION_NAME=""
 REQUIRED_MIGRATION=""
+REQUIRE_LATEST_MIGRATION="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --stack-name) STACK_NAME="$2"; shift 2 ;;
     --function-name) FUNCTION_NAME="$2"; shift 2 ;;
-    --require-migration) REQUIRED_MIGRATION="$2"; shift 2 ;;
+    --require-migration)
+      if [[ -z "${2:-}" ]]; then
+        echo "ERROR: --require-migration needs a migration file name; an empty value would skip the check." >&2
+        exit 1
+      fi
+      REQUIRED_MIGRATION="$2"; shift 2 ;;
+    --require-latest-migration) REQUIRE_LATEST_MIGRATION="true"; shift ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
+
+# The newest migration is the last NNNN_*.sql file. Every new migration must
+# carry a prefix above the highest one already on main -
+# scripts/checks/pr/check-migration-hygiene.mjs enforces that on every pull
+# request - so the newest file always has the single highest prefix and every
+# collation agrees on it; the two legacy duplicate prefixes (0028, 0069) are
+# older and can never be newest. LC_ALL=C only keeps the answer independent of
+# the runner's locale. README.md and any other non-numbered file never match
+# the glob.
+resolve_latest_migration() {
+  local -a migration_names=()
+  local migration_path
+
+  for migration_path in "${MIGRATIONS_DIR}"/[0-9][0-9][0-9][0-9]_*.sql; do
+    if [[ -f "$migration_path" ]]; then
+      migration_names+=("$(basename "$migration_path")")
+    fi
+  done
+
+  if [[ ${#migration_names[@]} -eq 0 ]]; then
+    echo "ERROR: No NNNN_*.sql migration found in ${MIGRATIONS_DIR}; cannot resolve the latest migration to require." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${migration_names[@]}" | LC_ALL=C sort | tail -n 1
+}
+
+if [[ "$REQUIRE_LATEST_MIGRATION" == "true" ]]; then
+  if [[ -n "$REQUIRED_MIGRATION" ]]; then
+    echo "ERROR: --require-latest-migration cannot be combined with --require-migration." >&2
+    exit 1
+  fi
+  REQUIRED_MIGRATION="$(resolve_latest_migration)"
+  echo "Resolved latest migration: ${REQUIRED_MIGRATION}"
+fi
 
 if [[ -z "$FUNCTION_NAME" ]]; then
   FUNCTION_NAME=$(aws cloudformation describe-stacks \


### PR DESCRIPTION
## Why

The release's "Verify required database migration" step ran:

```
bash scripts/deploy/migrate-aws.sh --require-migration 0123_backfill_live_review_answered_platform.sql
```

That name was last updated in `fc0f99341`; the repository is at `0131`. The step asserts the named file is in the Lambda's `installedMigrations`, so it kept passing on eight-migrations-old evidence. Seen live in the release that shipped `0131`: `Applied migrations: none` / `Verified required migration: 0123_…`. (The `none` is correct — the `DatabaseMigrationGate` custom resource applies files during the CDK deploy just before this step. Only the assertion was stale.)

## What

`migrate-aws.sh` gains `--require-latest-migration`: it resolves the newest `db/migrations/NNNN_*.sql` in the checkout and asserts on that. The workflow passes the flag.

Chosen over deriving the name in the YAML step because the script skips the assertion entirely when the required name is empty (`if required_migration and …`). Keeping resolution and assertion in one process means no empty value can cross a boundary and land on that branch:

- zero matching files → `ERROR: No NNNN_*.sql migration found …`, exit 1, Lambda never invoked;
- `--require-migration ""` or a missing value → parse-time exit 1 (previously a silent skip);
- both flags together → exit 1;
- no flag → report-only, unchanged (`make migrate-aws`).

"Newest" is byte order over the full filename. Every new migration must carry a prefix above the highest already on `main` (`check-migration-hygiene.mjs` enforces it per PR), so the newest file always has the single highest prefix and every collation — the Lambda's `localeCompare`, `migrate.sh`'s glob, this script's `LC_ALL=C sort` — agrees on it. The two legacy duplicate prefixes (`0028`, `0069`) are older and can never be newest.

The two `infra/aws` tests that pinned step order to the literal `--require-migration 0123…` now anchor on the flag; their ordering assertions are unchanged.

## Verified

- Fake-`aws` proof runs (14 cases): installed-through-`0131` → verified, exit 0; installed-through-`0123` only → **exit 1** where the old pin would have passed; empty/README-only/absent migrations dir → exit 1 with no Lambda call; unknown flag, empty value, both flags → exit 1; explicit `--require-migration 0110…` (bootstrap shape) still works.
- The crux — `exit 1` inside a function called via `$(…)` under `set -e` — proven to terminate the parent: the plain assignment form is used, not `local v="$(…)"`, which would mask it.
- `infra/aws`: `npm test` 102/102 (build + both edited tests).
- `node scripts/checks/pr/run-all.mjs`: all 4 pass. `bash -n` clean. `shellcheck`/`actionlint` run in CI.

## Same defect, elsewhere — not in this PR

- `infra/aws/lib/stack.ts:332` passes the same `0123` literal to `databaseMigrationGate`. At deploy time the gate's Lambda applies every pending file first and only then checks that name, so this pin catches only a bundle that lacks the file — and with `0123` it would pass a bundle missing `0124–0131`. After this PR the gate is the weaker of the two guards.
- `scripts/deploy/bootstrap.sh:149` pins `--require-migration 0110_collection_cover_media.sql`; `--require-latest-migration` now fits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)