### PR TITLE
Require the newest bundled migration in the CDK migration gate

### DIFF
--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
 import test from "node:test";
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
@@ -14,18 +16,28 @@ type CloudFormationResource = Readonly<{
   Properties?: Readonly<Record<string, unknown>>;
 }>;
 
-test("database migration gate blocks the dependent backend runtime", () => {
+// Independent of the resolver under test: the newest NNNN_*.sql in the bundled
+// directory by byte order, the same rule scripts/deploy/migrate-aws.sh applies.
+function readExpectedLatestMigration(): string {
+  const migrationFileNames = readdirSync(resolve(process.cwd(), "../../db/migrations"))
+    .filter((fileName) => /^[0-9]{4}_.*\.sql$/.test(fileName))
+    .sort();
+  const latestMigrationFileName = migrationFileNames.at(-1);
+  if (latestMigrationFileName === undefined) {
+    throw new Error("db/migrations holds no NNNN_*.sql file to expect from the gate");
+  }
+  return latestMigrationFileName;
+}
+
+test("database migration gate requires the newest bundled migration and blocks the dependent backend runtime", () => {
+  const expectedLatestMigration = readExpectedLatestMigration();
   const stack = new cdk.Stack();
   const migrationFn = new lambda.Function(stack, "MigrationHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({ installedMigrations: [] });"),
     handler: "index.handler",
     runtime: lambda.Runtime.NODEJS_24_X,
   });
-  const migrationGate = databaseMigrationGate(
-    stack,
-    migrationFn,
-    "0123_backfill_live_review_answered_platform.sql",
-  );
+  const migrationGate = databaseMigrationGate(stack, migrationFn);
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
     description: "Catalog-dependent backend runtime",
@@ -40,10 +52,12 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0123_backfill_live_review_answered_platform.sql"
+    && resource.Properties?.RequiredMigration === expectedLatestMigration
   ));
   if (migrationGateEntry === undefined) {
-    throw new Error("Synthesized template is missing the required database migration gate");
+    throw new Error(
+      `Synthesized template is missing a database migration gate requiring ${expectedLatestMigration}`,
+    );
   }
 
   const dependentRuntimeEntry = Object.entries(template.Resources).find(([, resource]) => (

--- a/infra/aws/lib/migration-runner.ts
+++ b/infra/aws/lib/migration-runner.ts
@@ -5,6 +5,7 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as customResources from "aws-cdk-lib/custom-resources";
 import * as rds from "aws-cdk-lib/aws-rds";
 import { Construct } from "constructs";
+import * as fs from "fs";
 import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
 import { backendStructuredLoggingProps } from "./backend-lambda-logging";
 import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
@@ -28,6 +29,27 @@ const dbAssetPaths = {
   migrations: resolveFromRepoRoot("db", "migrations"),
   views: resolveFromRepoRoot("db", "views"),
 };
+
+// Mirrors resolve_latest_migration in scripts/deploy/migrate-aws.sh: the same
+// NNNN_*.sql glob over the directory the bundle copies from, sorted in byte
+// order, last wins. Keeping the two definitions identical is what stops the
+// gate and the release step from disagreeing about which file is newest.
+const migrationFileNamePattern = /^[0-9]{4}_.*\.sql$/;
+
+function resolveLatestMigrationFileName(migrationsDirectory: string): string {
+  const migrationFileNames = fs
+    .readdirSync(migrationsDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && migrationFileNamePattern.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  const latestMigrationFileName = migrationFileNames.at(-1);
+  if (latestMigrationFileName === undefined) {
+    throw new Error(
+      `No NNNN_*.sql migration found in ${migrationsDirectory}; cannot resolve the migration the database migration gate must require.`,
+    );
+  }
+  return latestMigrationFileName;
+}
 
 const lambdaBundling: lambdaNodejs.BundlingOptions = {
   minify: true,
@@ -124,12 +146,13 @@ export function migrationRunner(scope: Construct, props: MigrationRunnerProps): 
 /**
  * Runs the current migration bundle during the stack deployment. A version
  * token makes CloudFormation update this resource whenever the bundled
- * migration Lambda changes.
+ * migration Lambda changes. The required migration is the newest file in the
+ * bundled directory, resolved at synth time, so the gate can never pin a
+ * stale name.
  */
 export function databaseMigrationGate(
   scope: Construct,
   migrationFn: lambda.Function,
-  requiredMigration: string,
 ): cdk.CustomResource {
   const provider = new customResources.Provider(scope, "DatabaseMigrationProvider", {
     onEventHandler: migrationFn,
@@ -138,7 +161,7 @@ export function databaseMigrationGate(
     serviceToken: provider.serviceToken,
     properties: {
       MigrationBundleVersion: migrationFn.currentVersion.version,
-      RequiredMigration: requiredMigration,
+      RequiredMigration: resolveLatestMigrationFileName(dbAssetPaths.migrations),
     },
   });
 }

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -95,15 +95,9 @@ test("shared worker has exact permanent-prefix access and no public route", () =
 });
 
 test("release disables cleanup until the latest migration is confirmed", () => {
-  for (const { relativePath, requireMigrationArgument } of [
-    {
-      relativePath: "../../.github/workflows/aws-web-release.yml",
-      requireMigrationArgument: "--require-latest-migration",
-    },
-    {
-      relativePath: "../../scripts/deploy/bootstrap.sh",
-      requireMigrationArgument: "--require-migration 0110_collection_cover_media.sql",
-    },
+  for (const relativePath of [
+    "../../.github/workflows/aws-web-release.yml",
+    "../../scripts/deploy/bootstrap.sh",
   ]) {
     const source = readSource(relativePath);
     const disabled = source.indexOf(
@@ -112,7 +106,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
     const cleanupDisabled = source.indexOf(
       "mediaBlobCleanupEnabled=false",
     );
-    const migration = source.indexOf(requireMigrationArgument);
+    const migration = source.indexOf("--require-latest-migration");
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",
     );

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -236,7 +236,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0123_backfill_live_review_answered_platform\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
+    /databaseMigrationGate\(this, migrationFn\)[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");
@@ -261,7 +261,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0110_collection_cover_media.sql",
+    "--require-latest-migration",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -326,11 +326,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       adminEmails,
       ...sentryContext,
     });
-    const migrationGate = databaseMigrationGate(
-      this,
-      migrationFn,
-      "0123_backfill_live_review_answered_platform.sql",
-    );
+    const migrationGate = databaseMigrationGate(this, migrationFn);
     const api = apiGateway(this, {
       vpc: net.vpc,
       lambdaSg: net.lambdaSg,

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -146,7 +146,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Verify required database migration ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0110_collection_cover_media.sql
+  --require-latest-migration
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Why

#1730 fixed the release workflow's required-migration step. Its review found the same defect one layer down: `infra/aws/lib/stack.ts` passed the literal `"0123_backfill_live_review_answered_platform.sql"` to `databaseMigrationGate`, which becomes `RequiredMigration` on the `DatabaseMigrationGate` custom resource.

What that pin actually guards: the gate's Lambda applies every pending file first and throws on failure — that path already fails the resource and rolls the deploy back. Only then does it assert the pinned name is installed. So the pin catches exactly one thing: a bundle that does not contain the file. With `0123` it would pass a bundle missing `0124`–`0131`, promote the runtime, and leave the workflow step to fail after promotion. After #1730 the gate was the weaker of the two guards.

## What

`databaseMigrationGate(scope, migrationFn)` — the name parameter is gone. The gate resolves its required migration at synth time from `dbAssetPaths.migrations`, the same constant the bundling hook copies `*.sql` from, so "the file the gate requires" and "the files in the bundle" come from one place in one process. Synth throws with a clear message if the directory holds no `NNNN_*.sql`; the gate cannot be created with an empty requirement.

The selection rule is the one `migrate-aws.sh --require-latest-migration` uses: four-digit prefix, `.sql`, full-filename byte order, last wins. Verified by comparing the complete ordered list from both rules over all 133 names — identical, not just the last element. JavaScript's `.sort()` compares UTF-16 code units and `LC_ALL=C sort` compares bytes; they can only differ for supplementary-plane characters, and the hygiene check admits `^\d{4}_[a-z0-9_]+\.sql$` only, so no admissible name can trigger it.

`scripts/deploy/bootstrap.sh` carried the last remaining pin (`0110_collection_cover_media.sql`); it now passes `--require-latest-migration`.

## Deploy-time effect

`RequiredMigration` changes `0123_…` → `0131_…` on the first deploy after merge, so CloudFormation sends an Update to the gate. `migrate-lambda.ts` treats Update like Create: idempotent `runMigrations()` then the assertion. `PhysicalResourceId` is constant, so no replacement and no Delete. `0131` is already installed in production, and `MigrationBundleVersion` changes on every release anyway, so this is not a new kind of event.

## Tests

Five assertions moved, none deleted. The template-level test now finds the gate by `RequiredMigration === <newest file>`, computing the expected name independently from the real `db/migrations` (own `readdirSync` + regex + sort, never calling the resolver), and still asserts the backend Lambda's `DependsOn`. The `stack.ts` source regex now requires `databaseMigrationGate(this, migrationFn)` immediately followed by `)`, so a re-introduced literal fails it — and fails `tsc` first. Bootstrap and workflow ordering assertions anchor on `--require-latest-migration`, which occurs exactly once in each.

## Verified

- `Template.fromStack` over `dist`: `DatabaseMigrationGate.RequiredMigration = 0131_require_catalog_educational_subject.sql`. Scratch copy with `db/migrations/` holding only `README.md`: synth throws `No NNNN_*.sql migration found in … ; cannot resolve the migration the database migration gate must require.`
- `infra/aws` `npm test`: 102/102. `node scripts/checks/pr/run-all.mjs`: all 4 pass. `bash -n scripts/deploy/bootstrap.sh` clean.
- `migrate-lambda.ts`, `migrate-aws.sh`, `migrate.sh`, and the bundling command are byte-identical to `main`.

Accepted residual: `Dirent.isFile()` has lstat semantics while `[[ -f ]]` follows symlinks, so a tracked symlink named `NNNN_x.sql` would be bundled and required by the workflow step but not by the gate. Nothing creates one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)