### PR TITLE
Key every tag comparison the same way

### DIFF
--- a/apps/backend/src/agent/reviews.ts
+++ b/apps/backend/src/agent/reviews.ts
@@ -11,6 +11,7 @@ import { createPostCommitAnalyticsBudget } from "../productAnalytics/serverFacts
 import { runTransactionReportingReviewAnswers } from "../productAnalytics/serverFacts/reviewAnswers";
 import type { FsrsCardState, ReviewRating } from "../scheduling";
 import { HttpError, type ReviewScheduleErrorDetails } from "../shared/errors";
+import { normalizeTagKey } from "../shared/tagKey";
 import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
 import { ensureAgentSyncReplica } from "./syncIdentity";
 import {
@@ -78,16 +79,9 @@ async function resolveTagsToStoredSpellings(
     unresolvedTags: ReadonlyArray<string>;
   }>
 > {
-  // Keys a requested name the way listWorkspaceTagsMatchingKeys keys a stored one: NFC, then
-  // lowercase, the request contract and normalizeDeckTags having trimmed it on the same code
-  // points that function's btrim strips. Case folding is the one axis left diverging: Postgres
-  // lower() under the RDS en_US.UTF-8 ctype collapses more than V8 does, mapping U+0130 to "i" and
-  // every sigma to the medial one. Both directions of that are accepted because both stay
-  // case-only: "İstanbul" and "ΟΔΟΣ" resolve to nothing even where a card carries them, while
-  // "istanbul" and "οδοσ" resolve to those same cards.
   const requestedByKey = new Map(
     requestedTags.map(
-      (tag) => [tag.normalize("NFC").toLowerCase(), tag] as const,
+      (tag) => [normalizeTagKey(tag), tag] as const,
     ),
   );
   const storedTags = await listWorkspaceTagsMatchingKeys(

--- a/apps/backend/src/cards/filters.ts
+++ b/apps/backend/src/cards/filters.ts
@@ -7,8 +7,7 @@ import type { CardFilter } from "./types";
 function normalizeCardFilterTags(tags: ReadonlyArray<string>): ReadonlyArray<string> {
   return tags.reduce<Array<string>>((result, tag) => {
     const normalizedTag = tag.trim();
-    const normalizedTagKey = normalizedTag.toLowerCase();
-    if (normalizedTag === "" || result.some((value) => value.toLowerCase() === normalizedTagKey)) {
+    if (normalizedTag === "" || result.includes(normalizedTag)) {
       return result;
     }
 

--- a/apps/backend/src/cards/queries.ts
+++ b/apps/backend/src/cards/queries.ts
@@ -5,6 +5,7 @@ import {
   type SqlValue,
 } from "../database";
 import { HttpError } from "../shared/errors";
+import { normalizeTagKey, storedTagKeyExpression } from "../shared/tagKey";
 import {
   buildTokenizedAndLikeClause,
   MAX_SEARCH_TOKEN_COUNT,
@@ -42,8 +43,8 @@ import type {
 const defaultCardsQueryPageSize = 50;
 const maximumCardsQuerySortCount = 3;
 const cardSearchExpressionFactories: ReadonlyArray<SearchTokenClauseFactory> = [
-  (paramIndex) => `lower(front_text || ' ' || back_text) LIKE $${paramIndex}`,
-  (paramIndex) => `EXISTS (SELECT 1 FROM unnest(tags) AS tag WHERE lower(tag) LIKE $${paramIndex})`,
+  (paramIndex) => `lower(normalize(front_text || ' ' || back_text, NFC)) LIKE $${paramIndex}`,
+  (paramIndex) => `EXISTS (SELECT 1 FROM unnest(tags) AS tag WHERE lower(normalize(tag, NFC)) LIKE $${paramIndex})`,
 ];
 
 type CursorValue = string | number | null;
@@ -329,8 +330,13 @@ export function buildCardsQueryFilterClause(
   const params: Array<SqlValue> = [];
 
   if (filter.tags.length > 0) {
+    // A typed spelling stays matched byte for byte: the key arm alone loses it where V8 and
+    // Postgres lower() disagree (see storedTagKeyExpression).
     params.push(filter.tags);
-    clauses.push(`tags && $${startIndex + params.length}::text[]`);
+    const spellingsParamIndex = startIndex + params.length;
+    params.push(filter.tags.map(normalizeTagKey));
+    const keysParamIndex = startIndex + params.length;
+    clauses.push(`(tags && $${spellingsParamIndex}::text[] OR EXISTS (SELECT 1 FROM unnest(tags) AS tag WHERE ${storedTagKeyExpression} = ANY($${keysParamIndex}::text[])))`);
   }
 
   if (clauses.length === 0) {
@@ -626,21 +632,6 @@ export async function listWorkspaceTagsSummary(userId: string, workspaceId: stri
     totalCards: toNumber(totalCardsRow.total_cards),
   };
 }
-
-/** The code points JS String.prototype.trim strips: ECMA-262 WhiteSpace, which is tab, line
- * tabulation, form feed, U+FEFF and every Space_Separator, plus the line terminators. Postgres
- * has no class that matches it: [[:space:]] under the RDS en_US.UTF-8 ctype covers most Unicode
- * spaces but not U+00A0, U+2007, U+202F or U+FEFF, and it matches U+0085 and U+001C-U+001F, which
- * JS trim keeps. Spelling the set out is what keeps the two trims identical. */
-const jsTrimCodePoints = String.raw`\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF`;
-
-/** A stored tag's key: NFC, then trim, then lowercase, the order normalizeTagKey keys a tag in on
- * web (apps/web/src/appData/domain/index.ts); iOS omits the NFC step, and Android's trim-last
- * order is equivalent because case mapping neither creates nor removes whitespace. Stored tags
- * are trimmed here because no write path trims them, on exactly the code points above, so a
- * spelling edged with one of them keys the same as the JS-trimmed name a caller sends.
- * normalize() and Unicode escapes both require a UTF8 database and raise otherwise. */
-const storedTagKeyExpression = `lower(btrim(normalize(tag, NFC), E'${jsTrimCodePoints}'))`;
 
 /** The spellings the workspace's live cards store for the given tag keys, each with the key it
  * matched, so nothing has to re-derive a stored tag's key in another engine. */

--- a/apps/backend/src/decks/index.ts
+++ b/apps/backend/src/decks/index.ts
@@ -553,8 +553,8 @@ export async function searchDecksPage(
   }
 
   const searchClauseResult = buildTokenizedOrLikeClause(searchTokens, 1, [
-    (paramIndex) => `lower(name) LIKE $${paramIndex}`,
-    (paramIndex) => `EXISTS (SELECT 1 FROM jsonb_array_elements_text(filter_definition->'tags') AS tag WHERE lower(tag) LIKE $${paramIndex})`,
+    (paramIndex) => `lower(normalize(name, NFC)) LIKE $${paramIndex}`,
+    (paramIndex) => `EXISTS (SELECT 1 FROM jsonb_array_elements_text(filter_definition->'tags') AS tag WHERE lower(normalize(tag, NFC)) LIKE $${paramIndex})`,
   ]);
   const decodedCursor = input.cursor === null ? null : decodeDeckPageCursor(input.cursor);
   const cursorClause = decodedCursor === null

--- a/apps/backend/src/search/tokens.ts
+++ b/apps/backend/src/search/tokens.ts
@@ -1,4 +1,5 @@
 import type { SqlValue } from "../database";
+import { normalizeTagKey } from "../shared/tagKey";
 
 export const MAX_SEARCH_TOKEN_COUNT = 5;
 
@@ -9,11 +10,6 @@ export type TokenizedSearchClause = Readonly<{
   params: ReadonlyArray<SqlValue>;
 }>;
 
-/**
- * Canonical text-search tokenization shared by card search features:
- * trim, lowercase, split by whitespace, and keep at most five tokens by
- * merging any overflow into the fifth token.
- */
 export function tokenizeSearchText(
   searchText: string,
   maximumTokenCount: number,
@@ -22,7 +18,7 @@ export function tokenizeSearchText(
     throw new Error("maximumTokenCount must be at least 1");
   }
 
-  const normalizedSearchText = searchText.trim().toLowerCase();
+  const normalizedSearchText = normalizeTagKey(searchText);
   if (normalizedSearchText === "") {
     return [];
   }
@@ -83,10 +79,6 @@ export function buildTokenizedOrLikeClause(
   };
 }
 
-/**
- * Canonical card-search semantics: all tokens are required (AND), while each
- * token may match any supported field expression (OR).
- */
 export function buildTokenizedAndLikeClause(
   searchTokens: ReadonlyArray<string>,
   startIndex: number,

--- a/apps/backend/src/shared/tagKey.ts
+++ b/apps/backend/src/shared/tagKey.ts
@@ -1,0 +1,22 @@
+/** The code points JS String.prototype.trim strips: ECMA-262 WhiteSpace, which is tab, line
+ * tabulation, form feed, U+FEFF and every Space_Separator, plus the line terminators. Postgres
+ * has no class that matches it: [[:space:]] under the RDS en_US.UTF-8 ctype covers most Unicode
+ * spaces but not U+00A0, U+2007, U+202F or U+FEFF, and it matches U+0085 and U+001C-U+001F, which
+ * JS trim keeps. Spelling the set out is what keeps the two trims identical. */
+const jsTrimCodePoints = String.raw`\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF`;
+
+/** Keys a tag name in the order the web's normalizeTagKey (apps/web/src/appData/domain/index.ts)
+ * does; iOS omits the NFC step, and Android's trim-last order is equivalent because case mapping
+ * neither creates nor removes whitespace. */
+export function normalizeTagKey(tag: string): string {
+  return tag.normalize("NFC").trim().toLowerCase();
+}
+
+/** normalizeTagKey over the unnested `tag` column. Stored tags are trimmed here because no write
+ * path trims them, on exactly the code points above, so a spelling edged with one of them keys
+ * the same as the JS-trimmed name a caller sends. normalize() and Unicode escapes both require a
+ * UTF8 database and raise otherwise. Case folding is the one axis left diverging: Postgres
+ * lower() under the RDS en_US.UTF-8 ctype collapses more than V8 does, mapping U+0130 to "i" and
+ * every sigma to the medial one, so a stored "İstanbul" or "ΟΔΟΣ" matches a requested "istanbul"
+ * or "οδοσ" but not its own spelling. Accepted because both directions stay case-only. */
+export const storedTagKeyExpression = `lower(btrim(normalize(tag, NFC), E'${jsTrimCodePoints}'))`;


### PR DESCRIPTION
The backend compared tags four different ways. The cards-list filter matched requested tags against stored ones byte for byte, so a user who typed `biology` saw an empty list when the cards stored `Biology`, with nothing to explain it — the same silent miss the agent review surface fixed for itself last week, on the human surface. Card and deck search lowercased in JavaScript against `lower()` in Postgres, and neither side normalized Unicode composition, so an accented tag typed on one keyboard missed the same tag stored from another. The agent surface carried its own inline copy of the key it had just introduced.

One definition now lives in `apps/backend/src/shared/tagKey.ts`, in both languages: NFC, then trim, then lowercase, with the trim set spelled out as 25 code points because Postgres has no character class that matches what JavaScript's `trim` strips — glibc's `[[:space:]]` omits the non-breaking spaces and U+FEFF, and matches U+0085 and U+001C–U+001F, which JavaScript keeps. It is a leaf module; `cards/`, `search/` and `agent/` import it one way.

The filter matches by exact spelling **or** by key, never by key alone. Postgres `lower()` and V8 `toLowerCase()` fold a few code points differently — `İ`, a word-final `Σ` — and matching by key alone would have dropped a card the user spelled exactly as stored. The overlap arm restores every match the old byte comparison produced; the keyed arm adds only rows whose stored key equals a requested key. Spellings are deduplicated by bytes rather than by key so that proof holds unconditionally.

The search token and every stored side it is compared against gain NFC together — card text, card tags, deck names and deck filter tags — because one tokenizer serves both screens and each token is one SQL parameter shared across a clause's expressions. Forking the tokenizer to spare deck search would have created the second copy this change removes. NFC is composition-only: it changes encoding, never the character set, so applied on both sides it can turn a spurious miss into a match and cannot create a false one.

The import tag comparator in `shared/cardImportTags.ts` is deliberately untouched: it orders tags, it does not match them.

Two things this surfaced for separate work: `idx_cards_active_search_trgm` has never served card search, because the search clause is an `OR` whose tag arm is a correlated `EXISTS` and Postgres cannot BitmapOr that — its migration comment has been untrue since the day both landed, and the index now costs write maintenance for nothing; and the agent SQL dialect's `tags OVERLAP` remains exact and case-sensitive by its own documented contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
