### PR TITLE
Drop the never-used cards trigram search index

### DIFF
--- a/db/migrations/0133_drop_cards_search_trgm_index.sql
+++ b/db/migrations/0133_drop_cards_search_trgm_index.sql
@@ -1,0 +1,20 @@
+-- Migration status: Current / corrective drop.
+-- Introduces: the drop of content.idx_cards_active_search_trgm, the GIN trigram index from
+--   db/migrations/0013_cards_query_indexes.sql. Nothing else changes: no replacement index,
+--   and the pg_trgm extension stays installed.
+-- Replaces or corrects: db/migrations/0013_cards_query_indexes.sql.
+-- Schemas touched/read explicitly: content.
+--
+-- The index was never usable for the card search it was created for. That search is an OR
+-- whose tag arm is a correlated EXISTS (SELECT 1 FROM unnest(tags) ...); Postgres can turn
+-- an OR into a BitmapOr only when every arm is indexable, and that arm is not, so the
+-- planner cannot choose this index. Its expression, lower(front_text || ' ' || back_text),
+-- also differs from the text arm, lower(normalize(front_text || ' ' || back_text, NFC)).
+--
+-- DROP INDEX takes ACCESS EXCLUSIVE on content.cards: it waits behind every transaction holding a
+-- lock on cards while every new cards statement queues behind it. CONCURRENTLY cannot run inside
+-- the transaction the runner (apps/backend/src/database/migrationRunner.ts) wraps around each file,
+-- and the runner sets no lock_timeout, so the wait would otherwise be unbounded. 30s caps how long
+-- cards traffic can queue; past it the drop fails 55P03, the release fails, and a rerun retries the file.
+SET LOCAL lock_timeout = '30s';
+DROP INDEX IF EXISTS content.idx_cards_active_search_trgm;

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -15,6 +15,11 @@ production, and `scripts/checks/pr/check-migration-hygiene.mjs` rejects the diff
 makes an applied migration's header state something that is no longer true, the correction is
 recorded here instead of in the file.
 
+### `0013_cards_query_indexes.sql` — the trigram index is gone
+
+Its header says "the trigram/search indexing remains relevant". `0133_drop_cards_search_trgm_index.sql`
+drops `content.idx_cards_active_search_trgm` and records why the planner could never choose it.
+
 ### `0128_catalog_educational_alignment.sql` — the guard list is out of date
 
 Its header says that "Nothing in the admin API writes catalog.package_versions.educational_* after


### PR DESCRIPTION
## What

Migration `0133_drop_cards_search_trgm_index.sql` drops `content.idx_cards_active_search_trgm`, the GIN trigram index from `0013`. `pg_trgm` stays installed (it has no other consumer; dropping the extension is a wider change for no benefit). `db/migrations/README.md` gets a "Corrections to applied migrations" entry for `0013`, whose header still says the trigram indexing "remains relevant".

## Why the index is dead

Verified in this repo, not inferred: the card search (`apps/backend/src/cards/queries.ts` + `apps/backend/src/search/tokens.ts`) generates, per token, `(lower(normalize(front_text || ' ' || back_text, NFC)) LIKE $n OR EXISTS (SELECT 1 FROM unnest(tags) AS tag WHERE lower(normalize(tag, NFC)) LIKE $n))`. The tag arm is a correlated EXISTS inside an OR, which Postgres cannot turn into a BitmapOr, so the planner has never been able to use the index for the text arm — and that shape dates from the same commit that finalized the index expression (`a878c1797`, 2026-03-10). Since #1733's NFC change the index expression `lower(front_text || ' ' || back_text)` no longer matches the predicate at all. The agent SQL surface evaluates LIKE in-process and never sends it to Postgres; no other backend/admin query touches the expression. The only cost the index has is on every card insert and non-HOT update.

Owner decision: drop now; whether card search should have any index is a separate measure-first item (EXPLAIN on production first, as done for the new-card bucket in #1736).

## Lock exposure

`DROP INDEX` takes ACCESS EXCLUSIVE on `content.cards`; it waits behind every transaction holding a cards lock while every new cards statement queues behind it, and the migration runner sets no `lock_timeout` (`CONCURRENTLY` cannot run inside the per-file transaction the runner wraps). The file therefore sets `SET LOCAL lock_timeout = '30s'`: past that the drop fails 55P03, the `DatabaseMigrationGate` custom resource fails, CloudFormation rolls back before any runtime code switches, and a rerun of the release retries the unrecorded file. In the normal case the lock is granted as soon as in-flight cards transactions finish.

## Checks

- `scripts/checks/pr/check-migration-hygiene.mjs` passes with `addedMigrations: ['db/migrations/0133_drop_cards_search_trgm_index.sql']`, `highestPrefixOnBase: '0132'`.
- No boundary entry in `apps/backend/scripts/postgresIntegrations/boundaries.mjs` (a DROP needs no rehearsed migrated state; no `expectedMigrationCount` changes since 0133 sorts after the last boundary).
- The release's `--require-latest-migration` gate will verify `0133` is recorded in `schema_migrations` after deploy.
- Two review rounds, all findings adjudicated; the reviewed tree snapshot matches the committed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
