### PR TITLE
fix(backend): align direct ingestion CI boundary

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -75,6 +75,7 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 134,
     testFiles: Object.freeze([
       "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
+      "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
     ]),
   }),
   // 0131 needs its own boundary rather than an extra test file on 0130's: it turns
@@ -185,7 +186,6 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 101,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
-      "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
       "src/mediaAssets/multipart/completion/completionReconciliation.postgres.integration.ts",
       "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),
@@ -195,7 +195,6 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 100,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
-      "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
       "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),
   }),


### PR DESCRIPTION
## Summary

- Fix the failure in AWS/Web Release run [34574911102](https://github.com/kirill-markin/flashcards-open-source-app/actions/runs/34574911102), job [103185094749](https://github.com/kirill-markin/flashcards-open-source-app/actions/runs/34574911102/job/103185094749): directIngestionApply.postgres.integration.ts calls a database function introduced by migration 0132, but the caller was registered at the 0098 and 0099 boundaries.
- Remove both stale registrations at 0098 and 0099, then register the caller exactly once at boundary 0132.
- Preserve every historical migration count and all other migration and security test registrations.
- Change only the CI integration-test caller map; runtime code and migration behavior are unaffected.

## Validation

- Use cloud CI only. Required pull-request checks must pass before the server-side merge, then every automatically triggered post-merge workflow, especially AWS/Web Release, will be watched through completion.