### PR TITLE
fix(web): classify package import 413 errors

### DIFF
--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx
@@ -21,10 +21,12 @@ import { WorkspaceImportScreen } from "./WorkspaceImportScreen";
 const workspaceReplicaId = "45268888-5620-5912-9ed1-4bd6f2105aff";
 
 const {
+  captureAppOperationErrorMock,
   confirmWorkspacePackageImportMock,
   previewWorkspacePackageImportMock,
   useAppDataMock,
 } = vi.hoisted(() => ({
+  captureAppOperationErrorMock: vi.fn(),
   confirmWorkspacePackageImportMock: vi.fn<(
     workspaceId: string,
     file: File,
@@ -48,6 +50,10 @@ vi.mock("../../../../api", async (importOriginal) => {
 
 vi.mock("../../../../appData", () => ({
   useAppData: useAppDataMock,
+}));
+
+vi.mock("../../../../observability/appOperationObservation", () => ({
+  captureAppOperationError: captureAppOperationErrorMock,
 }));
 
 type Mutable<Type> = {
@@ -207,6 +213,8 @@ function setupWorkspaceImportScreen(): WorkspaceImportScreenHarness {
   beforeEach(() => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     useAppDataMock.mockReset();
+    captureAppOperationErrorMock.mockReset();
+    captureAppOperationErrorMock.mockReturnValue(true);
     previewWorkspacePackageImportMock.mockReset();
     confirmWorkspacePackageImportMock.mockReset();
     appData = createAppData();
@@ -669,5 +677,59 @@ describe("WorkspaceImportScreen package import", () => {
     expect(getContainer().querySelector("[data-testid='workspace-package-import-preview']")).toBeNull();
     expect(document.body.querySelector("[data-testid='app-error-dialog']")).toBeNull();
     expect(confirmWorkspacePackageImportMock).not.toHaveBeenCalled();
+  });
+
+  it("shows inline package-too-large guidance for a code-less preview 413 without capturing it", async () => {
+    const file = createZipFile("flashcards.zip");
+    previewWorkspacePackageImportMock.mockRejectedValueOnce(new ApiError({
+      statusCode: 413,
+      message: "Request body is too large",
+      code: null,
+      requestId: null,
+      retryAfterMs: null,
+      endpoint: "POST /workspaces/workspace-1/packages/import/preview",
+      responseBodyKind: "empty",
+    }));
+
+    await renderScreen();
+    await choosePackageFile(file);
+    await waitForCondition("Package-too-large guidance was not shown", () => (
+      getContainer().querySelector("[data-testid='workspace-import-error']") !== null
+    ));
+
+    expect(requireElement("[data-testid='workspace-import-error']", HTMLParagraphElement).textContent).toContain(
+      "The selected package is too large. Choose a smaller flashcards.zip.",
+    );
+    expect(document.body.querySelector("[data-testid='app-error-dialog']")).toBeNull();
+    expect(captureAppOperationErrorMock).not.toHaveBeenCalled();
+    expect(confirmWorkspacePackageImportMock).not.toHaveBeenCalled();
+  });
+
+  it("shows inline package-too-large guidance for a coded confirm 413 without capturing it", async () => {
+    const file = createZipFile("flashcards.zip");
+    confirmWorkspacePackageImportMock.mockRejectedValueOnce(new ApiError({
+      statusCode: 413,
+      message: "Workspace package is too large",
+      code: "WORKSPACE_PACKAGE_IMPORT_FILE_TOO_LARGE",
+      requestId: "7684327b-64e3-41b2-a4f0-7bf428d4e225",
+      retryAfterMs: null,
+      endpoint: "POST /workspaces/workspace-1/packages/import/confirm",
+      responseBodyKind: "json",
+    }));
+
+    await renderScreen();
+    await choosePackageFile(file);
+    await waitForPreview();
+    await clickElement(requireElement("[data-testid='workspace-package-import-confirm-button']", HTMLButtonElement));
+    await waitForCondition("Package-too-large guidance was not shown", () => (
+      getContainer().querySelector("[data-testid='workspace-import-error']") !== null
+    ));
+
+    expect(requireElement("[data-testid='workspace-import-error']", HTMLParagraphElement).textContent).toContain(
+      "The selected package is too large. Choose a smaller flashcards.zip.",
+    );
+    expect(document.body.querySelector("[data-testid='app-error-dialog']")).toBeNull();
+    expect(captureAppOperationErrorMock).not.toHaveBeenCalled();
+    expect(confirmWorkspacePackageImportMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
@@ -38,6 +38,10 @@ function getWorkspacePackageValidationErrorMessage(
     return null;
   }
 
+  if (error.statusCode === 413) {
+    return t("workspaceImport.packageTooLarge");
+  }
+
   switch (error.code) {
     case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_EMPTY":
     case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID":


### PR DESCRIPTION
## Problem

The workspace-package import flow classified expected size failures only by application error code. A gateway-generated HTTP 413 can arrive without that code, so preview failures fell through to the generic technical-error path and Sentry capture; the mixed Sentry group also included application-coded 413 failures from confirmation.

## Change

- Map every workspace-package import HTTP 413 to the existing localized package-too-large guidance before application-code classification.
- Keep expected oversized-package failures inline and out of the generic technical-error dialog and Sentry capture.
- Cover both the code-less preview 413 and the coded confirm 413 paths.

## Validation

- Cloud CI only, per repository policy; no local tests, lint, builds, formatters, deployments, or browser tests were run.
- The Web test suite and required aggregate PR checks must pass before merge, followed by the automatically triggered AWS/Web Release and deployed web smoke workflows.
