### PR TITLE
fix(backend): order lifecycle fixture cleanup

### DIFF
--- a/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
@@ -217,6 +217,8 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
       DROP FUNCTION content.reserve_media_blob_writer(TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT), content.finalize_media_blob_writer(UUID, TEXT, UUID, UUID);
       DROP FUNCTION content.mark_media_blob_writer_ambiguous(UUID), content.reconcile_media_blob_writer(UUID, TEXT, UUID, UUID, INTEGER);
       DROP FUNCTION content.fail_media_blob_writer(UUID, INTEGER), content.claim_media_blob_cleanup(TEXT, INTEGER), content.generated_media_promotion_operation_applied(UUID, UUID);
+      DROP TABLE content.media_blob_cleanup_claims, content.media_blob_cleanup_renewals, content.media_blob_cleanup_failures;
+      DROP TABLE content.media_blob_cleanup_attempts;
       DROP TABLE content.media_blob_writer_owner_snapshots;
       DROP TABLE content.media_blob_writer_reservations, content.media_blob_lifecycles
     `);


### PR DESCRIPTION
## Summary

[AWS/Web Release run 34571574427, job 103175641175](https://github.com/kirill-markin/flashcards-open-source-app/actions/runs/34571574427/job/103175641175) failed after the preceding backend merge because the lifecycle migration integration fixture tried to drop historical media blob lifecycle tables while migration-0102 cleanup tables still referenced them.

The fixture now drops the migration-0102 cleanup child tables and cleanup attempts first, then drops the historical lifecycle objects in dependency order. The cleanup stays explicit and does not use `CASCADE`.

## Impact

This changes only the integration fixture. It does not change runtime behavior or any database migration.

## Validation

Validation is cloud-only: required pull-request checks will validate the patch, and the automatically triggered post-merge workflows will validate the release path, especially AWS/Web Release.