### PR TITLE
fix(backend): preserve direct-writer absolute lease target

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -70,6 +70,13 @@ export const createdRolesByMigration = new Map([
   ["0044_reporting_readonly_role.sql", Object.freeze(["reporting_readonly"])],
 ]);
 export const boundaryDefinitions = Object.freeze([
+  Object.freeze({
+    migrationFileName: "0132_direct_writer_absolute_lease_target.sql",
+    expectedMigrationCount: 134,
+    testFiles: Object.freeze([
+      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
+    ]),
+  }),
   // 0131 needs its own boundary rather than an extra test file on 0130's: it turns
   // educational_subject NOT NULL, and 0130's database stops one migration short of that schema. The
   // two row shapes that would abort that ALTER exist only here - the delisted 0105 test fixture
@@ -178,7 +185,6 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 101,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
-      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
       "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
       "src/mediaAssets/multipart/completion/completionReconciliation.postgres.integration.ts",
       "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
@@ -189,7 +195,6 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 100,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
-      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
       "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
       "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0123_backfill_live_review_answered_platform.sql",
+      RequiredMigration: "0132_direct_writer_absolute_lease_target.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0123_backfill_live_review_answered_platform.sql",
+    requiredMigration: "0132_direct_writer_absolute_lease_target.sql",
   });
 });
 

--- a/apps/backend/src/mediaAssets/blobLifecycle/index.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/index.ts
@@ -21,7 +21,7 @@ const maximumOperationIdLength = 1_024;
 const maximumMediaBlobWriterAttemptLeaseDurationMs = 3_600_000;
 const maximumMediaBlobWriterOperationDeadlineMs = 3_600_000;
 const maximumMediaBlobCleanupDelayMs = 604_800_000;
-const directMediaBlobWriterLeaseDatabaseSkewMarginMs = 100;
+const directMediaBlobWriterAbsoluteLeaseGrantPaddingMs = 100;
 export const mediaBlobCleanupDelayMs = 3_600_000;
 export const mediaBlobWriterKinds = ["direct_ingestion", "multipart_completion", "generated_promotion"] as const;
 export type MediaBlobWriterKind = typeof mediaBlobWriterKinds[number];
@@ -244,36 +244,16 @@ function snapshotDirectAttemptLease(
   const leaseTargetAtMs = Date.parse(leaseTargetAt);
   const remainingLeaseMs = leaseTargetAtMs - Date.now();
   if (
-    remainingLeaseMs <= 0
+    remainingLeaseMs <= directMediaBlobWriterAbsoluteLeaseGrantPaddingMs
     || remainingLeaseMs > maximumMediaBlobWriterAttemptLeaseDurationMs
-    || leaseTargetAtMs <= deadline.operationDeadlineAtMs
+    || leaseTargetAtMs - directMediaBlobWriterAbsoluteLeaseGrantPaddingMs
+      <= deadline.operationDeadlineAtMs
   ) {
     throw new MediaBlobWriterLeaseDeadlineError(
-      "leaseTargetAt must be a future timestamp strictly after operationDeadlineAt.",
+      `leaseTargetAt must be more than ${directMediaBlobWriterAbsoluteLeaseGrantPaddingMs} milliseconds in the future and remain strictly after operationDeadlineAt after padding.`,
     );
   }
   return Object.freeze({ leaseTargetAt, leaseTargetAtMs, ...deadline });
-}
-function deriveDirectAttemptLeaseDurationMs(
-  lease: DirectMediaBlobWriterAttemptLeaseSnapshot,
-): number {
-  const nowMs = Date.now();
-  const leaseDurationMs = Math.floor(
-    lease.leaseTargetAtMs
-    - nowMs
-    - directMediaBlobWriterLeaseDatabaseSkewMarginMs,
-  );
-  assertPositiveBoundedDuration(
-    leaseDurationMs,
-    "leaseDurationMs",
-    maximumMediaBlobWriterAttemptLeaseDurationMs,
-  );
-  if (lease.operationDeadlineAtMs - nowMs >= leaseDurationMs) {
-    throw new MediaBlobWriterLeaseDeadlineError(
-      "Insufficient exact writer lease budget remains for the operation deadline.",
-    );
-  }
-  return leaseDurationMs;
 }
 function snapshotDirectAttemptInput(
   input: DirectMediaBlobWriterAttemptInput,
@@ -470,15 +450,24 @@ async function beginDirectMediaBlobWriterAttemptSnapshotInExecutor(
   input: DirectMediaBlobWriterAttemptInput,
   lease: DirectMediaBlobWriterAttemptLeaseSnapshot,
 ): Promise<DirectMediaBlobWriterAttemptResult> {
-  const leaseDurationMs = deriveDirectAttemptLeaseDurationMs(lease);
   const result = await executor.query<AttemptBeginRow>(
     `SELECT attempt_status, reservation_token, normalization_version, lease_expires_at
-     FROM content.begin_direct_media_blob_writer_attempt_with_owner(
-       $1,$2,ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+     FROM content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(
+       $1,pg_catalog.to_timestamp($2::BIGINT / 1000.0),
+       ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
        ::content.direct_media_blob_writer_attempt_payload
      )`,
-    [input.attemptToken, leaseDurationMs, ...toDirectAttemptParams(input)],
+    [
+      input.attemptToken,
+      lease.leaseTargetAtMs - directMediaBlobWriterAbsoluteLeaseGrantPaddingMs,
+      ...toDirectAttemptParams(input),
+    ],
   );
+  if (result.rows.length === 0) {
+    throw new MediaBlobWriterLeaseDeadlineError(
+      "Direct media blob writer lease target expired before PostgreSQL admission.",
+    );
+  }
   if (result.rows.length !== 1) {
     throw new TypeError("PostgreSQL returned an invalid direct writer attempt row count.");
   }
@@ -492,15 +481,6 @@ async function beginDirectMediaBlobWriterAttemptSnapshotInExecutor(
     assertMediaBlobWriterReservationToken(row.reservation_token);
     const normalizationVersion = requireNormalizationVersion(row.normalization_version);
     const leaseExpiresAt = requireIsoTimestamp(row.lease_expires_at, "leaseExpiresAt");
-    const leaseExpiresAtMs = Date.parse(leaseExpiresAt);
-    if (
-      leaseExpiresAtMs <= lease.operationDeadlineAtMs
-      || leaseExpiresAtMs > lease.leaseTargetAtMs
-    ) {
-      throw new MediaBlobWriterLeaseDeadlineError(
-        "PostgreSQL returned a writer lease outside the exact operation window.",
-      );
-    }
     const exactInput = Object.freeze({
       ...input,
       reservationToken: row.reservation_token,

--- a/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
@@ -18,7 +18,7 @@ import {
   finalizeMediaBlobWriterInExecutor, markMediaBlobWriterAmbiguousInExecutor,
   mediaBlobCleanupDelayMs,
   MediaBlobLifecycleBusyError, MediaBlobLifecycleConflictError,
-  MediaBlobWriterFenceError, MediaBlobWriterLeaseDeadlineError,
+  MediaBlobWriterFenceError,
   reconcileMediaBlobWriterInExecutor, reserveMediaBlobWriterInExecutor,
   resolveDirectMediaBlobWriterAttemptAfterAccessRevocation,
   resolveDirectMediaBlobWriterAttemptFailureWithOwner,
@@ -40,6 +40,12 @@ type LifecycleUpgradeRow = Readonly<{
   backend_reserve_access: boolean; backend_fence_access: boolean;
   backend_terminalize_access: boolean; auth_terminalize_access: boolean;
   backend_generated_failure_access: boolean;
+}>;
+type DirectAttemptBeginRow = Readonly<{
+  attempt_status: string;
+  reservation_token: string | null;
+  normalization_version: string | null;
+  lease_expires_at: string | Date | null;
 }>;
 function createUniqueSha256(): string { return createHash("sha256").update(randomUUID()).digest("hex"); }
 const lifecycleMigrationSql = readFileSync(resolve(
@@ -253,7 +259,7 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
   }
 }
 
-async function waitForDirectAttemptAdvisoryLock(
+async function waitForDirectAttemptLock(
   fixture: PostgresIntegrationFixture,
 ): Promise<void> {
   const deadlineAtMs = Date.now() + 2_000;
@@ -264,18 +270,40 @@ async function waitForDirectAttemptAdvisoryLock(
          FROM pg_stat_activity
          WHERE usename = 'backend_app'
            AND wait_event_type = 'Lock'
-           AND query LIKE '%begin_direct_media_blob_writer_attempt_with_owner%'
+           AND query LIKE '%begin_direct_media_blob_writer_attempt_at_lease_target_with_owner%'
        ) AS waiting`,
     )).rows[0]?.waiting;
     if (waiting === true) return;
     if (Date.now() >= deadlineAtMs) {
-      throw new Error("Direct writer attempt did not reach its advisory lock.");
+      throw new Error("Direct writer attempt did not reach its blocking lock.");
     }
     await wait(10);
   }
 }
 
-test("direct writer acquisition rolls back a lease extended by lock latency", async () => {
+async function beginDirectAttemptAtLeaseTarget(
+  executor: DatabaseExecutor,
+  input: DirectMediaBlobWriterAttemptInput,
+  leaseTargetAt: string,
+): Promise<ReadonlyArray<DirectAttemptBeginRow>> {
+  return (await executor.query<DirectAttemptBeginRow>(
+    `SELECT attempt_status, reservation_token, normalization_version, lease_expires_at
+     FROM content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(
+       $1,$2::TIMESTAMPTZ,
+       ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+       ::content.direct_media_blob_writer_attempt_payload
+     )`,
+    [
+      input.attemptToken, leaseTargetAt, input.userId, input.workspaceId,
+      input.mediaAssetId, input.operationId, input.lastModifiedByReplicaId,
+      input.sha256, input.storageKey, input.mimeType, input.sizeBytes,
+      input.normalizationVersion, input.sourceUrl, input.assetCreatedAt,
+      input.clientUpdatedAt,
+    ],
+  )).rows;
+}
+
+test("direct writer absolute targets survive lock latency and reject expired admission", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {
     const sha256 = createUniqueSha256();
     const attemptInput = directAttemptInput(fixture, sha256);
@@ -288,24 +316,283 @@ test("direct writer acquisition rolls back a lease extended by lock latency", as
         [fixture.userId, fixture.workspaceId],
       );
       const nowMs = Date.now();
+      const leaseTargetAt = new Date(nowMs + 5_000).toISOString();
       const outcome = beginDirectMediaBlobWriterAttemptWithOwner(
         attemptInput,
         {
           operationDeadlineAt: new Date(nowMs + 4_000).toISOString(),
-          leaseTargetAt: new Date(nowMs + 5_000).toISOString(),
+          leaseTargetAt,
         },
-      ).then(
-        (value) => ({ value, error: null }),
-        (error: unknown) => ({ value: null, error }),
       );
-      await waitForDirectAttemptAdvisoryLock(fixture);
+      await waitForDirectAttemptLock(fixture);
       await wait(250);
       await holder.query("COMMIT");
       holderCommitted = true;
 
-      const settled = await outcome;
-      assert.equal(settled.value, null);
-      assert.ok(settled.error instanceof MediaBlobWriterLeaseDeadlineError);
+      const acquired = await outcome;
+      assert.equal(acquired.status, "acquired");
+      if (!("reservationToken" in acquired)) {
+        throw new Error("Delayed direct writer attempt did not acquire.");
+      }
+      assert.equal(
+        Date.parse(acquired.leaseExpiresAt),
+        Date.parse(leaseTargetAt) - 100,
+      );
+      const renewalHolder = await fixture.ownerPool.connect();
+      let renewalHolderCommitted = false;
+      try {
+        await renewalHolder.query("BEGIN");
+        await renewalHolder.query(
+          `SELECT 1
+           FROM content.media_blob_writer_attempts
+           WHERE attempt_token = $1
+           FOR UPDATE`,
+          [attemptInput.attemptToken],
+        );
+        const renewalTargetAtMs = Date.now() + 3_000;
+        const renewalRowsPromise = transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => beginDirectAttemptAtLeaseTarget(
+            executor,
+            attemptInput,
+            new Date(renewalTargetAtMs).toISOString(),
+          ),
+        );
+        await waitForDirectAttemptLock(fixture);
+        assert.ok(Date.now() < renewalTargetAtMs);
+        await wait(Math.max(1, renewalTargetAtMs - Date.now() + 50));
+        assert.ok(Date.now() >= renewalTargetAtMs);
+        await renewalHolder.query("COMMIT");
+        renewalHolderCommitted = true;
+
+        assert.deepEqual(await renewalRowsPromise, []);
+        const leaseAfterRejectedRenewal = (await fixture.ownerPool.query<{
+          lease_expires_at: Date;
+        }>(
+          `SELECT lease_expires_at
+           FROM content.media_blob_writer_attempts
+           WHERE attempt_token = $1`,
+          [attemptInput.attemptToken],
+        )).rows[0]?.lease_expires_at;
+        assert.equal(
+          leaseAfterRejectedRenewal?.getTime(),
+          Date.parse(acquired.leaseExpiresAt),
+        );
+      } finally {
+        if (!renewalHolderCommitted) {
+          await renewalHolder.query("ROLLBACK");
+        }
+        renewalHolder.release();
+      }
+      const blockedAcquisitionSha256 = createUniqueSha256();
+      const blockedAcquisitionInput = directAttemptInput(
+        fixture,
+        blockedAcquisitionSha256,
+      );
+      const acquisitionHolder = await fixture.ownerPool.connect();
+      let acquisitionHolderCommitted = false;
+      try {
+        await acquisitionHolder.query("BEGIN");
+        await acquisitionHolder.query(
+          `INSERT INTO content.media_blob_lifecycles (
+             sha256, storage_key, mime_type, size_bytes, normalization_version
+           ) VALUES ($1, $2, $3, $4, $5)`,
+          [
+            blockedAcquisitionInput.sha256,
+            blockedAcquisitionInput.storageKey,
+            blockedAcquisitionInput.mimeType,
+            blockedAcquisitionInput.sizeBytes,
+            blockedAcquisitionInput.normalizationVersion,
+          ],
+        );
+        const acquisitionTargetAtMs = Date.now() + 3_000;
+        const acquisitionRowsPromise = transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => beginDirectAttemptAtLeaseTarget(
+            executor,
+            blockedAcquisitionInput,
+            new Date(acquisitionTargetAtMs).toISOString(),
+          ),
+        );
+        await waitForDirectAttemptLock(fixture);
+        assert.ok(Date.now() < acquisitionTargetAtMs);
+        await wait(Math.max(1, acquisitionTargetAtMs - Date.now() + 50));
+        assert.ok(Date.now() >= acquisitionTargetAtMs);
+        await acquisitionHolder.query("COMMIT");
+        acquisitionHolderCommitted = true;
+
+        assert.deepEqual(await acquisitionRowsPromise, []);
+        const acquisitionResidue = (await fixture.ownerPool.query<{
+          attempt_exists: boolean;
+          reservation_exists: boolean;
+        }>(
+          `SELECT
+             EXISTS (
+               SELECT 1 FROM content.media_blob_writer_attempts
+               WHERE attempt_token = $1
+             ) AS attempt_exists,
+             EXISTS (
+               SELECT 1 FROM content.media_blob_writer_reservations
+               WHERE writer_kind = 'direct_ingestion'
+                 AND workspace_id = $2
+                 AND media_asset_id = $3
+                 AND operation_id = $4
+             ) AS reservation_exists`,
+          [
+            blockedAcquisitionInput.attemptToken,
+            blockedAcquisitionInput.workspaceId,
+            blockedAcquisitionInput.mediaAssetId,
+            blockedAcquisitionInput.operationId,
+          ],
+        )).rows[0];
+        assert.deepEqual(acquisitionResidue, {
+          attempt_exists: false,
+          reservation_exists: false,
+        });
+      } finally {
+        if (!acquisitionHolderCommitted) {
+          await acquisitionHolder.query("ROLLBACK");
+        }
+        acquisitionHolder.release();
+      }
+      const existingAssetInput = directAttemptInput(
+        fixture,
+        createUniqueSha256(),
+      );
+      const expiredPeer = await beginDirectMediaBlobWriterAttemptWithOwner(
+        existingAssetInput,
+        createDirectAttemptLease(),
+      );
+      if (!("reservationToken" in expiredPeer)) {
+        throw new Error("Existing-asset peer attempt did not acquire.");
+      }
+      await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => insertDirectAttemptAsset(executor, existingAssetInput),
+      );
+      await fixture.ownerPool.query(
+        `UPDATE content.media_blob_writer_attempts
+         SET lease_expires_at = clock_timestamp() - interval '1 second'
+         WHERE attempt_token = $1`,
+        [existingAssetInput.attemptToken],
+      );
+      const blockedFenceInput = {
+        ...existingAssetInput,
+        attemptToken: randomUUID(),
+      };
+      const fenceHolder = await fixture.ownerPool.connect();
+      let fenceHolderCommitted = false;
+      try {
+        await fenceHolder.query("BEGIN");
+        await fenceHolder.query(
+          `SELECT 1
+           FROM content.media_assets AS assets
+           INNER JOIN content.media_blobs AS blobs
+             ON blobs.media_blob_id = assets.media_blob_id
+           WHERE assets.media_asset_id = $1
+           FOR UPDATE OF assets, blobs`,
+          [existingAssetInput.mediaAssetId],
+        );
+        const fenceTargetAtMs = Date.now() + 3_000;
+        const fenceRowsPromise = transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => beginDirectAttemptAtLeaseTarget(
+            executor,
+            blockedFenceInput,
+            new Date(fenceTargetAtMs).toISOString(),
+          ),
+        );
+        await waitForDirectAttemptLock(fixture);
+        assert.ok(Date.now() < fenceTargetAtMs);
+        await wait(Math.max(1, fenceTargetAtMs - Date.now() + 50));
+        assert.ok(Date.now() >= fenceTargetAtMs);
+        await fenceHolder.query("COMMIT");
+        fenceHolderCommitted = true;
+
+        assert.deepEqual(await fenceRowsPromise, []);
+        const fenceResidue = (await fixture.ownerPool.query<{
+          new_attempt_exists: boolean;
+          peer_state: string | null;
+          peer_outcome: string | null;
+          peer_terminal_at: Date | null;
+          attempt_count: number;
+          reservation_count: number;
+          reservation_unchanged: boolean;
+        }>(
+          `SELECT
+             EXISTS (
+               SELECT 1 FROM content.media_blob_writer_attempts
+               WHERE attempt_token = $1
+             ) AS new_attempt_exists,
+             (
+               SELECT state FROM content.media_blob_writer_attempts
+               WHERE attempt_token = $2
+             ) AS peer_state,
+             (
+               SELECT outcome FROM content.media_blob_writer_attempts
+               WHERE attempt_token = $2
+             ) AS peer_outcome,
+             (
+               SELECT terminal_at FROM content.media_blob_writer_attempts
+               WHERE attempt_token = $2
+             ) AS peer_terminal_at,
+             (
+               SELECT count(*)::INTEGER
+               FROM content.media_blob_writer_attempts
+               WHERE writer_kind = 'direct_ingestion'
+                 AND workspace_id = $3
+                 AND media_asset_id = $4
+                 AND operation_id = $5
+             ) AS attempt_count,
+             (
+               SELECT count(*)::INTEGER
+               FROM content.media_blob_writer_reservations
+               WHERE writer_kind = 'direct_ingestion'
+                 AND workspace_id = $3
+                 AND media_asset_id = $4
+                 AND operation_id = $5
+             ) AS reservation_count,
+             EXISTS (
+               SELECT 1
+               FROM content.media_blob_writer_reservations
+               WHERE reservation_token = $6
+                 AND state = 'active'
+             ) AS reservation_unchanged`,
+          [
+            blockedFenceInput.attemptToken,
+            existingAssetInput.attemptToken,
+            existingAssetInput.workspaceId,
+            existingAssetInput.mediaAssetId,
+            existingAssetInput.operationId,
+            expiredPeer.reservationToken,
+          ],
+        )).rows[0];
+        assert.deepEqual(fenceResidue, {
+          new_attempt_exists: false,
+          peer_state: "leased",
+          peer_outcome: null,
+          peer_terminal_at: null,
+          attempt_count: 1,
+          reservation_count: 1,
+          reservation_unchanged: true,
+        });
+      } finally {
+        if (!fenceHolderCommitted) {
+          await fenceHolder.query("ROLLBACK");
+        }
+        fenceHolder.release();
+      }
+      const expiredSha256 = createUniqueSha256();
+      const expiredInput = directAttemptInput(fixture, expiredSha256);
+      const expiredRows = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => beginDirectAttemptAtLeaseTarget(
+          executor,
+          expiredInput,
+          new Date(Date.now() - 1_000).toISOString(),
+        ),
+      );
+      assert.deepEqual(expiredRows, []);
       const residue = (await fixture.ownerPool.query<{
         attempt_exists: boolean;
         reservation_exists: boolean;
@@ -324,12 +611,46 @@ test("direct writer acquisition rolls back a lease extended by lock latency", as
              SELECT 1 FROM content.media_blob_lifecycles
              WHERE sha256 = $2
            ) AS lifecycle_exists`,
-        [attemptInput.attemptToken, sha256],
+        [expiredInput.attemptToken, expiredSha256],
       )).rows[0];
       assert.deepEqual(residue, {
         attempt_exists: false,
         reservation_exists: false,
         lifecycle_exists: false,
+      });
+      const privileges = (await fixture.ownerPool.query<{
+        legacy_backend_execute: boolean;
+        absolute_backend_execute: boolean;
+        absolute_auth_execute: boolean;
+        absolute_reporting_execute: boolean;
+      }>(
+        `SELECT
+           has_function_privilege(
+             'backend_app',
+             'content.begin_direct_media_blob_writer_attempt_with_owner(uuid,integer,content.direct_media_blob_writer_attempt_payload)',
+             'EXECUTE'
+           ) AS legacy_backend_execute,
+           has_function_privilege(
+             'backend_app',
+             'content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(uuid,timestamp with time zone,content.direct_media_blob_writer_attempt_payload)',
+             'EXECUTE'
+           ) AS absolute_backend_execute,
+           has_function_privilege(
+             'auth_app',
+             'content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(uuid,timestamp with time zone,content.direct_media_blob_writer_attempt_payload)',
+             'EXECUTE'
+           ) AS absolute_auth_execute,
+           has_function_privilege(
+             'reporting_readonly',
+             'content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(uuid,timestamp with time zone,content.direct_media_blob_writer_attempt_payload)',
+             'EXECUTE'
+           ) AS absolute_reporting_execute`,
+      )).rows[0];
+      assert.deepEqual(privileges, {
+        legacy_backend_execute: true,
+        absolute_backend_execute: true,
+        absolute_auth_execute: false,
+        absolute_reporting_execute: false,
       });
     } finally {
       if (!holderCommitted) {
@@ -913,10 +1234,12 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
            INSERT INTO catalog.authors (author_id, slug, display_name) VALUES ($1, $3, 'Lifecycle integration')
            RETURNING author_id
          )
-         INSERT INTO catalog.packages (package_id, author_id, slug, title, summary, description,
-                                       language_tags, topic_tags, license)
+         INSERT INTO catalog.packages (
+           package_id, author_id, slug, title, summary, description,
+           language_tags, educational_subject, license
+         )
          SELECT $2, author_id, $3 || '-package', 'Lifecycle', 'Lifecycle', 'Lifecycle',
-                ARRAY['en'], ARRAY[]::text[], 'CC0-1.0'
+                ARRAY['en'], 'Software testing', 'CC0-1.0'
          FROM inserted_author`,
         [authorId, packageId, catalogSlug],
       );

--- a/db/migrations/0132_direct_writer_absolute_lease_target.sql
+++ b/db/migrations/0132_direct_writer_absolute_lease_target.sql
@@ -1,0 +1,553 @@
+-- Current additive migration for absolute-target direct writer leases.
+-- Schemas touched/read explicitly: content, org, security, sync, pg_catalog.
+
+CREATE FUNCTION
+content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(
+  p_attempt_token UUID,
+  p_lease_expires_at TIMESTAMPTZ,
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_attempt content.media_blob_writer_attempts%ROWTYPE;
+  peer_attempt content.media_blob_writer_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reservation_result RECORD;
+  apply_payload content.direct_media_blob_writer_attempt_payload;
+  fence_status TEXT;
+  takeover BOOLEAN := false;
+  admitted_at TIMESTAMPTZ;
+  leased_until TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR content.direct_media_blob_writer_attempt_requested_payload_valid_internal(
+      p_payload
+    ) IS DISTINCT FROM true
+    OR content.direct_media_blob_writer_attempt_payload_valid_internal(
+      p_payload
+    ) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY
+    SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN
+    RETURN QUERY
+    SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.state <> 'leased';
+
+  IF FOUND THEN
+    IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id()
+      OR existing_attempt.workspace_id IS DISTINCT FROM
+        security.current_workspace_id()
+    THEN
+      RETURN QUERY
+      SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+    apply_payload := p_payload;
+    apply_payload.normalization_version := existing_attempt.normalization_version;
+    fence_status := content.direct_media_blob_writer_attempt_identity_status_internal(
+      existing_attempt,
+      existing_attempt.reservation_token,
+      apply_payload
+    );
+    IF existing_attempt.requested_normalization_version IS DISTINCT FROM
+      p_payload.normalization_version
+    THEN
+      fence_status := 'stale_attempt';
+    END IF;
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY
+      SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+    RETURN QUERY
+    SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_payload.user_id || ':' || p_payload.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_payload.workspace_id
+      AND memberships.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY
+    SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_payload.replica_id
+      AND replicas.workspace_id = p_payload.workspace_id
+      AND replicas.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY
+    SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'direct:' || p_payload.workspace_id::TEXT || ':'
+        || p_payload.media_asset_id::TEXT || ':' || p_payload.operation_id,
+      2::BIGINT
+    )
+  );
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'attempt:' || p_attempt_token::TEXT,
+      3::BIGINT
+    )
+  );
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+
+  IF FOUND THEN
+    IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id()
+      OR existing_attempt.workspace_id IS DISTINCT FROM
+        security.current_workspace_id()
+    THEN
+      RETURN QUERY
+      SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+    apply_payload := p_payload;
+    apply_payload.normalization_version := existing_attempt.normalization_version;
+    fence_status := content.direct_media_blob_writer_attempt_identity_status_internal(
+      existing_attempt,
+      existing_attempt.reservation_token,
+      apply_payload
+    );
+    IF existing_attempt.requested_normalization_version IS DISTINCT FROM
+      p_payload.normalization_version
+    THEN
+      fence_status := 'stale_attempt';
+    END IF;
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY
+      SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+    IF existing_attempt.state <> 'leased' THEN
+      RETURN QUERY
+      SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    admitted_at := pg_catalog.clock_timestamp();
+    IF p_lease_expires_at IS NULL
+      OR p_lease_expires_at <= admitted_at
+      OR p_lease_expires_at > admitted_at + interval '3600000 milliseconds'
+    THEN
+      RETURN;
+    END IF;
+
+    fence_status := content.fence_direct_media_blob_writer_attempt_apply_with_owner(
+      p_attempt_token,
+      existing_attempt.reservation_token,
+      apply_payload,
+      3600000
+    );
+    IF fence_status = 'ready' THEN
+      admitted_at := pg_catalog.clock_timestamp();
+      IF p_lease_expires_at IS NULL
+        OR p_lease_expires_at <= admitted_at
+        OR p_lease_expires_at > admitted_at + interval '3600000 milliseconds'
+      THEN
+        RETURN;
+      END IF;
+      leased_until := p_lease_expires_at;
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET lease_expires_at = leased_until
+      WHERE attempts.attempt_token = p_attempt_token
+        AND attempts.state = 'leased'
+        AND attempts.lease_expires_at > pg_catalog.clock_timestamp();
+      IF NOT FOUND THEN
+        fence_status := 'stale_attempt';
+      ELSE
+        fence_status := 'replayed';
+      END IF;
+    END IF;
+    IF fence_status = 'replayed' THEN
+      RETURN QUERY
+      SELECT
+        fence_status,
+        existing_attempt.reservation_token,
+        existing_attempt.normalization_version,
+        leased_until;
+    ELSE
+      RETURN QUERY
+      SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    END IF;
+    RETURN;
+  END IF;
+
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id,
+    min_available_hot_change_id,
+    updated_at
+  )
+  VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+
+  PERFORM 1
+  FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id
+  FOR UPDATE;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'direct_ingestion'
+    AND reservations.workspace_id = p_payload.workspace_id
+    AND reservations.media_asset_id = p_payload.media_asset_id
+    AND reservations.operation_id = p_payload.operation_id
+  FOR UPDATE;
+
+  IF FOUND THEN
+    SELECT snapshots.*
+    INTO owner_snapshot
+    FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token
+    FOR UPDATE;
+  END IF;
+
+  SELECT attempts.*
+  INTO peer_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'direct_ingestion'
+    AND attempts.workspace_id = p_payload.workspace_id
+    AND attempts.media_asset_id = p_payload.media_asset_id
+    AND attempts.operation_id = p_payload.operation_id
+    AND attempts.state = 'leased'
+  FOR UPDATE;
+
+  admitted_at := pg_catalog.clock_timestamp();
+  IF p_lease_expires_at IS NULL
+    OR p_lease_expires_at <= admitted_at
+    OR p_lease_expires_at > admitted_at + interval '3600000 milliseconds'
+  THEN
+    RETURN;
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+    OR NOT EXISTS (
+      SELECT 1
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = p_payload.workspace_id
+        AND memberships.user_id = p_payload.user_id
+    )
+  THEN
+    RETURN QUERY
+    SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_payload.replica_id
+      AND replicas.workspace_id = p_payload.workspace_id
+      AND replicas.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY
+    SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF lifecycle.sha256 IS NOT NULL
+    AND (
+      lifecycle.storage_key IS DISTINCT FROM p_payload.storage_key
+      OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type
+      OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    )
+  THEN
+    RETURN QUERY
+    SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN
+    RETURN QUERY
+    SELECT
+      'cleanup_claimed'::TEXT,
+      NULL::UUID,
+      lifecycle.normalization_version,
+      NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF reservation.reservation_token IS NOT NULL
+    AND (
+      reservation.sha256 IS DISTINCT FROM p_payload.sha256
+      OR owner_snapshot.reservation_token IS NULL
+    )
+  THEN
+    RETURN QUERY
+    SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF owner_snapshot.reservation_token IS NOT NULL
+    AND (
+      owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id
+      OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id
+    )
+  THEN
+    RETURN QUERY
+    SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  BEGIN
+    IF peer_attempt.attempt_token IS NOT NULL THEN
+      apply_payload := p_payload;
+      apply_payload.normalization_version := peer_attempt.normalization_version;
+      fence_status := content.direct_media_blob_writer_attempt_identity_status_internal(
+        peer_attempt,
+        peer_attempt.reservation_token,
+        apply_payload
+      );
+      IF fence_status <> 'ready'
+        OR peer_attempt.requested_normalization_version IS DISTINCT FROM
+          p_payload.normalization_version
+      THEN
+        RETURN QUERY
+        SELECT
+          CASE WHEN fence_status = 'ready' THEN 'stale_attempt' ELSE fence_status END,
+          NULL::UUID,
+          NULL::TEXT,
+          NULL::TIMESTAMPTZ;
+        RETURN;
+      ELSIF peer_attempt.reservation_token IS DISTINCT FROM
+          reservation.reservation_token
+        OR peer_attempt.normalization_version IS DISTINCT FROM
+          lifecycle.normalization_version
+        OR reservation.state NOT IN ('active', 'ambiguous', 'finalized')
+      THEN
+        RETURN QUERY
+        SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+        RETURN;
+      ELSIF peer_attempt.lease_expires_at > pg_catalog.clock_timestamp() THEN
+        RETURN QUERY
+        SELECT
+          'busy'::TEXT,
+          NULL::UUID,
+          NULL::TEXT,
+          peer_attempt.lease_expires_at;
+        RETURN;
+      END IF;
+
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET
+        state = 'expired',
+        outcome = 'stale_attempt',
+        terminal_at = pg_catalog.clock_timestamp()
+      WHERE attempts.attempt_token = peer_attempt.attempt_token
+        AND attempts.state = 'leased';
+      takeover := true;
+    END IF;
+
+    SELECT *
+    INTO reservation_result
+    FROM content.reserve_owned_media_blob_writer_internal(
+      p_payload.user_id,
+      p_payload.replica_id,
+      p_payload.sha256,
+      p_payload.storage_key,
+      p_payload.mime_type,
+      p_payload.size_bytes,
+      p_payload.normalization_version,
+      'direct_ingestion',
+      p_payload.workspace_id,
+      p_payload.media_asset_id,
+      p_payload.operation_id,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL
+    );
+
+    IF reservation_result.reservation_status = 'cleanup_claimed' THEN
+      RETURN QUERY
+      SELECT
+        'cleanup_claimed'::TEXT,
+        NULL::UUID,
+        reservation_result.normalization_version,
+        NULL::TIMESTAMPTZ;
+      RETURN;
+    ELSIF reservation_result.reservation_status = 'ownership_mismatch' THEN
+      RETURN QUERY
+      SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    ELSIF reservation_result.reservation_status <> 'reserved'
+      OR reservation_result.reservation_token IS NULL
+    THEN
+      RETURN QUERY
+      SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    admitted_at := pg_catalog.clock_timestamp();
+    IF p_lease_expires_at IS NULL
+      OR p_lease_expires_at <= admitted_at
+      OR p_lease_expires_at > admitted_at + interval '3600000 milliseconds'
+    THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0132',
+        MESSAGE = 'Direct writer absolute lease target expired during admission';
+    END IF;
+
+    leased_until := p_lease_expires_at;
+    INSERT INTO content.media_blob_writer_attempts (
+      attempt_token,
+      reservation_token,
+      writer_kind,
+      user_id,
+      workspace_id,
+      media_asset_id,
+      operation_id,
+      replica_id,
+      sha256,
+      blob_storage_key,
+      mime_type,
+      size_bytes,
+      requested_normalization_version,
+      normalization_version,
+      source_url,
+      asset_created_at,
+      client_updated_at,
+      state,
+      lease_expires_at
+    )
+    VALUES (
+      p_attempt_token,
+      reservation_result.reservation_token,
+      'direct_ingestion',
+      p_payload.user_id,
+      p_payload.workspace_id,
+      p_payload.media_asset_id,
+      p_payload.operation_id,
+      p_payload.replica_id,
+      p_payload.sha256,
+      p_payload.storage_key,
+      p_payload.mime_type,
+      p_payload.size_bytes,
+      p_payload.normalization_version,
+      reservation_result.normalization_version,
+      p_payload.source_url,
+      p_payload.asset_created_at,
+      p_payload.client_updated_at,
+      'leased',
+      leased_until
+    );
+
+    apply_payload := p_payload;
+    apply_payload.normalization_version := reservation_result.normalization_version;
+    fence_status := content.fence_direct_media_blob_writer_attempt_apply_with_owner(
+      p_attempt_token,
+      reservation_result.reservation_token,
+      apply_payload,
+      3600000
+    );
+
+    admitted_at := pg_catalog.clock_timestamp();
+    IF p_lease_expires_at IS NULL
+      OR p_lease_expires_at <= admitted_at
+      OR p_lease_expires_at > admitted_at + interval '3600000 milliseconds'
+    THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0132',
+        MESSAGE = 'Direct writer absolute lease target expired during admission';
+    END IF;
+
+    IF fence_status = 'ready' THEN
+      fence_status := CASE WHEN takeover THEN 'expired_takeover' ELSE 'acquired' END;
+    END IF;
+  EXCEPTION
+    WHEN SQLSTATE 'P0132' THEN
+      RETURN;
+  END;
+
+  IF fence_status IN ('acquired', 'expired_takeover') THEN
+    RETURN QUERY
+    SELECT
+      fence_status,
+      reservation_result.reservation_token,
+      reservation_result.normalization_version,
+      leased_until;
+  ELSE
+    RETURN QUERY
+    SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION
+  content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(
+    UUID,
+    TIMESTAMPTZ,
+    content.direct_media_blob_writer_attempt_payload
+  ) IS
+  'Leases one exact direct writer attempt until the caller-supplied absolute deadline, admitting the call only while that deadline is still ahead of a database clock read taken after its blocking locks.';
+
+REVOKE ALL ON FUNCTION
+  content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(
+    UUID,
+    TIMESTAMPTZ,
+    content.direct_media_blob_writer_attempt_payload
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION
+  content.begin_direct_media_blob_writer_attempt_at_lease_target_with_owner(
+    UUID,
+    TIMESTAMPTZ,
+    content.direct_media_blob_writer_attempt_payload
+  )
+  TO backend_app;


### PR DESCRIPTION
## Problem

Direct media blob writer attempts converted the caller-supplied absolute lease target into a relative duration before waiting on PostgreSQL locks. Lock latency could therefore start that duration late, allowing an import-loop writer lease to extend beyond the intended operation window.

## Fix

- Add the additive `0132_direct_writer_absolute_lease_target.sql` migration, which admits and renews direct writer attempts against a caller-supplied absolute PostgreSQL timestamp after blocking locks are acquired.
- Pass the absolute lease target from the backend caller with a 100 ms admission padding, and surface a specific lease-deadline error when PostgreSQL rejects an expired target.
- Advance the migration gates used by the release workflow, bootstrap path, CDK stack, and their contract checks to migration 0132.

## Coverage

- Expand the PostgreSQL integration boundary to cover lock-delayed acquisition, expired renewal and acquisition, expired fence admission, rollback residue, and function privileges.
- Update backend and infrastructure contract coverage for the new migration gate and caller behavior.

## Cloud validation

- Local tests, lint, builds, formatters, database tests, deployments, and AWS commands were intentionally not run; required PR checks are the validation lane.
- After merge, the automatically triggered AWS/Web Release workflow must complete successfully before delivery is considered complete.